### PR TITLE
Bump okhttp3 version to 4.10.0 (To fix sonatype-2022-4262),Guava vers…

### DIFF
--- a/backend-modules/blockfrost/build.gradle
+++ b/backend-modules/blockfrost/build.gradle
@@ -12,10 +12,13 @@ dependencies {
     compile project(':')
     compile project(':cardano-client-backend')
 
-    implementation group: 'com.squareup.retrofit2', name: 'retrofit', version: '2.9.0'
+    implementation('com.squareup.retrofit2:retrofit:2.9.0') {
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+    }
     implementation('com.squareup.retrofit2:converter-jackson:2.9.0') {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
 
     compileOnly 'org.projectlombok:lombok:1.18.20'
     annotationProcessor 'org.projectlombok:lombok:1.18.20'

--- a/backend-modules/cardano-graphql/build.gradle
+++ b/backend-modules/cardano-graphql/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     implementation("com.apollographql.apollo:apollo-runtime:2.5.9")
     implementation("com.apollographql.apollo:apollo-reactor-support:2.5.9")
-    implementation("com.squareup.okhttp3:okhttp:4.9.1")
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
 
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.2.2'
-    implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.1-jre'
 
     //ed25519
     implementation group: 'net.i2p.crypto', name: 'eddsa', version: '0.3.0'

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':')
     implementation project(':cardano-client-backend')
     implementation project(':cardano-client-backend-blockfrost')
-    implementation project(':cardano-client-backend-gql')
+//    implementation project(':cardano-client-backend-gql')
     implementation project(':cardano-client-backend-koios')
     implementation project(':cardano-client-backend-ogmios')
 

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/function/ContractTxBuilderContextITTest.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/function/ContractTxBuilderContextITTest.java
@@ -108,14 +108,13 @@ public class ContractTxBuilderContextITTest extends BaseITTest {
         System.out.println("Script Address: " + scriptAddress);
 
         Guess guess = new Guess(Integer.valueOf(42));
-
-        Optional<Utxo> utxoOptional = ScriptUtxoFinders.findFirstByDatum(utxoSupplier, scriptAddress, guess);
+        Optional<Utxo> utxoOptional = ScriptUtxoFinders.findFirstByDatumHashUsingDatum(utxoSupplier, scriptAddress, guess);
         //Start contract transaction to claim fund
         if (!utxoOptional.isPresent()) {
             System.out.println("No utxo found...Let's transfer some Ada to script address");
             boolean paymentSuccessful = transferToContractAddress(sender, scriptAddress, adaToLovelace(5),
                     Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(guess).getDatumHash(), collateral, collateralIndex);
-            utxoOptional = ScriptUtxoFinders.findFirstByDatum(utxoSupplier, scriptAddress, guess);
+            utxoOptional = ScriptUtxoFinders.findFirstByDatumHashUsingDatum(utxoSupplier, scriptAddress, guess);
             assertTrue(paymentSuccessful);
         }
 
@@ -223,13 +222,13 @@ public class ContractTxBuilderContextITTest extends BaseITTest {
 
         Guess guess = new Guess(Integer.valueOf(42));
 
-        Optional<Utxo> customGuessUtxoOptional = ScriptUtxoFinders.findFirstByDatum(utxoSupplier, customGuessScriptAddress, guess);
+        Optional<Utxo> customGuessUtxoOptional = ScriptUtxoFinders.findFirstByDatumHashUsingDatum(utxoSupplier, customGuessScriptAddress, guess);
         //Start contract transaction to claim fund
         if (!customGuessUtxoOptional.isPresent()) {
             System.out.println("No utxo found...Let's transfer some Ada to script address");
             boolean paymentSuccessful = transferToContractAddress(sender, customGuessScriptAddress, adaToLovelace(5),
                     Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(guess).getDatumHash(), collateral, collateralIndex);
-            customGuessUtxoOptional = ScriptUtxoFinders.findFirstByDatum(utxoSupplier, customGuessScriptAddress, guess);
+            customGuessUtxoOptional = ScriptUtxoFinders.findFirstByDatumHashUsingDatum(utxoSupplier, customGuessScriptAddress, guess);
             assertTrue(paymentSuccessful);
         }
 
@@ -246,14 +245,14 @@ public class ContractTxBuilderContextITTest extends BaseITTest {
         String sumScriptAddress = AddressService.getInstance().getEntAddress(sumScript, Networks.testnet()).getAddress();
         System.out.println("Sum Script Address: " + sumScriptAddress);
 
-        Optional<Utxo> sumUtxoOptional = ScriptUtxoFinders.findFirstByDatum(utxoSupplier, sumScriptAddress, sumDatum);
+        Optional<Utxo> sumUtxoOptional = ScriptUtxoFinders.findFirstByDatumHashUsingDatum(utxoSupplier, sumScriptAddress, sumDatum);
         //Start contract transaction to claim fund
         if (!sumUtxoOptional.isPresent()) {
             System.out.println("No utxo found for sum contract...Let's transfer some Ada to script address");
             System.out.println("Sum Datum hash >>> " + Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(sumDatum).getDatumHash());
             boolean paymentSuccessful = transferToContractAddress(sender, sumScriptAddress, adaToLovelace(6),
                     Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(sumDatum).getDatumHash(), collateral, collateralIndex);
-            sumUtxoOptional = ScriptUtxoFinders.findFirstByDatum(utxoSupplier, sumScriptAddress, sumDatum);
+            sumUtxoOptional = ScriptUtxoFinders.findFirstByDatumHashUsingDatum(utxoSupplier, sumScriptAddress, sumDatum);
             assertTrue(paymentSuccessful);
         }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name = 'cardano-client-lib'
 include 'backend'
 include 'blockfrost'
-include 'cardano-graphql'
+//include 'cardano-graphql'
 include 'koios'
 include 'ogmios'
 include 'integration-test'
@@ -15,8 +15,8 @@ project(':blockfrost').projectDir = file('backend-modules/blockfrost')
 project(":blockfrost").name = "cardano-client-backend-blockfrost"
 
 //cardano-graphql backend
-project(':cardano-graphql').projectDir = file('backend-modules/cardano-graphql')
-project(":cardano-graphql").name = "cardano-client-backend-gql"
+//project(':cardano-graphql').projectDir = file('backend-modules/cardano-graphql')
+//project(":cardano-graphql").name = "cardano-client-backend-gql"
 
 //Koios backend
 project(':koios').projectDir = file('backend-modules/koios')

--- a/src/test/java/com/bloxbean/cardano/client/function/helper/ScriptUtxoFindersTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/function/helper/ScriptUtxoFindersTest.java
@@ -47,7 +47,7 @@ class ScriptUtxoFindersTest extends BaseTest {
         String scriptAddress = "addr_test1wqryj32h6d4srdj720nqxy4hew26anzx8h7lny79qlum89s5hrkh0";
         String datum = "hello";
 
-        Optional<Utxo> utxoOptional = ScriptUtxoFinders.findFirstByDatum(utxoSupplier, scriptAddress, datum);
+        Optional<Utxo> utxoOptional = ScriptUtxoFinders.findFirstByDatumHashUsingDatum(utxoSupplier, scriptAddress, datum);
 
         assertThat(utxoOptional.get().getTxHash()).isEqualTo("88c014d348bf1919c78a5cb87a5beed87729ff3f8a2019be040117a41a83e82e");
         assertThat(utxoOptional.get().getOutputIndex()).isEqualTo(1);
@@ -79,7 +79,7 @@ class ScriptUtxoFindersTest extends BaseTest {
         String scriptAddress = "addr_test1wqryj32h6d4srdj720nqxy4hew26anzx8h7lny79qlum89s5hrkh0";
         String datum = "hello";
 
-        List<Utxo> list = ScriptUtxoFinders.findAllByDatum(utxoSupplier, scriptAddress, datum);
+        List<Utxo> list = ScriptUtxoFinders.findAllByDatumHashUsingDatum(utxoSupplier, scriptAddress, datum);
 
         assertThat(list).hasSize(2);
         assertThat(list.get(0).getTxHash()).isEqualTo("88c014d348bf1919c78a5cb87a5beed87729ff3f8a2019be040117a41a83e82e");
@@ -121,7 +121,7 @@ class ScriptUtxoFindersTest extends BaseTest {
         String scriptAddress = "addr_test1wqryj32h6d4srdj720nqxy4hew26anzx8h7lny79qlum89s5hrkh0";
         String datum = "hello111";
 
-        Optional<Utxo> utxoOptional = ScriptUtxoFinders.findFirstByDatum(utxoSupplier, scriptAddress, datum);
+        Optional<Utxo> utxoOptional = ScriptUtxoFinders.findFirstByDatumHashUsingDatum(utxoSupplier, scriptAddress, datum);
 
         assertThat(utxoOptional.isPresent()).isEqualTo(false);
     }
@@ -139,5 +139,63 @@ class ScriptUtxoFindersTest extends BaseTest {
 
         assertThat(list).hasSize(0);
     }
+
+    @Test
+    void findFirstByInlineDatum() throws IOException, ApiException {
+        List<Utxo> utxos = loadUtxos(LIST_1);
+        given(utxoSupplier.getPage(any(), anyInt(), eq(0), any())).willReturn(utxos);
+        given(utxoSupplier.getPage(any(), anyInt(), eq(1), any())).willReturn(Collections.EMPTY_LIST);
+
+        String scriptAddress = "addr_test1wqryj32h6d4srdj720nqxy4hew26anzx8h7lny79qlum89s5hrkh0";
+        Integer datum = Integer.valueOf(-179132674);
+
+        Optional<Utxo> utxoOptional = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scriptAddress, datum);
+
+        assertThat(utxoOptional.orElse(new Utxo()).getTxHash()).isEqualTo("9999e44f0f03915b1611ce58aaff5f2e52054e1911fbcd0f17dbc205f44763b6");
+    }
+
+    @Test
+    void findAllByInlineDatum() throws IOException, ApiException {
+        List<Utxo> utxos = loadUtxos(LIST_1);
+        given(utxoSupplier.getPage(any(), anyInt(), eq(0), any())).willReturn(utxos);
+        given(utxoSupplier.getPage(any(), anyInt(), eq(1), any())).willReturn(Collections.EMPTY_LIST);
+
+        String scriptAddress = "addr_test1wqryj32h6d4srdj720nqxy4hew26anzx8h7lny79qlum89s5hrkh0";
+        Integer datum = Integer.valueOf(-179132674);
+
+        List<Utxo> list = ScriptUtxoFinders.findAllByInlineDatum(utxoSupplier, scriptAddress, datum);
+
+        assertThat(list).hasSize(3);
+        assertThat(list.get(0).getTxHash()).isEqualTo("9999e44f0f03915b1611ce58aaff5f2e52054e1911fbcd0f17dbc205f44763b6");
+        assertThat(list.get(1).getTxHash()).isEqualTo("111e44f0f03915b1611ce58aaff5f2e52054e1911fbcd0f17dbc205f44763b6");
+        assertThat(list.get(2).getTxHash()).isEqualTo("222e44f0f03915b1611ce58aaff5f2e52054e1911fbcd0f17dbc205f44763b6");
+    }
+
+    @Test
+    void findFirstByInlineDatum_whenNoUtxoAvailable() throws IOException, ApiException {
+        List<Utxo> utxos = loadUtxos(LIST_1);
+        given(utxoSupplier.getPage(any(), anyInt(), eq(0), any())).willReturn(utxos);
+        given(utxoSupplier.getPage(any(), anyInt(), eq(1), any())).willReturn(Collections.EMPTY_LIST);
+
+        String scriptAddress = "addr_test1wqryj32h6d4srdj720nqxy4hew26anzx8h7lny79qlum89s5hrkh0";
+        Integer datum = Integer.valueOf(-479132674);
+
+        Optional<Utxo> utxoOptional = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scriptAddress, datum);
+        assertThat(utxoOptional.isPresent()).isFalse();
+    }
+
+    @Test
+    void findAllByInlineDatum_whenNoUtxoAvailable() throws IOException, ApiException {
+        List<Utxo> utxos = loadUtxos(LIST_1);
+        given(utxoSupplier.getPage(any(), anyInt(), eq(0), any())).willReturn(utxos);
+        given(utxoSupplier.getPage(any(), anyInt(), eq(1), any())).willReturn(Collections.EMPTY_LIST);
+
+        String scriptAddress = "addr_test1wqryj32h6d4srdj720nqxy4hew26anzx8h7lny79qlum89s5hrkh0";
+        Integer datum = Integer.valueOf(-1791326745);
+
+        List<Utxo> list = ScriptUtxoFinders.findAllByInlineDatum(utxoSupplier, scriptAddress, datum);
+
+        assertThat(list).hasSize(0);
+     }
 
 }

--- a/src/test/resources/utxos-script-utxo-finders.json
+++ b/src/test/resources/utxos-script-utxo-finders.json
@@ -54,6 +54,57 @@
         }
       ],
       "block": "c2a5408a54596d52e3b0d7aed546ceb7e4d74a06ce80dca13664acd3afdea3e5"
+    },
+    {
+      "tx_hash": "9999e44f0f03915b1611ce58aaff5f2e52054e1911fbcd0f17dbc205f44763b6",
+      "tx_index": 0,
+      "output_index": 0,
+      "inline_datum": "3a0aad5901",
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "1000"
+        }
+      ],
+      "block": "eb2043df94b34d1746cb47303446237e6dca7d051100c8f4229795be8c1f5e63"
+    },
+    {
+      "tx_hash": "111e44f0f03915b1611ce58aaff5f2e52054e1911fbcd0f17dbc205f44763b6",
+      "tx_index": 0,
+      "output_index": 0,
+      "inline_datum": "3a0aad5901",
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "500"
+        }
+      ],
+      "block": "eb2043df94b34d1746cb47303446237e6dca7d051100c8f4229795be8c1f5e63"
+    },
+    {
+      "tx_hash": "222e44f0f03915b1611ce58aaff5f2e52054e1911fbcd0f17dbc205f44763b6",
+      "tx_index": 0,
+      "output_index": 0,
+      "inline_datum": "3a0aad5901",
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "800"
+        }
+      ],
+      "block": "eb2043df94b34d1746cb47303446237e6dca7d051100c8f4229795be8c1f5e63"
+    },
+    {
+      "tx_hash": "444e44f0f03915b1611ce58aaff5f2e52054e1911fbcd0f17dbc205f44763b6",
+      "tx_index": 0,
+      "output_index": 0,
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "1000"
+        }
+      ],
+      "block": "eb2043df94b34d1746cb47303446237e6dca7d051100c8f4229795be8c1f5e63"
     }
   ]
 }


### PR DESCRIPTION
1. Bump okhttp3 version to 4.10.0 (To fix sonatype-2022-4262)
2. Guava version to 31.1-jre
3. GraphQL backend  has been removed
4. Added findByInlineDatum methods 