### PR TITLE
Fix [#79] - Retry fee calculation (with amount = amount - fee) in cas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The library has been tested on the following Operating Systems.
 - [Cardano-client-lib : A Java Library to interact with Cardano - Part I](https://medium.com/p/83fba0fee537)
 - [Cardano-client-lib: Transaction with Metadata in Java - Part II](https://medium.com/p/fa34f403b90e)
 - [Cardano-client-lib: Minting a new Native Token in Java - Part III](https://medium.com/p/1a94a21cfeeb)
+- [Composable functions to build transactions](https://medium.com/coinmonks/cardano-client-lib-new-composable-functions-to-build-transaction-in-java-part-i-be3a8b4da835)
 
 **Examples**
 
@@ -72,6 +73,8 @@ Other backend like Cardano-wallet will be added in future release.
 
 ### Add dependency
 
+#### For release binary
+
 - For Maven, add the following dependency to project's pom.xml
 ```
         <dependency>
@@ -84,7 +87,45 @@ Other backend like Cardano-wallet will be added in future release.
 - For Gradle, add the following dependency to build.gradle
 
 ```
-compile 'com.bloxbean.cardano:cardano-client-lib:0.1.5'
+implementation 'com.bloxbean.cardano:cardano-client-lib:0.2.0-beta2'
+```
+
+#### For snapshot binary
+
+- For Maven, add the following dependency and repository to project's pom.xml
+```
+    <dependencies>
+        <dependency>
+            <groupId>com.bloxbean.cardano</groupId>
+            <artifactId>cardano-client-lib</artifactId>
+            <version>0.2.0-beta3-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+    
+    <repositories>
+        <repository>
+            <id>snapshots-repo</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+```
+- For Gradle, add the following dependency and repository to build.gradle
+
+```
+repositories {
+    ...
+    maven {
+        url "https://oss.sonatype.org/content/repositories/snapshots"
+    }
+}
+
+implementation 'com.bloxbean.cardano:cardano-client-lib:0.2.0-beta3-SNAPSHOT'
 ```
 
 ### Account API Usage
@@ -294,7 +335,7 @@ transactionHelperService.getUtxoTransactionBuilder().setUtxoSelectionStrategy(cu
 ```
 git clone https://github.com/bloxbean/cardano-client-lib.git
 
-./gradlew build fatJar
+./gradlew clean build
 ```
 
 # Run Integration Tests

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ The library has been tested on the following Operating Systems.
 - [Cardano-client-lib : A Java Library to interact with Cardano - Part I](https://medium.com/p/83fba0fee537)
 - [Cardano-client-lib: Transaction with Metadata in Java - Part II](https://medium.com/p/fa34f403b90e)
 - [Cardano-client-lib: Minting a new Native Token in Java - Part III](https://medium.com/p/1a94a21cfeeb)
-- [Composable functions to build transactions](https://medium.com/coinmonks/cardano-client-lib-new-composable-functions-to-build-transaction-in-java-part-i-be3a8b4da835)
 
 **Examples**
 
@@ -73,8 +72,6 @@ Other backend like Cardano-wallet will be added in future release.
 
 ### Add dependency
 
-#### For release binary
-
 - For Maven, add the following dependency to project's pom.xml
 ```
         <dependency>
@@ -87,45 +84,7 @@ Other backend like Cardano-wallet will be added in future release.
 - For Gradle, add the following dependency to build.gradle
 
 ```
-implementation 'com.bloxbean.cardano:cardano-client-lib:0.2.0-beta2'
-```
-
-#### For snapshot binary
-
-- For Maven, add the following dependency and repository to project's pom.xml
-```
-    <dependencies>
-        <dependency>
-            <groupId>com.bloxbean.cardano</groupId>
-            <artifactId>cardano-client-lib</artifactId>
-            <version>0.2.0-beta3-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
-    
-    <repositories>
-        <repository>
-            <id>snapshots-repo</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-```
-- For Gradle, add the following dependency and repository to build.gradle
-
-```
-repositories {
-    ...
-    maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots"
-    }
-}
-
-implementation 'com.bloxbean.cardano:cardano-client-lib:0.2.0-beta3-SNAPSHOT'
+compile 'com.bloxbean.cardano:cardano-client-lib:0.1.5'
 ```
 
 ### Account API Usage
@@ -335,7 +294,7 @@ transactionHelperService.getUtxoTransactionBuilder().setUtxoSelectionStrategy(cu
 ```
 git clone https://github.com/bloxbean/cardano-client-lib.git
 
-./gradlew clean build
+./gradlew build fatJar
 ```
 
 # Run Integration Tests

--- a/src/main/java/com/bloxbean/cardano/client/backend/api/helper/impl/FeeCalculationServiceImpl.java
+++ b/src/main/java/com/bloxbean/cardano/client/backend/api/helper/impl/FeeCalculationServiceImpl.java
@@ -58,16 +58,19 @@ public class FeeCalculationServiceImpl implements FeeCalculationService {
 
         PaymentTransaction clonePaymentTransaction = paymentTransaction.toBuilder().build();
         if(clonePaymentTransaction.getFee() == null || clonePaymentTransaction.getFee().compareTo(DUMMY_FEE) == -1) //Just a dummy fee
-            clonePaymentTransaction.setFee(DUMMY_FEE); //Set a min fee just for calcuation purpose if not set
+            clonePaymentTransaction.setFee(DUMMY_FEE); //Set a min fee just for calculation purpose if not set
 
         String txnCBORHash;
         try {
             //Build transaction
             txnCBORHash = transactionHelperService.createSignedTransaction(Arrays.asList(clonePaymentTransaction), detailsParams, metadata);
         } catch (InsufficientBalanceException e) {
-            clonePaymentTransaction.setFee(MIN_DUMMY_FEE);
-            clonePaymentTransaction.setAmount(clonePaymentTransaction.getAmount().subtract(MIN_DUMMY_FEE));
-            txnCBORHash = transactionHelperService.createSignedTransaction(Arrays.asList(clonePaymentTransaction), detailsParams, metadata);
+            if (LOVELACE.equals(clonePaymentTransaction.getUnit())) {
+                clonePaymentTransaction.setFee(MIN_DUMMY_FEE);
+                clonePaymentTransaction.setAmount(clonePaymentTransaction.getAmount().subtract(MIN_DUMMY_FEE));
+                txnCBORHash = transactionHelperService.createSignedTransaction(Arrays.asList(clonePaymentTransaction), detailsParams, metadata);
+            } else
+                throw e;
         }
 
         //Calculate fee

--- a/src/main/java/com/bloxbean/cardano/client/backend/api/helper/impl/FeeCalculationServiceImpl.java
+++ b/src/main/java/com/bloxbean/cardano/client/backend/api/helper/impl/FeeCalculationServiceImpl.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.client.backend.api.EpochService;
 import com.bloxbean.cardano.client.backend.api.helper.FeeCalculationService;
 import com.bloxbean.cardano.client.backend.api.helper.TransactionHelperService;
 import com.bloxbean.cardano.client.backend.exception.ApiException;
+import com.bloxbean.cardano.client.backend.exception.InsufficientBalanceException;
 import com.bloxbean.cardano.client.backend.model.ProtocolParams;
 import com.bloxbean.cardano.client.backend.model.Result;
 import com.bloxbean.cardano.client.exception.AddressExcepion;
@@ -19,11 +20,19 @@ import com.bloxbean.cardano.client.util.HexUtil;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.bloxbean.cardano.client.common.CardanoConstants.LOVELACE;
 
 public class FeeCalculationServiceImpl implements FeeCalculationService {
+    //A dummy fee which is used during regular fee calculation
+    private final static BigInteger DUMMY_FEE = BigInteger.valueOf(170000);
+
+    //A very minimum fee which is used during retry after InsufficientBalanceException.
+    //Here the goal is to make the fee calculation successful by reducing cost during transaction building.
+    private final static BigInteger MIN_DUMMY_FEE = BigInteger.valueOf(100000);
 
     private TransactionHelperService transactionHelperService;
     private EpochService epochService;
@@ -47,10 +56,19 @@ public class FeeCalculationServiceImpl implements FeeCalculationService {
     public BigInteger calculateFee(PaymentTransaction paymentTransaction, TransactionDetailsParams detailsParams,
                                    Metadata metadata, ProtocolParams protocolParams) throws CborSerializationException, AddressExcepion, ApiException {
 
-        if(paymentTransaction.getFee() == null || paymentTransaction.getFee().compareTo(BigInteger.valueOf(170000)) == -1) //Just a dummy fee
-            paymentTransaction.setFee(new BigInteger("170000")); //Set a min fee just for calcuation purpose if not set
-        //Build transaction
-        String txnCBORHash = transactionHelperService.createSignedTransaction(Arrays.asList(paymentTransaction), detailsParams, metadata);
+        PaymentTransaction clonePaymentTransaction = paymentTransaction.toBuilder().build();
+        if(clonePaymentTransaction.getFee() == null || clonePaymentTransaction.getFee().compareTo(DUMMY_FEE) == -1) //Just a dummy fee
+            clonePaymentTransaction.setFee(DUMMY_FEE); //Set a min fee just for calcuation purpose if not set
+
+        String txnCBORHash;
+        try {
+            //Build transaction
+            txnCBORHash = transactionHelperService.createSignedTransaction(Arrays.asList(clonePaymentTransaction), detailsParams, metadata);
+        } catch (InsufficientBalanceException e) {
+            clonePaymentTransaction.setFee(MIN_DUMMY_FEE);
+            clonePaymentTransaction.setAmount(clonePaymentTransaction.getAmount().subtract(MIN_DUMMY_FEE));
+            txnCBORHash = transactionHelperService.createSignedTransaction(Arrays.asList(clonePaymentTransaction), detailsParams, metadata);
+        }
 
         //Calculate fee
         return doFeeCalculationFromTxnSize(HexUtil.decodeHexString(txnCBORHash), protocolParams);
@@ -70,8 +88,8 @@ public class FeeCalculationServiceImpl implements FeeCalculationService {
     public BigInteger calculateFee(MintTransaction mintTransaction, TransactionDetailsParams detailsParams,
                                    Metadata metadata, ProtocolParams protocolParams) throws ApiException,
             CborSerializationException, AddressExcepion {
-        if(mintTransaction.getFee() == null || mintTransaction.getFee().compareTo(BigInteger.valueOf(170000)) == -1) //Just a dummy fee
-            mintTransaction.setFee(new BigInteger("170000")); //Set a min fee just for calcuation purpose if not set
+        if(mintTransaction.getFee() == null || mintTransaction.getFee().compareTo(DUMMY_FEE) == -1) //Just a dummy fee
+            mintTransaction.setFee(DUMMY_FEE); //Set a min fee just for calcuation purpose if not set
         //Build transaction
         String txnCBORHash = transactionHelperService.createSignedMintTransaction(mintTransaction, detailsParams, metadata);
 
@@ -91,7 +109,7 @@ public class FeeCalculationServiceImpl implements FeeCalculationService {
     @Override
     public BigInteger calculateFee(Transaction transaction, ProtocolParams protocolParams) throws CborSerializationException {
         if(transaction.getBody().getFee() == null) //Just a dummy fee
-            transaction.getBody().setFee(new BigInteger("170000")); //Set a min fee just for calcuation purpose if not set
+            transaction.getBody().setFee(DUMMY_FEE); //Set a min fee just for calcuation purpose if not set
 
         byte[] serializedBytes = transaction.serialize();
         return doFeeCalculationFromTxnSize(serializedBytes, protocolParams);
@@ -124,21 +142,32 @@ public class FeeCalculationServiceImpl implements FeeCalculationService {
     @Override
     public BigInteger calculateFee(List<PaymentTransaction> paymentTransactions, TransactionDetailsParams detailsParams,
                                    Metadata metadata, ProtocolParams protocolParams) throws CborSerializationException, AddressExcepion, ApiException {
+        //Clone
+        List<PaymentTransaction> clonePaymentTransactions = paymentTransactions.stream()
+                .map(paymentTransaction -> paymentTransaction.toBuilder().build())
+                .collect(Collectors.toList());
 
-        List<BigInteger> originalFees = new ArrayList<>(); //keep copy of original fee
-        paymentTransactions.forEach(paymentTransaction -> {
-            originalFees.add(paymentTransaction.getFee());
-            if(paymentTransaction.getFee() == null || paymentTransaction.getFee().compareTo(BigInteger.valueOf(170000)) == -1) //Just a dummy fee
-                paymentTransaction.setFee(new BigInteger("170000")); //Set a min fee just for calcuation purpose if not set
+        //Set fee only for the first payment transaction. NULL for others
+        clonePaymentTransactions.get(0).setFee(DUMMY_FEE);
+        clonePaymentTransactions.stream().skip(1).forEach(paymentTransaction -> {
+            paymentTransaction.setFee(null);
         });
 
-
         //Build transaction
-        String txnCBORHash = transactionHelperService.createSignedTransaction(paymentTransactions, detailsParams, metadata);
+        String txnCBORHash;
+        try {
+            txnCBORHash = transactionHelperService.createSignedTransaction(clonePaymentTransactions, detailsParams, metadata);
+        } catch (InsufficientBalanceException exception) {
+            //Update fee in the first payment transaction
+            clonePaymentTransactions.get(0).setFee(MIN_DUMMY_FEE);
+            //substract DUMMY_FEE from lovelace txn
+            clonePaymentTransactions.stream().filter(paymentTransaction -> paymentTransaction.getUnit().equals(LOVELACE))
+                    .findFirst()
+                    .ifPresent(paymentTransaction -> {
+                        paymentTransaction.setAmount(paymentTransaction.getAmount().subtract(MIN_DUMMY_FEE));
+                    });
 
-        //reset to original fee in the input paymentransactions
-        for (int i=0; i < paymentTransactions.size();i++) {
-            paymentTransactions.get(i).setFee(originalFees.get(i));
+            txnCBORHash = transactionHelperService.createSignedTransaction(clonePaymentTransactions, detailsParams, metadata);
         }
 
         //Calculate fee

--- a/src/main/java/com/bloxbean/cardano/client/transaction/model/PaymentTransaction.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/model/PaymentTransaction.java
@@ -18,7 +18,7 @@ public class PaymentTransaction extends TransactionRequest {
     private String unit;
     private BigInteger amount;
 
-    @Builder
+    @Builder(toBuilder = true)
     public PaymentTransaction(Account sender, String receiver, BigInteger fee, List<Account> additionalWitnessAccounts,
                               List<Utxo> utxosToInclude, String unit, BigInteger amount, String datumHash) {
         super(sender, receiver, fee, additionalWitnessAccounts, utxosToInclude, datumHash);

--- a/src/main/java/com/bloxbean/cardano/client/transaction/model/TransactionRequest.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/model/TransactionRequest.java
@@ -18,11 +18,11 @@ public abstract class TransactionRequest {
     protected BigInteger fee;
 
     //Optional - parameter for now. Can be used in future to add multiple witness accounts to a transaction
-    private List<Account> additionalWitnessAccounts;
+    protected List<Account> additionalWitnessAccounts;
 
     //Optional - Utxos to include to the transaction
-    private List<Utxo> utxosToInclude;
+    protected List<Utxo> utxosToInclude;
 
     //Datumhash - Required when receiver is a script
-    private String datumHash;
+    protected String datumHash;
 }

--- a/src/test/java/com/bloxbean/cardano/client/backend/api/helper/impl/FeeCalculationServiceTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/backend/api/helper/impl/FeeCalculationServiceTest.java
@@ -377,6 +377,32 @@ class FeeCalculationServiceTest extends BaseTest {
     }
 
     @Test
+    public void testCalculateFeeWhenSendAll_onlyTokens_throwsException() throws Exception {
+        String receiver = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
+
+        List<Utxo> utxos = loadUtxos(LIST_5);
+        given(utxoService.getUtxos(any(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
+        given(utxoService.getUtxos(any(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.EMPTY_LIST).code(200));
+        given(epochService.getProtocolParameters()).willReturn(Result.success(protocolParams.toString()).withValue(protocolParams).code(200));
+
+        Account sender = new Account(Networks.testnet());
+        PaymentTransaction paymentTransaction = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("07309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(1000))
+                .receiver(receiver)
+                .build();
+
+        TransactionDetailsParams detailsParams = TransactionDetailsParams.builder()
+                .ttl(199999)
+                .build();
+
+        Assertions.assertThrows(InsufficientBalanceException.class, () -> {
+            feeCalculationService.calculateFee(paymentTransaction, detailsParams, null, protocolParams);
+        });
+    }
+
+    @Test
     public void testCalculateFeeWhenSendAll_loveLaceAndMultipleTokens() throws Exception {
         String receiver = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
 

--- a/src/test/java/com/bloxbean/cardano/client/backend/api/helper/impl/FeeCalculationServiceTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/backend/api/helper/impl/FeeCalculationServiceTest.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -51,6 +52,10 @@ class FeeCalculationServiceTest extends BaseTest {
 
     public static final String LIST_1 = "list1";
     public static final String LIST_2 = "list2-insufficient-change-amount";
+    public static final String LIST_3 = "list3-send-all-only-lovelace";
+    public static final String LIST_4 = "list4-send-all-not-enough-lovelace";
+    public static final String LIST_5 = "list5-send-all-lovelace-all-tokens";
+    public static final String LIST_6 = "list6-send-all-lovelace-all-multiple-tokens";
 
     @Mock
     UtxoService utxoService;
@@ -281,5 +286,205 @@ class FeeCalculationServiceTest extends BaseTest {
 
         BigInteger fee = feeCalculationService.calculateScriptFee(Arrays.asList(exUnits1, exUnits2));
         assertThat(fee.intValue(), is(296));
+    }
+
+    @Test
+    public void testCalculateFeeWhenSendAll_Lovelace() throws Exception {
+        String receiver = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
+
+        List<Utxo> utxos = loadUtxos(LIST_3);
+        given(utxoService.getUtxos(any(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
+        given(utxoService.getUtxos(any(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.EMPTY_LIST).code(200));
+        given(epochService.getProtocolParameters()).willReturn(Result.success(protocolParams.toString()).withValue(protocolParams).code(200));
+
+        Account sender = new Account(Networks.testnet());
+        PaymentTransaction paymentTransaction = PaymentTransaction.builder()
+                .sender(sender)
+                .unit(CardanoConstants.LOVELACE)
+                .amount(adaToLovelace(1.5))
+                .receiver(receiver)
+                .build();
+
+        TransactionDetailsParams detailsParams = TransactionDetailsParams.builder()
+                .ttl(199999)
+                .build();
+
+        BigInteger fee = feeCalculationService.calculateFee(paymentTransaction, detailsParams, null, protocolParams);
+
+        System.out.println(fee);
+        assertThat(fee, greaterThan(BigInteger.valueOf(150000)));
+    }
+
+    @Test
+    public void testCalculateFeeWhenSendAll_notEnoughLovelace_throwsException() throws Exception {
+        String receiver = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
+
+        List<Utxo> utxos = loadUtxos(LIST_4);
+        given(utxoService.getUtxos(any(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
+        given(utxoService.getUtxos(any(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.EMPTY_LIST).code(200));
+        given(epochService.getProtocolParameters()).willReturn(Result.success(protocolParams.toString()).withValue(protocolParams).code(200));
+
+        Account sender = new Account(Networks.testnet());
+        PaymentTransaction paymentTransaction = PaymentTransaction.builder()
+                .sender(sender)
+                .unit(CardanoConstants.LOVELACE)
+                .amount(adaToLovelace(0.9))
+                .receiver(receiver)
+                .build();
+
+        TransactionDetailsParams detailsParams = TransactionDetailsParams.builder()
+                .ttl(199999)
+                .build();
+
+        Assertions.assertThrows(InsufficientBalanceException.class, () -> {
+            feeCalculationService.calculateFee(paymentTransaction, detailsParams
+                    , null, protocolParams);
+        });
+    }
+
+    @Test
+    public void testCalculateFeeWhenSendAll_bothLoveLaceAndTokens() throws Exception {
+        String receiver = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
+
+        List<Utxo> utxos = loadUtxos(LIST_5);
+        given(utxoService.getUtxos(any(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
+        given(epochService.getProtocolParameters()).willReturn(Result.success(protocolParams.toString()).withValue(protocolParams).code(200));
+
+        Account sender = new Account(Networks.testnet());
+        PaymentTransaction paymentTransaction1 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit(CardanoConstants.LOVELACE)
+                .amount(adaToLovelace(1.5))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction2 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("07309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(1000))
+                .receiver(receiver)
+                .build();
+
+        TransactionDetailsParams detailsParams = TransactionDetailsParams.builder()
+                .ttl(199999)
+                .build();
+
+        BigInteger fee = feeCalculationService.calculateFee(List.of(paymentTransaction1, paymentTransaction2), detailsParams
+                , null, protocolParams);
+
+        System.out.println(fee);
+        assertThat(fee, greaterThan(BigInteger.valueOf(150000)));
+    }
+
+    @Test
+    public void testCalculateFeeWhenSendAll_loveLaceAndMultipleTokens() throws Exception {
+        String receiver = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
+
+        List<Utxo> utxos = loadUtxos(LIST_6);
+        given(utxoService.getUtxos(any(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
+        given(epochService.getProtocolParameters()).willReturn(Result.success(protocolParams.toString()).withValue(protocolParams).code(200));
+
+        Account sender = new Account(Networks.testnet());
+        PaymentTransaction paymentTransaction1 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit(CardanoConstants.LOVELACE)
+                .amount(adaToLovelace(2))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction2 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("04309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(1000))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction3 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("05309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(2000))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction4 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("06309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(3000))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction5 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("07309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(4000))
+                .receiver(receiver)
+                .build();
+
+        TransactionDetailsParams detailsParams = TransactionDetailsParams.builder()
+                .ttl(199999)
+                .build();
+
+        BigInteger fee = feeCalculationService.calculateFee(List.of(paymentTransaction1, paymentTransaction2,
+                paymentTransaction3, paymentTransaction4, paymentTransaction5), detailsParams
+                , null, protocolParams);
+
+        System.out.println(fee);
+        assertThat(fee, greaterThan(BigInteger.valueOf(170000)));
+    }
+
+    @Test
+    public void testCalculateFeeWhenSendAll_loveLaceAndMultipleTokens_lovelacePaymentTxnIsNotTheFirstOneInList() throws Exception {
+        String receiver = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
+
+        List<Utxo> utxos = loadUtxos(LIST_6);
+        given(utxoService.getUtxos(any(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
+        given(epochService.getProtocolParameters()).willReturn(Result.success(protocolParams.toString()).withValue(protocolParams).code(200));
+
+        Account sender = new Account(Networks.testnet());
+        PaymentTransaction paymentTransaction1 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit(CardanoConstants.LOVELACE)
+                .amount(adaToLovelace(2))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction2 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("04309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(1000))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction3 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("05309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(2000))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction4 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("06309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(3000))
+                .receiver(receiver)
+                .build();
+
+        PaymentTransaction paymentTransaction5 = PaymentTransaction.builder()
+                .sender(sender)
+                .unit("07309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e")
+                .amount(BigInteger.valueOf(4000))
+                .receiver(receiver)
+                .build();
+
+        TransactionDetailsParams detailsParams = TransactionDetailsParams.builder()
+                .ttl(199999)
+                .build();
+
+        BigInteger fee = feeCalculationService.calculateFee(List.of(paymentTransaction2,
+                paymentTransaction3, paymentTransaction4, paymentTransaction1,  paymentTransaction5), detailsParams
+                , null, protocolParams);
+
+        System.out.println(fee);
+        assertThat(fee, greaterThan(BigInteger.valueOf(170000)));
     }
 }

--- a/src/test/resources/fee-test-utxos.json
+++ b/src/test/resources/fee-test-utxos.json
@@ -84,5 +84,85 @@
       "block": "eee6cd082d297f85406cff49f83aa3ebd1083dae3c8997ec03f4a17f49297bf6",
       "data_hash": null
     }
+  ],
+  "list3-send-all-only-lovelace": [
+    {
+      "tx_hash": "f3c464be15a5e29a1a6d322c5cd040c87075d1cfc89d4b397568d14c0ba53cd9",
+      "tx_index": 1,
+      "output_index": 1,
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "1500000"
+        }
+      ],
+      "block": "10974607187afacfeed5e3eaf4342e06bad0f26de438319eca18fa93f6a1541e",
+      "data_hash": null
+    }
+  ],
+  "list4-send-all-not-enough-lovelace": [
+    {
+      "tx_hash": "f3c464be15a5e29a1a6d322c5cd040c87075d1cfc89d4b397568d14c0ba53cd9",
+      "tx_index": 1,
+      "output_index": 1,
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "900000"
+        }
+      ],
+      "block": "10974607187afacfeed5e3eaf4342e06bad0f26de438319eca18fa93f6a1541e",
+      "data_hash": null
+    }
+  ],
+  "list5-send-all-lovelace-all-tokens": [
+    {
+      "tx_hash": "f3c464be15a5e29a1a6d322c5cd040c87075d1cfc89d4b397568d14c0ba53cd9",
+      "tx_index": 1,
+      "output_index": 1,
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "1500000"
+        },
+        {
+          "unit": "07309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e",
+          "quantity": "1000"
+        }
+      ],
+      "block": "10974607187afacfeed5e3eaf4342e06bad0f26de438319eca18fa93f6a1541e",
+      "data_hash": null
+    }
+  ],
+  "list6-send-all-lovelace-all-multiple-tokens": [
+    {
+      "tx_hash": "f3c464be15a5e29a1a6d322c5cd040c87075d1cfc89d4b397568d14c0ba53cd9",
+      "tx_index": 1,
+      "output_index": 1,
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "2000000"
+        },
+        {
+          "unit": "04309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e",
+          "quantity": "1000"
+        },
+        {
+          "unit": "05309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e",
+          "quantity": "2000"
+        },
+        {
+          "unit": "06309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e",
+          "quantity": "3000"
+        },
+        {
+          "unit": "07309ed26f7636932617826b6991c7b6d8a7fa8fea66c5b9f020e6874d59546f6b656e",
+          "quantity": "4000"
+        }
+      ],
+      "block": "10974607187afacfeed5e3eaf4342e06bad0f26de438319eca18fa93f6a1541e",
+      "data_hash": null
+    }
   ]
 }


### PR DESCRIPTION
To avoid exception during fee calculation -

- If fee calculation throws InsufficientBalanceException, retry fee calculation with an updated amount (amount = amount - fee) in catch block. 
- If retry still fails, then throw exception.

To send all ada from an address after successful fee calculation, the application has to update the lovelace amount 

amount =  current ada balance - calculated fee

**Example**  To send all ada from an address with balance 1.5 Ada

```
//Create a payment transaction with total lovelace balance
            PaymentTransaction paymentTransaction =
                    PaymentTransaction.builder()
                            .sender(receiver)
                            .receiver(sender.baseAddress())
                            .amount(adaToLovelace(1.5))
                            .unit(LOVELACE)
                            .build();

//Calculate fee
            BigInteger fee = feeCalculationService.calculateFee(paymentTransaction, TransactionDetailsParams.builder().ttl(getTtl()).build(), null);

            //Update the amount and fee
            paymentTransaction.setAmount(paymentTransaction.getAmount().subtract(fee));
            paymentTransaction.setFee(fee);

//Submit transaction
            result = transactionHelperService.transfer(paymentTransaction, TransactionDetailsParams.builder().ttl(getTtl()).build());
```


