### PR TITLE
UTXO supplier abstraction

### DIFF
--- a/src/main/java/com/bloxbean/cardano/client/backend/api/helper/TransactionHelperService.java
+++ b/src/main/java/com/bloxbean/cardano/client/backend/api/helper/TransactionHelperService.java
@@ -10,6 +10,8 @@ import com.bloxbean.cardano.client.backend.exception.ApiException;
 import com.bloxbean.cardano.client.backend.model.ProtocolParams;
 import com.bloxbean.cardano.client.backend.model.Result;
 import com.bloxbean.cardano.client.coinselection.UtxoSelectionStrategy;
+import com.bloxbean.cardano.client.coinselection.UtxoSupplier;
+import com.bloxbean.cardano.client.coinselection.impl.DefaultUtxoSupplier;
 import com.bloxbean.cardano.client.crypto.SecretKey;
 import com.bloxbean.cardano.client.exception.AddressExcepion;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
@@ -41,17 +43,27 @@ public class TransactionHelperService {
     private ProtocolParams protocolParams;
 
     /**
-     * Create a {@link TransactionHelperService} from {@link TransactionService} and {@link UtxoService}
+     * Create a {@link TransactionHelperService} from {@link TransactionService} and {@link UtxoSupplier}
+     *
+     * @param transactionService
+     * @param utxoSupplier
+     */
+    public TransactionHelperService(TransactionService transactionService, EpochService epochService, UtxoSupplier utxoSupplier) {
+        this.transactionService = transactionService;
+        this.utxoTransactionBuilder = new UtxoTransactionBuilderImpl(utxoSupplier);
+        this.epochService = epochService;
+    }
+    /**
+     * Create a {@link TransactionHelperService} from {@link TransactionService} and {@link UtxoSupplier}
      *
      * @param transactionService
      * @param utxoService
+     * @deprecated use UtxoSupplier
      */
+    @Deprecated
     public TransactionHelperService(TransactionService transactionService, EpochService epochService, UtxoService utxoService) {
-        this.transactionService = transactionService;
-        this.utxoTransactionBuilder = new UtxoTransactionBuilderImpl(utxoService);
-        this.epochService = epochService;
+        this(transactionService, epochService, new DefaultUtxoSupplier(utxoService));
     }
-
     /**
      * Create a {@link TransactionHelperService} from {@link TransactionService} and custom {@link UtxoTransactionBuilder} implementation
      *

--- a/src/main/java/com/bloxbean/cardano/client/backend/api/helper/impl/UtxoTransactionBuilderImpl.java
+++ b/src/main/java/com/bloxbean/cardano/client/backend/api/helper/impl/UtxoTransactionBuilderImpl.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.backend.model.Amount;
 import com.bloxbean.cardano.client.backend.model.ProtocolParams;
 import com.bloxbean.cardano.client.backend.model.Utxo;
 import com.bloxbean.cardano.client.coinselection.UtxoSelectionStrategy;
+import com.bloxbean.cardano.client.coinselection.UtxoSupplier;
 import com.bloxbean.cardano.client.coinselection.impl.DefaultUtxoSelectionStrategyImpl;
 import com.bloxbean.cardano.client.metadata.Metadata;
 import com.bloxbean.cardano.client.transaction.model.MintTransaction;
@@ -32,8 +33,19 @@ public class UtxoTransactionBuilderImpl implements UtxoTransactionBuilder {
     /**
      * Create a {@link UtxoTransactionBuilder} with {@link DefaultUtxoSelectionStrategyImpl}
      *
-     * @param utxoService
+     * @param utxoSupplier
      */
+    public UtxoTransactionBuilderImpl(UtxoSupplier utxoSupplier) {
+        this.utxoSelectionStrategy = new DefaultUtxoSelectionStrategyImpl(utxoSupplier);
+    }
+
+    /**
+     * Create a {@link UtxoTransactionBuilder} with {@link DefaultUtxoSelectionStrategyImpl}
+     *
+     * @param utxoService
+     * @deprecated use UtxoSupplier
+     */
+    @Deprecated
     public UtxoTransactionBuilderImpl(UtxoService utxoService) {
         this.utxoSelectionStrategy = new DefaultUtxoSelectionStrategyImpl(utxoService);
     }

--- a/src/main/java/com/bloxbean/cardano/client/coinselection/UtxoSupplier.java
+++ b/src/main/java/com/bloxbean/cardano/client/coinselection/UtxoSupplier.java
@@ -1,0 +1,30 @@
+package com.bloxbean.cardano.client.coinselection;
+
+import com.bloxbean.cardano.client.backend.common.OrderEnum;
+import com.bloxbean.cardano.client.backend.model.Utxo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface UtxoSupplier {
+    int DEFAULT_NR_OF_ITEMS_TO_FETCH = 100;
+
+    List<Utxo> getPage(String address, Integer nrOfItems, Integer page, OrderEnum order);
+
+    default List<Utxo> getAll(String address){
+        var pageToFetch = 0;
+        var result = new ArrayList<Utxo>();
+        // call fetch until result is empty or < nr of items
+        while(true){
+            var pageResult = getPage(address, DEFAULT_NR_OF_ITEMS_TO_FETCH, pageToFetch, OrderEnum.asc);
+            if(pageResult != null){
+                result.addAll(pageResult);
+            }
+            if(pageResult == null || pageResult.isEmpty()){
+                break;
+            }
+            pageToFetch += 1;
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/coinselection/impl/DefaultUtxoSupplier.java
+++ b/src/main/java/com/bloxbean/cardano/client/coinselection/impl/DefaultUtxoSupplier.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.client.coinselection.impl;
+
+import com.bloxbean.cardano.client.backend.api.UtxoService;
+import com.bloxbean.cardano.client.backend.common.OrderEnum;
+import com.bloxbean.cardano.client.backend.exception.ApiException;
+import com.bloxbean.cardano.client.backend.exception.ApiRuntimeException;
+import com.bloxbean.cardano.client.backend.model.Utxo;
+import com.bloxbean.cardano.client.coinselection.UtxoSupplier;
+
+import java.util.Collections;
+import java.util.List;
+
+public class DefaultUtxoSupplier implements UtxoSupplier {
+    private final UtxoService utxoService;
+
+    public DefaultUtxoSupplier(UtxoService utxoService){
+        this.utxoService = utxoService;
+    }
+
+    @Override
+    public List<Utxo> getPage(String address, Integer nrOfItems, Integer page, OrderEnum order) {
+        try{
+            var result = utxoService.getUtxos(address, nrOfItems != null ? nrOfItems : UtxoSupplier.DEFAULT_NR_OF_ITEMS_TO_FETCH, page != null ? page + 1 : 1, order);
+            return result != null && result.getValue() != null ? result.getValue() : Collections.emptyList();
+        }catch(ApiException e){
+            throw new ApiRuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/bloxbean/cardano/client/backend/api/helper/impl/RandomImproveUtxoTransactionBuilderTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/backend/api/helper/impl/RandomImproveUtxoTransactionBuilderTest.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.backend.model.Amount;
 import com.bloxbean.cardano.client.backend.model.ProtocolParams;
 import com.bloxbean.cardano.client.backend.model.Result;
 import com.bloxbean.cardano.client.backend.model.Utxo;
+import com.bloxbean.cardano.client.coinselection.impl.DefaultUtxoSupplier;
 import com.bloxbean.cardano.client.coinselection.impl.RandomImproveUtxoSelectionStrategy;
 import com.bloxbean.cardano.client.common.ADAConversionUtil;
 import com.bloxbean.cardano.client.common.CardanoConstants;
@@ -60,7 +61,7 @@ public class RandomImproveUtxoTransactionBuilderTest {
     @BeforeEach
     public void setup() {
         MockitoAnnotations.openMocks(this);
-        utxoTransactionBuilder = new UtxoTransactionBuilderImpl(new RandomImproveUtxoSelectionStrategy(utxoService));
+        utxoTransactionBuilder = new UtxoTransactionBuilderImpl(new RandomImproveUtxoSelectionStrategy(new DefaultUtxoSupplier(utxoService)));
         protocolParams = ProtocolParams.builder()
                 .coinsPerUtxoWord("34482")
                 .build();

--- a/src/test/java/com/bloxbean/cardano/client/coinselection/impl/LargestFirstUtxoSelectionStrategyImplTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/coinselection/impl/LargestFirstUtxoSelectionStrategyImplTest.java
@@ -56,7 +56,7 @@ class LargestFirstUtxoSelectionStrategyImplTest {
         List<Utxo> utxos = loadUtxos(LIST_1);
         given(utxoService.getUtxos(any(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
 
-        LargestFirstUtxoSelectionStrategy selectionStrategy = new LargestFirstUtxoSelectionStrategy(utxoService);
+        LargestFirstUtxoSelectionStrategy selectionStrategy = new LargestFirstUtxoSelectionStrategy(new DefaultUtxoSupplier(utxoService));
         List<Utxo> selectedUtxos = selectionStrategy.selectUtxos(address, LOVELACE, new BigInteger("7500"), Collections.EMPTY_SET);
 
         List<String> txnHashList = selectedUtxos.stream().map(utxo -> utxo.getTxHash()).collect(Collectors.toList());
@@ -74,7 +74,7 @@ class LargestFirstUtxoSelectionStrategyImplTest {
         List<Utxo> utxos = loadUtxos(LIST_1);
         given(utxoService.getUtxos(any(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
 
-        LargestFirstUtxoSelectionStrategy selectionStrategy = new LargestFirstUtxoSelectionStrategy(utxoService);
+        LargestFirstUtxoSelectionStrategy selectionStrategy = new LargestFirstUtxoSelectionStrategy(new DefaultUtxoSupplier(utxoService));
         selectionStrategy.setIgnoreUtxosWithDatumHash(false);
 
         List<Utxo> selectedUtxos = selectionStrategy.selectUtxos(address, LOVELACE, new BigInteger("7500"), Collections.EMPTY_SET);

--- a/src/test/java/com/bloxbean/cardano/client/coinselection/impl/RandomImproveUtxoSelectionStrategyTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/coinselection/impl/RandomImproveUtxoSelectionStrategyTest.java
@@ -2,7 +2,6 @@ package com.bloxbean.cardano.client.coinselection.impl;
 
 import com.bloxbean.cardano.client.backend.api.UtxoService;
 import com.bloxbean.cardano.client.backend.model.Amount;
-import com.bloxbean.cardano.client.backend.model.ProtocolParams;
 import com.bloxbean.cardano.client.backend.model.Result;
 import com.bloxbean.cardano.client.backend.model.Utxo;
 import com.bloxbean.cardano.client.coinselection.UtxoSelectionStrategy;
@@ -63,7 +62,7 @@ class RandomImproveUtxoSelectionStrategyTest {
         given(utxoService.getUtxos(anyString(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
         given(utxoService.getUtxos(anyString(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.emptyList()).code(200));
 
-        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(this.utxoService, true);
+        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(new DefaultUtxoSupplier(this.utxoService), true);
 
         var requested = new Amount(CardanoConstants.LOVELACE, ADAConversionUtil.adaToLovelace(BigDecimal.TEN));
         Set<Utxo> selectedUtxos = selectionStrategy.select(address, requested, null, Collections.emptySet(), 40);
@@ -87,7 +86,7 @@ class RandomImproveUtxoSelectionStrategyTest {
         given(utxoService.getUtxos(anyString(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
         given(utxoService.getUtxos(anyString(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.emptyList()).code(200));
 
-        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(this.utxoService, true);
+        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(new DefaultUtxoSupplier(this.utxoService), true);
 
         var requested = new Amount(CardanoConstants.LOVELACE, BigInteger.valueOf(995770000).add(BigInteger.valueOf(999817955).add(BigInteger.valueOf(983172035))));
 
@@ -104,7 +103,7 @@ class RandomImproveUtxoSelectionStrategyTest {
         given(utxoService.getUtxos(anyString(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
         given(utxoService.getUtxos(anyString(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.emptyList()).code(200));
 
-        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(this.utxoService, true);
+        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(new DefaultUtxoSupplier(this.utxoService), true);
 
         var requested = new Amount(CardanoConstants.LOVELACE, BigInteger.valueOf(995770000).add(BigInteger.valueOf(999817955).add(BigInteger.valueOf(983172035))).divide(BigInteger.TWO));
 
@@ -143,7 +142,7 @@ class RandomImproveUtxoSelectionStrategyTest {
         given(utxoService.getUtxos(anyString(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
         given(utxoService.getUtxos(anyString(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.emptyList()).code(200));
 
-        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(this.utxoService, true);
+        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(new DefaultUtxoSupplier(this.utxoService), true);
 
         var requested = new Amount(unit, BigInteger.ONE);
 
@@ -165,7 +164,7 @@ class RandomImproveUtxoSelectionStrategyTest {
         given(utxoService.getUtxos(anyString(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
         given(utxoService.getUtxos(anyString(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.emptyList()).code(200));
 
-        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(this.utxoService, true);
+        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(new DefaultUtxoSupplier(this.utxoService), true);
         
         var requested = new Amount(unit, BigInteger.valueOf(4000000000L));
 
@@ -188,7 +187,7 @@ class RandomImproveUtxoSelectionStrategyTest {
         given(utxoService.getUtxos(anyString(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
         given(utxoService.getUtxos(anyString(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.emptyList()).code(200));
 
-        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(this.utxoService, true);
+        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(new DefaultUtxoSupplier(this.utxoService), true);
 
         var requested = new Amount(unit, BigInteger.valueOf(200000000L));
 
@@ -210,7 +209,7 @@ class RandomImproveUtxoSelectionStrategyTest {
         given(utxoService.getUtxos(anyString(), anyInt(), eq(1), any())).willReturn(Result.success(utxos.toString()).withValue(utxos).code(200));
         given(utxoService.getUtxos(anyString(), anyInt(), eq(2), any())).willReturn(Result.success(utxos.toString()).withValue(Collections.emptyList()).code(200));
 
-        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(this.utxoService, true);
+        UtxoSelectionStrategy selectionStrategy = new RandomImproveUtxoSelectionStrategy(new DefaultUtxoSupplier(this.utxoService), true);
         
         Set<Utxo> selectedUtxos1 = selectionStrategy.select(address, new Amount(CardanoConstants.LOVELACE, ADAConversionUtil.adaToLovelace(BigDecimal.TEN)), null, Collections.emptySet(), 40);
         Set<Utxo> selectedUtxos2 = selectionStrategy.select(address, new Amount(CardanoConstants.LOVELACE, ADAConversionUtil.adaToLovelace(BigDecimal.TEN)), null, Collections.emptySet(), 40);

--- a/src/test/java/com/bloxbean/cardano/client/function/helper/InputBuildersTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/function/helper/InputBuildersTest.java
@@ -6,7 +6,6 @@ import com.bloxbean.cardano.client.backend.api.BackendService;
 import com.bloxbean.cardano.client.backend.api.EpochService;
 import com.bloxbean.cardano.client.backend.api.UtxoService;
 import com.bloxbean.cardano.client.backend.exception.ApiException;
-import com.bloxbean.cardano.client.backend.exception.ApiRuntimeException;
 import com.bloxbean.cardano.client.backend.exception.InsufficientBalanceException;
 import com.bloxbean.cardano.client.backend.model.Amount;
 import com.bloxbean.cardano.client.backend.model.ProtocolParams;


### PR DESCRIPTION
- Added `UtxoSupplier` for supplying UTXOs to the UtxoSelectionStrategy. 
- Added `DefaultUtxoSupplier` which uses existing UtxoService for providing UTXOs

The aim of this PR is to provide abstraction in preparation of splitting the code into different modules (core, api, backends) where `UtxoSupplier` remains in `core` and `UtxoService` moves to `api`.