### PR TITLE
Allow to create an Account from a private key

### DIFF
--- a/src/main/java/com/bloxbean/cardano/client/account/Account.java
+++ b/src/main/java/com/bloxbean/cardano/client/account/Account.java
@@ -27,7 +27,10 @@ import java.util.stream.Collectors;
 public class Account {
     @JsonIgnore
     private String mnemonic;
+    @JsonIgnore
+    private String secretKey;
     private String baseAddress;
+    private String changeAddress;
     private String enterpriseAddress;
     private String stakeAddress;
     private Network network;
@@ -131,8 +134,27 @@ public class Account {
     public Account(Network network, String mnemonic, DerivationPath derivationPath) {
         this.network = network;
         this.mnemonic = mnemonic;
+        this.secretKey = null;
         this.derivationPath = derivationPath;
         validateMnemonic();
+        baseAddress();
+    }
+
+    /**
+     * Create an account for the network and derivation path from a private key
+     *
+     * @param network
+     * @param derivationPath
+     * @param secretKey is a private key of 192 bytes or 256 bytes (with pubkey and chaincode) encoded in a base64 String
+     */
+    public Account(Network network, DerivationPath derivationPath, String secretKey) {
+        this.network = network;
+        this.mnemonic = null;
+        if (secretKey.length() == 192)
+            this.secretKey = secretKey;
+        else
+            this.secretKey = secretKey.substring(0,128) + secretKey.substring(192,256);
+        this.derivationPath = derivationPath;
         baseAddress();
     }
 
@@ -148,7 +170,7 @@ public class Account {
      */
     public String baseAddress() {
         if (baseAddress == null || baseAddress.isEmpty()) {
-            HdKeyPair paymentKeyPair = getHdKeyPair();
+            HdKeyPair paymentKeyPair = getExternalKeyPair();
             HdKeyPair stakeKeyPair = getStakeKeyPair();
 
             Address address = AddressService.getInstance().getBaseAddress(paymentKeyPair.getPublicKey(), stakeKeyPair.getPublicKey(), network);
@@ -156,6 +178,21 @@ public class Account {
         }
 
         return baseAddress;
+    }
+
+    /**
+     * @return changeAddress at index
+     */
+    public String changeAddress() {
+        if (changeAddress == null || changeAddress.isEmpty()) {
+            HdKeyPair changeKeyPair = getChangeKeyPair();
+            HdKeyPair stakeKeyPair = getStakeKeyPair();
+
+            Address address = AddressService.getInstance().getBaseAddress(changeKeyPair.getPublicKey(), stakeKeyPair.getPublicKey(), network);
+            changeAddress = address.toBech32();
+        }
+
+        return changeAddress;
     }
 
     /**
@@ -248,7 +285,7 @@ public class Account {
      * @return
      */
     public Transaction sign(Transaction transaction) {
-        return TransactionSigner.INSTANCE.sign(transaction, getHdKeyPair());
+        return TransactionSigner.INSTANCE.sign(transaction, getExternalKeyPair());
     }
 
     private void generateNew(Words noOfWords) {
@@ -278,13 +315,50 @@ public class Account {
     }
 
     private HdKeyPair getHdKeyPair() {
-        HdKeyPair hdKeyPair = new CIP1852().getKeyPairFromMnemonic(mnemonic, derivationPath);
+        HdKeyPair hdKeyPair;
+        if (mnemonic == null || mnemonic.trim().length() == 0) {
+            hdKeyPair = new CIP1852().getKeyPairFromAccountKey(this.secretKey, derivationPath);
+        }
+        else {
+            hdKeyPair = new CIP1852().getKeyPairFromMnemonic(mnemonic, derivationPath);
+        }
+        return hdKeyPair;
+    }
+
+    public HdKeyPair getExternalKeyPair() {
+        HdKeyPair hdKeyPair;
+        DerivationPath externalDerivationPath = DerivationPath.createExternalAddressDerivationPathForAccount(derivationPath.getAccount().getValue());
+        if (mnemonic == null || mnemonic.trim().length() == 0) {
+            hdKeyPair = new CIP1852().getKeyPairFromAccountKey(this.secretKey, externalDerivationPath);
+        }
+        else {
+            hdKeyPair = new CIP1852().getKeyPairFromMnemonic(mnemonic, externalDerivationPath);
+        }
+
+        return hdKeyPair;
+    }
+
+    private HdKeyPair getChangeKeyPair() {
+        HdKeyPair hdKeyPair;
+        DerivationPath internalDerivationPath = DerivationPath.createInternalAddressDerivationPathForAccount(derivationPath.getAccount().getValue());
+        if (mnemonic == null || mnemonic.trim().length() == 0) {
+            hdKeyPair = new CIP1852().getKeyPairFromAccountKey(this.secretKey, internalDerivationPath);
+        }
+        else {
+            hdKeyPair = new CIP1852().getKeyPairFromMnemonic(mnemonic, internalDerivationPath);
+        }
+
         return hdKeyPair;
     }
 
     private HdKeyPair getStakeKeyPair() {
+        HdKeyPair hdKeyPair;
         DerivationPath stakeDerivationPath = DerivationPath.createStakeAddressDerivationPathForAccount(derivationPath.getAccount().getValue());
-        HdKeyPair hdKeyPair = new CIP1852().getKeyPairFromMnemonic(mnemonic, stakeDerivationPath);
+        if (mnemonic == null || mnemonic.trim().length() == 0) {
+            hdKeyPair = new CIP1852().getKeyPairFromAccountKey(this.secretKey, stakeDerivationPath);
+        } else {
+            hdKeyPair = new CIP1852().getKeyPairFromMnemonic(mnemonic, stakeDerivationPath);
+        }
 
         return hdKeyPair;
     }

--- a/src/main/java/com/bloxbean/cardano/client/account/Account.java
+++ b/src/main/java/com/bloxbean/cardano/client/account/Account.java
@@ -141,20 +141,19 @@ public class Account {
     }
 
     /**
-     * Create an account for the network and derivation path from a private key
+     * Create an account from a private key for a specified network
      *
-     * @param network
-     * @param derivationPath
      * @param secretKey is a private key of 192 bytes or 256 bytes (with pubkey and chaincode) encoded in a base64 String
+     * @param network
      */
-    public Account(Network network, DerivationPath derivationPath, String secretKey) {
+    public Account(String secretKey, Network network) {
         this.network = network;
         this.mnemonic = null;
         if (secretKey.length() == 192)
             this.secretKey = secretKey;
         else
             this.secretKey = secretKey.substring(0,128) + secretKey.substring(192,256);
-        this.derivationPath = derivationPath;
+        this.derivationPath = DerivationPath.createExternalAddressDerivationPath(0);
         baseAddress();
     }
 
@@ -170,7 +169,7 @@ public class Account {
      */
     public String baseAddress() {
         if (baseAddress == null || baseAddress.isEmpty()) {
-            HdKeyPair paymentKeyPair = getExternalKeyPair();
+            HdKeyPair paymentKeyPair = getHdKeyPair();
             HdKeyPair stakeKeyPair = getStakeKeyPair();
 
             Address address = AddressService.getInstance().getBaseAddress(paymentKeyPair.getPublicKey(), stakeKeyPair.getPublicKey(), network);
@@ -285,7 +284,7 @@ public class Account {
      * @return
      */
     public Transaction sign(Transaction transaction) {
-        return TransactionSigner.INSTANCE.sign(transaction, getExternalKeyPair());
+        return TransactionSigner.INSTANCE.sign(transaction, getHdKeyPair());
     }
 
     private void generateNew(Words noOfWords) {
@@ -322,19 +321,6 @@ public class Account {
         else {
             hdKeyPair = new CIP1852().getKeyPairFromMnemonic(mnemonic, derivationPath);
         }
-        return hdKeyPair;
-    }
-
-    public HdKeyPair getExternalKeyPair() {
-        HdKeyPair hdKeyPair;
-        DerivationPath externalDerivationPath = DerivationPath.createExternalAddressDerivationPathForAccount(derivationPath.getAccount().getValue());
-        if (mnemonic == null || mnemonic.trim().length() == 0) {
-            hdKeyPair = new CIP1852().getKeyPairFromAccountKey(this.secretKey, externalDerivationPath);
-        }
-        else {
-            hdKeyPair = new CIP1852().getKeyPairFromMnemonic(mnemonic, externalDerivationPath);
-        }
-
         return hdKeyPair;
     }
 

--- a/src/main/java/com/bloxbean/cardano/client/crypto/cip1852/CIP1852.java
+++ b/src/main/java/com/bloxbean/cardano/client/crypto/cip1852/CIP1852.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.client.crypto.CryptoException;
 import com.bloxbean.cardano.client.crypto.bip32.HdKeyGenerator;
 import com.bloxbean.cardano.client.crypto.bip32.HdKeyPair;
 import com.bloxbean.cardano.client.crypto.bip39.MnemonicCode;
+import com.bloxbean.cardano.client.util.HexUtil;
 
 public class CIP1852 {
 
@@ -25,6 +26,16 @@ public class CIP1852 {
         HdKeyPair coinTypeKey = hdKeyGenerator.getChildKeyPair(purposeKey, derivationPath.getCoinType().getValue(), derivationPath.getCoinType().isHarden());
         HdKeyPair accountKey = hdKeyGenerator.getChildKeyPair(coinTypeKey, derivationPath.getAccount().getValue(), derivationPath.getAccount().isHarden());
         HdKeyPair roleKey = hdKeyGenerator.getChildKeyPair(accountKey, derivationPath.getRole().getValue(), derivationPath.getRole().isHarden());
+
+        HdKeyPair indexKey = hdKeyGenerator.getChildKeyPair(roleKey, derivationPath.getIndex().getValue(), derivationPath.getIndex().isHarden());
+        return indexKey;
+    }
+
+    public HdKeyPair getKeyPairFromAccountKey(String accountKey, DerivationPath derivationPath) {
+        HdKeyGenerator hdKeyGenerator = new HdKeyGenerator();
+
+        HdKeyPair accountKeyPair = hdKeyGenerator.getAccountKeyPairFromSecretKey(HexUtil.decodeHexString(accountKey),  derivationPath);
+        HdKeyPair roleKey = hdKeyGenerator.getChildKeyPair(accountKeyPair, derivationPath.getRole().getValue(), derivationPath.getRole().isHarden());
 
         HdKeyPair indexKey = hdKeyGenerator.getChildKeyPair(roleKey, derivationPath.getIndex().getValue(), derivationPath.getIndex().isHarden());
         return indexKey;

--- a/src/main/java/com/bloxbean/cardano/client/crypto/cip1852/DerivationPath.java
+++ b/src/main/java/com/bloxbean/cardano/client/crypto/cip1852/DerivationPath.java
@@ -16,6 +16,15 @@ public class DerivationPath {
       private Segment role;
       private Segment index;
 
+
+    public static DerivationPath createAccountDerivationPath(int index) {
+        return DerivationPath.builder()
+                .purpose(new Segment(1852, true))
+                .coinType(new Segment(1815, true))
+                .account(new Segment(index, true))
+                .build();
+    }
+
     public static DerivationPath createExternalAddressDerivationPath() {
           return createExternalAddressDerivationPath(0);
       }
@@ -30,6 +39,16 @@ public class DerivationPath {
                 .build();
     }
 
+    public static DerivationPath createExternalAddressDerivationPathForAccount(int account) {
+        return DerivationPath.builder()
+                .purpose(new Segment(1852, true))
+                .coinType(new Segment(1815, true))
+                .account(new Segment(account, true))
+                .role(new Segment(0, false))
+                .index(new Segment(0, false))
+                .build();
+    }
+
     public static DerivationPath createInternalAddressDerivationPath(int index) {
         return DerivationPath.builder()
                 .purpose(new Segment(1852, true))
@@ -37,6 +56,16 @@ public class DerivationPath {
                 .account(new Segment(0, true))
                 .role(new Segment(1, false))
                 .index(new Segment(index, false))
+                .build();
+    }
+
+    public static DerivationPath createInternalAddressDerivationPathForAccount(int account) {
+        return DerivationPath.builder()
+                .purpose(new Segment(1852, true))
+                .coinType(new Segment(1815, true))
+                .account(new Segment(account, true))
+                .role(new Segment(1, false))
+                .index(new Segment(0, false))
                 .build();
     }
 

--- a/src/main/java/com/bloxbean/cardano/client/crypto/cip1852/DerivationPath.java
+++ b/src/main/java/com/bloxbean/cardano/client/crypto/cip1852/DerivationPath.java
@@ -17,17 +17,9 @@ public class DerivationPath {
       private Segment index;
 
 
-    public static DerivationPath createAccountDerivationPath(int index) {
-        return DerivationPath.builder()
-                .purpose(new Segment(1852, true))
-                .coinType(new Segment(1815, true))
-                .account(new Segment(index, true))
-                .build();
-    }
-
     public static DerivationPath createExternalAddressDerivationPath() {
           return createExternalAddressDerivationPath(0);
-      }
+    }
 
     public static DerivationPath createExternalAddressDerivationPath(int index) {
         return DerivationPath.builder()

--- a/src/test/java/com/bloxbean/cardano/client/account/AccountTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/account/AccountTest.java
@@ -80,7 +80,7 @@ public class AccountTest {
         String accountPrivateKey = "a83aa0356397602d3da7648f139ca06be2465caef14ac4d795b17cdf13bd0f4fe9aac037f7e22335cd99495b963d54f21e8dae540112fe56243b287962da366fd4016f4cfb6d6baba1807621b4216d18581c38404c4768fe820204bef98ba706";
         String address0 = "addr_test1qzsaa6czesrzwp45rd5flg86n5hnwhz5setqfyt39natwvsl5mr3vkp82y2kcwxxtu4zjcxvm80ttmx2hyeyjka4v8psa5ns0z";
 
-        Account account = new Account(Networks.testnet(), DerivationPath.createExternalAddressDerivationPath(0), accountPrivateKey);
+        Account account = new Account(accountPrivateKey, Networks.testnet());
 
         assertNotNull(account.baseAddress());
         assertNotNull(account.privateKeyBytes());
@@ -92,7 +92,7 @@ public class AccountTest {
         String accountPrivateKey = "a83aa0356397602d3da7648f139ca06be2465caef14ac4d795b17cdf13bd0f4fe9aac037f7e22335cd99495b963d54f21e8dae540112fe56243b287962da366fd4016f4cfb6d6baba1807621b4216d18581c38404c4768fe820204bef98ba706";
         String changeAddress0 = "addr_test1qpqwpvc7946mqvl0mwwhqgmh6w4a6335mkuypjyg9fd5elsl5mr3vkp82y2kcwxxtu4zjcxvm80ttmx2hyeyjka4v8psy8w5eh";
 
-        Account account = new Account(Networks.testnet(), DerivationPath.createExternalAddressDerivationPath(0), accountPrivateKey);
+        Account account = new Account(accountPrivateKey, Networks.testnet());
 
         assertNotNull(account.changeAddress());
         assertNotNull(account.privateKeyBytes());

--- a/src/test/java/com/bloxbean/cardano/client/account/AccountTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/account/AccountTest.java
@@ -1,11 +1,13 @@
 package com.bloxbean.cardano.client.account;
 
 import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.crypto.cip1852.DerivationPath;
 import com.bloxbean.cardano.client.exception.AddressExcepion;
 import com.bloxbean.cardano.client.exception.AddressRuntimeException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.address.util.AddressUtil;
+import com.bloxbean.cardano.client.util.HexUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -71,6 +73,30 @@ public class AccountTest {
         assertNotNull(account.mnemonic());
         assertEquals(address0, account.baseAddress());
         assertEquals(phrase24W, account.mnemonic());
+    }
+
+    @Test
+    void getBaseAddressFromAccountPrivateKey_byNetwork() {
+        String accountPrivateKey = "a83aa0356397602d3da7648f139ca06be2465caef14ac4d795b17cdf13bd0f4fe9aac037f7e22335cd99495b963d54f21e8dae540112fe56243b287962da366fd4016f4cfb6d6baba1807621b4216d18581c38404c4768fe820204bef98ba706";
+        String address0 = "addr_test1qzsaa6czesrzwp45rd5flg86n5hnwhz5setqfyt39natwvsl5mr3vkp82y2kcwxxtu4zjcxvm80ttmx2hyeyjka4v8psa5ns0z";
+
+        Account account = new Account(Networks.testnet(), DerivationPath.createExternalAddressDerivationPath(0), accountPrivateKey);
+
+        assertNotNull(account.baseAddress());
+        assertNotNull(account.privateKeyBytes());
+        assertEquals(address0, account.baseAddress());
+    }
+
+    @Test
+    void getChangeAddressFromAccountPrivateKey_byNetwork() {
+        String accountPrivateKey = "a83aa0356397602d3da7648f139ca06be2465caef14ac4d795b17cdf13bd0f4fe9aac037f7e22335cd99495b963d54f21e8dae540112fe56243b287962da366fd4016f4cfb6d6baba1807621b4216d18581c38404c4768fe820204bef98ba706";
+        String changeAddress0 = "addr_test1qpqwpvc7946mqvl0mwwhqgmh6w4a6335mkuypjyg9fd5elsl5mr3vkp82y2kcwxxtu4zjcxvm80ttmx2hyeyjka4v8psy8w5eh";
+
+        Account account = new Account(Networks.testnet(), DerivationPath.createExternalAddressDerivationPath(0), accountPrivateKey);
+
+        assertNotNull(account.changeAddress());
+        assertNotNull(account.privateKeyBytes());
+        assertEquals(changeAddress0, account.changeAddress());
     }
 
     @Test


### PR DESCRIPTION
Allow to create an Account from a private key because it's not always possible to have the seed available and it's safer/faster to derive from the account hardened key.

