### PR TITLE
Remove JsonIgnore Annotation from getPolicyId()

### DIFF
--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/Policy.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/Policy.java
@@ -3,7 +3,7 @@ package com.bloxbean.cardano.client.transaction.spec;
 import com.bloxbean.cardano.client.crypto.SecretKey;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,6 +14,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Policy {
 
     //Optional - name distinguishes between multiple Policies in a project

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/Policy.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/Policy.java
@@ -43,7 +43,6 @@ public class Policy {
         return this;
     }
 
-    @JsonIgnore
     public String getPolicyId() throws CborSerializationException {
         return policyScript.getPolicyId();
     }


### PR DESCRIPTION
Policy Id shouldn't be ignored because it is better not to add serialization capabilities in frontend apps (better performance)