### PR TITLE
Function to serialize datum hex to json format 

### DIFF
--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/BigIntPlutusData.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/BigIntPlutusData.java
@@ -6,6 +6,10 @@ import co.nstant.in.cbor.model.Number;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.transaction.spec.serializers.BigIntDataJsonDeserializer;
+import com.bloxbean.cardano.client.transaction.spec.serializers.BigIntDataJsonSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.*;
 
 import java.math.BigInteger;
@@ -15,6 +19,8 @@ import java.math.BigInteger;
 @NoArgsConstructor
 @Builder
 @EqualsAndHashCode
+@JsonSerialize(using = BigIntDataJsonSerializer.class)
+@JsonDeserialize(using = BigIntDataJsonDeserializer.class)
 public class BigIntPlutusData implements PlutusData {
     private BigInteger value;
 

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/BytesPlutusData.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/BytesPlutusData.java
@@ -4,6 +4,10 @@ import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.transaction.spec.serializers.BytesDataJsonDeserializer;
+import com.bloxbean.cardano.client.transaction.spec.serializers.BytesDataJsonSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.*;
 
 import java.nio.charset.StandardCharsets;
@@ -13,6 +17,8 @@ import java.nio.charset.StandardCharsets;
 @NoArgsConstructor
 @Builder
 @EqualsAndHashCode
+@JsonSerialize(using = BytesDataJsonSerializer.class)
+@JsonDeserialize(using = BytesDataJsonDeserializer.class)
 public class BytesPlutusData implements PlutusData {
     private byte[] value;
 

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/ConstrPlutusData.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/ConstrPlutusData.java
@@ -6,10 +6,11 @@ import co.nstant.in.cbor.model.Tag;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.bloxbean.cardano.client.transaction.spec.serializers.ConstrDataJsonDeserializer;
+import com.bloxbean.cardano.client.transaction.spec.serializers.ConstrDataJsonSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.*;
 
 import java.util.List;
 
@@ -17,6 +18,9 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@EqualsAndHashCode
+@JsonSerialize(using = ConstrDataJsonSerializer.class)
+@JsonDeserialize(using = ConstrDataJsonDeserializer.class)
 public class ConstrPlutusData implements PlutusData {
     // see: https://github.com/input-output-hk/plutus/blob/1f31e640e8a258185db01fa899da63f9018c0e85/plutus-core/plutus-core/src/PlutusCore/Data.hs#L61
     // We don't directly serialize the alternative in the tag, instead the scheme is:

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/ListPlutusData.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/ListPlutusData.java
@@ -5,10 +5,11 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Special;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.bloxbean.cardano.client.transaction.spec.serializers.ListDataJsonDeserializer;
+import com.bloxbean.cardano.client.transaction.spec.serializers.ListDataJsonSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,6 +19,9 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@EqualsAndHashCode
+@JsonSerialize(using = ListDataJsonSerializer.class)
+@JsonDeserialize(using = ListDataJsonDeserializer.class)
 public class ListPlutusData implements PlutusData {
 
     @Builder.Default
@@ -91,5 +95,4 @@ public class ListPlutusData implements PlutusData {
 
         return plutusDataArray;
     }
-
 }

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/MapPlutusData.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/MapPlutusData.java
@@ -4,10 +4,11 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.bloxbean.cardano.client.transaction.spec.serializers.MapDataJsonDeserializer;
+import com.bloxbean.cardano.client.transaction.spec.serializers.MapDataJsonSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.*;
 
 import java.util.HashMap;
 
@@ -15,6 +16,9 @@ import java.util.HashMap;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@EqualsAndHashCode
+@JsonSerialize(using = MapDataJsonSerializer.class)
+@JsonDeserialize(using = MapDataJsonDeserializer.class)
 public class MapPlutusData implements PlutusData {
 
     @Builder.Default

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/PlutusData.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/PlutusData.java
@@ -4,12 +4,13 @@ import co.nstant.in.cbor.CborDecoder;
 import co.nstant.in.cbor.CborException;
 import co.nstant.in.cbor.model.Number;
 import co.nstant.in.cbor.model.*;
-import com.bloxbean.cardano.client.crypto.KeyGenUtil;
+import com.bloxbean.cardano.client.crypto.Blake2bUtil;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborRuntimeException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.transaction.util.CborSerializationUtil;
 import com.bloxbean.cardano.client.util.HexUtil;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.NonNull;
 
 public interface PlutusData {
@@ -62,12 +63,14 @@ public interface PlutusData {
         }
     }
 
+    @JsonIgnore
     default String getDatumHash() throws CborSerializationException, CborException {
         return HexUtil.encodeHexString(getDatumHashAsBytes());
     }
 
+    @JsonIgnore
     default byte[] getDatumHashAsBytes() throws CborSerializationException, CborException {
-        return KeyGenUtil.blake2bHash256(CborSerializationUtil.serialize(serialize()));
+        return Blake2bUtil.blake2bHash256(CborSerializationUtil.serialize(serialize()));
     }
 
     default String serializeToHex()  {

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/BigIntDataJsonDeserializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/BigIntDataJsonDeserializer.java
@@ -1,0 +1,32 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.BigIntPlutusData;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.INT;
+
+public class BigIntDataJsonDeserializer extends StdDeserializer<BigIntPlutusData> {
+
+    public BigIntDataJsonDeserializer() {
+        this(null);
+    }
+
+    public BigIntDataJsonDeserializer(Class<?> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public BigIntPlutusData deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        BigInteger intVal = node.get(INT).bigIntegerValue();
+        return BigIntPlutusData.of(intVal);
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/BigIntDataJsonSerializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/BigIntDataJsonSerializer.java
@@ -1,0 +1,28 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.BigIntPlutusData;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.INT;
+
+public class BigIntDataJsonSerializer extends StdSerializer<BigIntPlutusData> {
+
+    public BigIntDataJsonSerializer() {
+        this(null);
+    }
+
+    public BigIntDataJsonSerializer(Class<BigIntPlutusData> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public void serialize(BigIntPlutusData value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        gen.writeNumberField(INT, value.getValue());
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/BytesDataJsonDeserializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/BytesDataJsonDeserializer.java
@@ -1,0 +1,32 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.BYTES;
+
+public class BytesDataJsonDeserializer extends StdDeserializer<BytesPlutusData> {
+
+    public BytesDataJsonDeserializer() {
+        this(null);
+    }
+
+    public BytesDataJsonDeserializer(Class<?> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public BytesPlutusData deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        String bytesHex = node.get(BYTES).asText();
+        return BytesPlutusData.of(HexUtil.decodeHexString(bytesHex));
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/BytesDataJsonSerializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/BytesDataJsonSerializer.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.BYTES;
+
+public class BytesDataJsonSerializer extends StdSerializer<BytesPlutusData> {
+
+    public BytesDataJsonSerializer() {
+        this(null);
+    }
+
+    public BytesDataJsonSerializer(Class<BytesPlutusData> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public void serialize(BytesPlutusData value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        gen.writeStringField(BYTES, HexUtil.encodeHexString(value.getValue()));
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/ConstrDataJsonDeserializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/ConstrDataJsonDeserializer.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.ConstrPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.PlutusData;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.CONSTRUCTOR;
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.FIELDS;
+
+public class ConstrDataJsonDeserializer extends StdDeserializer<ConstrPlutusData> {
+
+    public ConstrDataJsonDeserializer() {
+        this(null);
+    }
+
+    public ConstrDataJsonDeserializer(Class<?> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public ConstrPlutusData deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        if (!node.has(CONSTRUCTOR))
+            throw new IllegalArgumentException("Invalid json for ConstrPlutusData. " + node);
+
+        long alternative = node.get(CONSTRUCTOR).asLong();
+
+        ArrayNode fieldsNode = (ArrayNode) node.get(FIELDS);
+        List<PlutusData> plutusDataList = new ArrayList<>();
+        for (int i = 0; i < fieldsNode.size(); i++) {
+            plutusDataList.add(PlutusDataJsonConverter.toPlutusData(fieldsNode.get(i)));
+        }
+
+        return ConstrPlutusData.of(alternative, plutusDataList.toArray(new PlutusData[0]));
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/ConstrDataJsonSerializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/ConstrDataJsonSerializer.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.ConstrPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.ListPlutusData;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.CONSTRUCTOR;
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.FIELDS;
+
+public class ConstrDataJsonSerializer extends StdSerializer<ConstrPlutusData> {
+
+    public ConstrDataJsonSerializer() {
+        this(null);
+    }
+
+    public ConstrDataJsonSerializer(Class<ConstrPlutusData> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public void serialize(ConstrPlutusData value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        gen.writeNumberField(CONSTRUCTOR, value.getAlternative());
+        if (value.getData() != null) {
+            ListPlutusData listPlutusData = value.getData();
+            gen.writeObjectField(FIELDS, listPlutusData.getPlutusDataList());
+        } else
+            gen.writeObjectField(FIELDS, Collections.emptyList());
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/ListDataJsonDeserializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/ListDataJsonDeserializer.java
@@ -1,0 +1,43 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.ListPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.PlutusData;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.LIST;
+
+public class ListDataJsonDeserializer extends StdDeserializer<ListPlutusData> {
+
+    public ListDataJsonDeserializer() {
+        this(null);
+    }
+
+    public ListDataJsonDeserializer(Class<?> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public ListPlutusData deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        if (!node.has(LIST))
+            throw new IllegalArgumentException("Invalid json for ListPlutusData : " + node);
+
+        ArrayNode arrayNode = (ArrayNode) node.get(LIST);
+        List<PlutusData> plutusDataList = new ArrayList<>();
+        for (int i = 0; i < arrayNode.size(); i++) {
+            JsonNode itemNode = arrayNode.get(i);
+            plutusDataList.add(PlutusDataJsonConverter.toPlutusData(itemNode));
+        }
+
+        return ListPlutusData.of(plutusDataList.toArray(new PlutusData[0]));
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/ListDataJsonSerializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/ListDataJsonSerializer.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.ListPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.PlutusData;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.LIST;
+
+public class ListDataJsonSerializer extends StdSerializer<ListPlutusData> {
+
+    public ListDataJsonSerializer() {
+        this(null);
+    }
+
+    public ListDataJsonSerializer(Class<ListPlutusData> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public void serialize(ListPlutusData value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeStartObject();
+        gen.writeFieldName(LIST);
+        gen.writeStartArray();
+        List<PlutusData> items = value.getPlutusDataList();
+        for (PlutusData item : items) {
+            gen.writeObject(item);
+        }
+        gen.writeEndArray();
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/MapDataJsonDeserializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/MapDataJsonDeserializer.java
@@ -1,0 +1,42 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.MapPlutusData;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.io.IOException;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.*;
+
+public class MapDataJsonDeserializer extends StdDeserializer<MapPlutusData> {
+
+    public MapDataJsonDeserializer() {
+        this(null);
+    }
+
+    public MapDataJsonDeserializer(Class<?> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public MapPlutusData deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        if (!node.has(MAP))
+            throw new IllegalArgumentException("Invalid json for MapPlutusData : " + node);
+
+        ArrayNode arrayNode = (ArrayNode) node.get(MAP);
+        MapPlutusData mapPlutusData = new MapPlutusData();
+        for (int i = 0; i < arrayNode.size(); i++) {
+            JsonNode itemNode = arrayNode.get(i);
+            JsonNode keyNode = itemNode.get(MAP_KEY);
+            JsonNode valueNode = itemNode.get(MAP_VALUE);
+            mapPlutusData.put(PlutusDataJsonConverter.toPlutusData(keyNode), PlutusDataJsonConverter.toPlutusData(valueNode));
+        }
+
+        return mapPlutusData;
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/MapDataJsonSerializer.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/MapDataJsonSerializer.java
@@ -1,0 +1,43 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.MapPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.PlutusData;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.*;
+
+public class MapDataJsonSerializer extends StdSerializer<MapPlutusData> {
+
+    public MapDataJsonSerializer() {
+        this(null);
+    }
+
+    public MapDataJsonSerializer(Class<MapPlutusData> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public void serialize(MapPlutusData mapData, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        Map<PlutusData, PlutusData> map = mapData.getMap();
+
+        gen.writeStartObject();
+        gen.writeFieldName(MAP);
+        gen.writeStartArray();
+        Iterator<Map.Entry<PlutusData, PlutusData>> itr = map.entrySet().iterator();
+        while (itr.hasNext()) {
+            Map.Entry<PlutusData, PlutusData> entry = itr.next();
+            gen.writeStartObject();
+            gen.writeObjectField(MAP_KEY, entry.getKey());
+            gen.writeObjectField(MAP_VALUE, entry.getValue());
+            gen.writeEndObject();
+        }
+        gen.writeEndArray();
+        gen.writeEndObject();
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/PlutusDataJsonConverter.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/PlutusDataJsonConverter.java
@@ -1,0 +1,66 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.NonNull;
+
+import static com.bloxbean.cardano.client.transaction.spec.serializers.PlutusDataJsonKeys.*;
+
+/**
+ * Use this class to convert {@link PlutusData} to json or parse a compatible json to {@link PlutusData}
+ * It supports detailed schema mapping for json conversion.
+ * Follows ScriptDataJsonSchema in cardano-cli defined at for detailed schema mapping.
+ * https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/ScriptData.hs#L254
+ */
+public class PlutusDataJsonConverter {
+    private static ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);;
+
+    /**
+     * Convert a compatible json string to {@link PlutusData}
+     * @param json
+     * @return
+     * @throws JsonProcessingException
+     */
+    public static PlutusData toPlutusData(@NonNull String json) throws JsonProcessingException {
+        JsonNode jsonNode = mapper.readTree(json);
+        return toPlutusData(jsonNode);
+    }
+
+    /**
+     * Convert a compatible {@link JsonNode} to {@link PlutusData}
+     * @param jsonNode
+     * @return
+     * @throws JsonProcessingException
+     */
+    public static PlutusData toPlutusData(@NonNull JsonNode jsonNode) throws JsonProcessingException {
+        if (jsonNode instanceof ObjectNode) {
+            if (jsonNode.has(CONSTRUCTOR))
+                return mapper.readValue(jsonNode.toString(), ConstrPlutusData.class);
+            else if (jsonNode.has(INT))
+                return mapper.readValue(jsonNode.toString(), BigIntPlutusData.class);
+            else if (jsonNode.has(BYTES))
+                return mapper.readValue(jsonNode.toString(), BytesPlutusData.class);
+            else if (jsonNode.has(LIST)) {
+                return mapper.readValue(jsonNode.toString(), ListPlutusData.class);
+            } else if (jsonNode.has(MAP)) {
+                return mapper.readValue(jsonNode.toString(), MapPlutusData.class);
+            }
+        }
+
+        throw new IllegalArgumentException("Json parsing failed. " + jsonNode);
+    }
+
+    /**
+     * Convert {@link PlutusData} to json
+     * @param plutusData
+     * @return
+     * @throws JsonProcessingException
+     */
+    public static String toJson(PlutusData plutusData) throws JsonProcessingException {
+        return mapper.writeValueAsString(plutusData);
+    }
+}

--- a/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/PlutusDataJsonKeys.java
+++ b/src/main/java/com/bloxbean/cardano/client/transaction/spec/serializers/PlutusDataJsonKeys.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+class PlutusDataJsonKeys {
+    final static String CONSTRUCTOR = "constructor";
+    final static String FIELDS = "fields";
+    final static String INT = "int";
+    final static String BYTES = "bytes";
+    final static String LIST = "list";
+    final static String MAP = "map";
+    final static String MAP_KEY = "k";
+    final static String MAP_VALUE = "v";
+}

--- a/src/main/java/com/bloxbean/cardano/client/util/JsonUtil.java
+++ b/src/main/java/com/bloxbean/cardano/client/util/JsonUtil.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class JsonUtil {
 
     protected static final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
@@ -14,6 +16,7 @@ public class JsonUtil {
         try {
             return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(obj);
         } catch (JsonProcessingException e) {
+            log.error("Json parsing error", e);
             return obj.toString();
         }
     }

--- a/src/test/java/com/bloxbean/cardano/client/transaction/spec/MapPlutusDataTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/transaction/spec/MapPlutusDataTest.java
@@ -1,0 +1,34 @@
+package com.bloxbean.cardano.client.transaction.spec;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MapPlutusDataTest {
+
+    @Test
+    void testEquals() {
+        MapPlutusData mapPlutusData = new MapPlutusData();
+        mapPlutusData.put(BytesPlutusData.of("key1"), BytesPlutusData.of("value1"));
+        mapPlutusData.put(BytesPlutusData.of("key2"), BigIntPlutusData.of(300000));
+
+        MapPlutusData mapPlutusData2 = new MapPlutusData();
+        mapPlutusData2.put(BytesPlutusData.of("key1"), BytesPlutusData.of("value1"));
+        mapPlutusData2.put(BytesPlutusData.of("key2"), BigIntPlutusData.of(300000));
+
+        assertThat(mapPlutusData).isEqualTo(mapPlutusData2);
+    }
+
+    @Test
+    void testNotEquals() {
+        MapPlutusData mapPlutusData = new MapPlutusData();
+        mapPlutusData.put(BytesPlutusData.of("key1"), BytesPlutusData.of("value1"));
+        mapPlutusData.put(BytesPlutusData.of("key2"), BigIntPlutusData.of(300000));
+
+        MapPlutusData mapPlutusData2 = new MapPlutusData();
+        mapPlutusData2.put(BytesPlutusData.of("key1"), BytesPlutusData.of("value1"));
+        mapPlutusData2.put(BytesPlutusData.of("key2"), BigIntPlutusData.of(222));
+
+        assertThat(mapPlutusData).isNotEqualTo(mapPlutusData2);
+    }
+}

--- a/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/BigIntDataJsonSerializerTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/BigIntDataJsonSerializerTest.java
@@ -1,0 +1,40 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.util.JsonUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BigIntDataJsonSerializerTest {
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serialize() throws JsonProcessingException {
+        BigIntPlutusData bigIntPlutusData = BigIntPlutusData.of(new BigInteger("20000"));
+        JsonNode expected = JsonUtil.parseJson("{\n" +
+                "   \"int\": 20000\n" +
+                "}");
+
+        String json = JsonUtil.getPrettyJson(bigIntPlutusData);
+        System.out.println(json);
+        JsonNode actualJsonNode = JsonUtil.parseJson(json);
+
+        assertThat(actualJsonNode).isEqualTo(expected);
+    }
+
+    @Test
+    void deserialize() throws JsonProcessingException {
+        String json = "{\n" +
+                "   \"int\": 20000\n" +
+                "}";
+        BigIntPlutusData bigIntPlutusData = objectMapper.readValue(json, BigIntPlutusData.class);
+
+        assertThat(bigIntPlutusData.getValue()).isEqualTo(BigInteger.valueOf(20000));
+    }
+}

--- a/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/BytesDataJsonSerializerTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/BytesDataJsonSerializerTest.java
@@ -1,0 +1,39 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.util.JsonUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BytesDataJsonSerializerTest {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void serialize() throws JsonProcessingException {
+        BytesPlutusData bytesPlutusData = BytesPlutusData.of("Hello World");
+        System.out.println(bytesPlutusData.serializeToHex());
+
+        String json = JsonUtil.getPrettyJson(bytesPlutusData);
+        JsonNode actualJsonNode = JsonUtil.parseJson(json);
+
+        JsonNode expectedJson = JsonUtil.parseJson("{\n" +
+                "   \"bytes\": \"48656c6c6f20576f726c64\"\n" +
+                "}");
+        assertThat(actualJsonNode).isEqualTo(expectedJson);
+    }
+
+    @Test
+    void deserialize() throws JsonProcessingException {
+        String json = "{\n" +
+                "   \"bytes\": \"48656c6c6f20576f726c64\"\n" +
+                "}";
+        BytesPlutusData bytesPlutusData = objectMapper.readValue(json, BytesPlutusData.class);
+
+        BytesPlutusData expectedBytesPlutusData = BytesPlutusData.of("Hello World");
+        assertThat(bytesPlutusData).isEqualTo(expectedBytesPlutusData);
+    }
+}

--- a/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/ConstrDataJsonSerializerTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/ConstrDataJsonSerializerTest.java
@@ -1,0 +1,74 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.ConstrPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.ListPlutusData;
+import com.bloxbean.cardano.client.util.JsonUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConstrDataJsonSerializerTest {
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serialize() throws JsonProcessingException {
+        ConstrPlutusData constrPlutusData = ConstrPlutusData.of(0,
+                BigIntPlutusData.of(100),
+                BytesPlutusData.of("Hello"),
+                ListPlutusData.of(BigIntPlutusData.of(2000), BytesPlutusData.of("World")));
+
+        System.out.println(constrPlutusData.serializeToHex());
+
+        String json = JsonUtil.getPrettyJson(constrPlutusData);
+        System.out.println(json);
+        JsonNode jsonNode = JsonUtil.parseJson(json);
+
+        JsonNode expectedJson = JsonUtil.parseJson("{\"constructor\":0," +
+                "\"fields\":[" +
+                "{\"int\":100}," +
+                "{\"bytes\":\"48656c6c6f\"}," +
+                "{\"list\":" +
+                "[{\"int\":2000},{\"bytes\":\"576f726c64\"}]}]" +
+                "}");
+
+        assertThat(jsonNode).isEqualTo(expectedJson);
+    }
+
+    @Test
+    void deserialize() throws JsonProcessingException {
+        String json = "{\n" +
+                "   \"constructor\": 2,\n" +
+                "   \"fields\": [\n" +
+                "      {\n" +
+                "         \"int\": 100\n" +
+                "      },\n" +
+                "      {\n" +
+                "         \"bytes\": \"48656c6c6f\"\n" +
+                "      },\n" +
+                "      {\"list\": [\n" +
+                "         {\n" +
+                "            \"int\": 2000\n" +
+                "         },\n" +
+                "         {\n" +
+                "            \"bytes\": \"576f726c64\"\n" +
+                "         }\n" +
+                "      ]}\n" +
+                "   ]\n" +
+                "}";
+
+        ConstrPlutusData constrPlutusData = mapper.readValue(json, ConstrPlutusData.class);
+
+        ConstrPlutusData expectedConstrPlutusData = ConstrPlutusData.of(2,
+                BigIntPlutusData.of(100),
+                BytesPlutusData.of("Hello"),
+                ListPlutusData.of(BigIntPlutusData.of(2000), BytesPlutusData.of("World")));
+
+        assertThat(constrPlutusData).isEqualTo(expectedConstrPlutusData);
+    }
+
+}

--- a/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/ListDataJsonSerializerTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/ListDataJsonSerializerTest.java
@@ -1,0 +1,40 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.ListPlutusData;
+import com.bloxbean.cardano.client.util.JsonUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListDataJsonSerializerTest {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serialize() throws JsonProcessingException {
+        ListPlutusData listPlutusData = ListPlutusData.of(BytesPlutusData.of("Hello"), BigIntPlutusData.of(10000), BytesPlutusData.of("World"));
+
+        String json = JsonUtil.getPrettyJson(listPlutusData);
+        JsonNode jsonNode = JsonUtil.parseJson(json);
+
+        JsonNode expectedJson = JsonUtil.parseJson("{\"list\":[{\"bytes\":\"48656c6c6f\"},{\"int\":10000},{\"bytes\":\"576f726c64\"}]}");
+
+        assertThat(jsonNode).isEqualTo(expectedJson);
+    }
+
+    @Test
+    void deserialize() throws JsonProcessingException {
+        String json = "{\"list\":[{\"bytes\":\"48656c6c6f\"},{\"int\":10000},{\"bytes\":\"576f726c64\"}]}";
+
+        ListPlutusData listPlutusData = objectMapper.readValue(json, ListPlutusData.class);
+
+        assertThat(listPlutusData.getPlutusDataList()).hasSize(3);
+        assertThat(listPlutusData.getPlutusDataList().get(0)).isEqualTo(BytesPlutusData.of("Hello"));
+        assertThat(listPlutusData.getPlutusDataList().get(1)).isEqualTo(BigIntPlutusData.of(10000));
+        assertThat(listPlutusData.getPlutusDataList().get(2)).isEqualTo(BytesPlutusData.of("World"));
+    }
+}

--- a/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/MapDataJsonSerializerTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/MapDataJsonSerializerTest.java
@@ -1,0 +1,78 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import co.nstant.in.cbor.model.Map;
+import com.bloxbean.cardano.client.transaction.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.BytesPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.ListPlutusData;
+import com.bloxbean.cardano.client.transaction.spec.MapPlutusData;
+import com.bloxbean.cardano.client.transaction.util.CborSerializationUtil;
+import com.bloxbean.cardano.client.util.HexUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MapDataJsonSerializerTest {
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializeAndDeserialize() throws JsonProcessingException {
+        MapPlutusData mapPlutusData = new MapPlutusData();
+        mapPlutusData.put(BigIntPlutusData.of(1000), BigIntPlutusData.of(2000));
+        mapPlutusData.put(BigIntPlutusData.of(3), BytesPlutusData.of("Hello"));
+        mapPlutusData.put(ListPlutusData.of(BigIntPlutusData.of(1), BytesPlutusData.of("key")), BytesPlutusData.of("World"));
+
+        String expectedJson = "{\n" +
+                "  \"map\": [\n" +
+                "    {\n" +
+                "      \"k\": {\n" +
+                "        \"list\": [\n" +
+                "          {\n" +
+                "            \"int\": 1\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"bytes\": \"6b6579\"\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      \"v\": {\n" +
+                "        \"bytes\": \"576f726c64\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"k\": {\n" +
+                "        \"int\": 3\n" +
+                "      },\n" +
+                "      \"v\": {\n" +
+                "        \"bytes\": \"48656c6c6f\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"k\": {\n" +
+                "        \"int\": 1000\n" +
+                "      },\n" +
+                "      \"v\": {\n" +
+                "        \"int\": 2000\n" +
+                "      }\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        MapPlutusData mapPlutusData2 = (MapPlutusData) mapper.readValue(expectedJson, MapPlutusData.class);
+        assertThat(mapPlutusData).isEqualTo(mapPlutusData2);
+
+    }
+
+    @Test
+    void serDeser_from_cbor() throws Exception {
+        String cborHex = "a3034548656c6c6f1903e81907d09f01436b6579ff45576f726c64";
+        MapPlutusData mapPlutusData = MapPlutusData.deserialize((Map) CborSerializationUtil.deserialize(HexUtil.decodeHexString(cborHex)));
+
+        String json = mapper.writeValueAsString(mapPlutusData);
+        MapPlutusData mapPlutusData2 = mapper.readValue(json, MapPlutusData.class);
+        String cborHex2 = mapPlutusData2.serializeToHex();
+
+        assertThat(cborHex2).isEqualTo(cborHex);
+    }
+}

--- a/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/PlutusDataJsonConverterTest.java
+++ b/src/test/java/com/bloxbean/cardano/client/transaction/spec/serializers/PlutusDataJsonConverterTest.java
@@ -1,0 +1,53 @@
+package com.bloxbean.cardano.client.transaction.spec.serializers;
+
+import com.bloxbean.cardano.client.transaction.spec.PlutusData;
+import com.bloxbean.cardano.client.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlutusDataJsonConverterTest {
+
+    @Test
+    void serDeser1() throws Exception {
+        String datumHex = "d8799fd8799f4040ffd8799f581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c23545484f534b59ff1b000000e449901987181eff";
+        PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString(datumHex));
+
+        String json = PlutusDataJsonConverter.toJson(plutusData);
+        System.out.println(json);
+
+        PlutusData dePlutusData = PlutusDataJsonConverter.toPlutusData(json);
+        assertThat(dePlutusData).isEqualTo(plutusData);
+    }
+
+    @Test
+    void serDeser2() throws Exception {
+        String datumHex = "d8799fd8799fd8799fd8799f581c33163652e747a54b16680371b7b6812d355a1dd1087239bfaf57d2f3ffd8799fd8799fd8799f581c1ee198ba32b1d7abe754cc38075471d7a322b72b624e63e56109fe8effffffff581ca0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c23545484f534b5940401a29d8e284d87a801a00286f90ffff";
+        PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString(datumHex));
+
+        String json = PlutusDataJsonConverter.toJson(plutusData);
+        System.out.println(json);
+
+        PlutusData dePlutusData = PlutusDataJsonConverter.toPlutusData(json);
+        System.out.println(PlutusDataJsonConverter.toJson(dePlutusData));
+
+        String serHex = dePlutusData.serializeToHex();
+        assertThat(serHex).isEqualTo(datumHex);
+
+    }
+
+    @Test
+    void serDeser_with_map() throws Exception {
+        String datumHex = "d8799f581cdf078188aedb870e1161440a90c6c29bc6e9732054a1aa59bd440c2a9fd8799fd8799fd8799f581c1ed92de403227c0fad57b35c8337557234a3863d54294a834b6e95a3ffd8799fd8799fd8799f581cf4627cc3236d1ec8e948ea05b8c8381a2e10ec9a2df4dd2bf6bf084affffffffa140d8799f00a1401a019b3970ffffd8799fd8799fd8799f581c70e60f3b5ea7153e0acc7a803e4401d44b8ed1bae1c7baaad1a62a72ffd8799fd8799fd8799f581c1e78aae7c90cc36d624f7b3bb6d86b52696dc84e490f343eba89005fffffffffa140d8799f00a1401a00a47d60ffffd8799fd8799fd8799f581cdf078188aedb870e1161440a90c6c29bc6e9732054a1aa59bd440c2affd8799fd8799fd8799f581c581d95b6e83eb838560b2d71ee9af38ee347bfe3b577791391525d7effffffffa140d8799f00a1401a1de0c5f0ffffffff";
+        PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString(datumHex));
+
+        String json = PlutusDataJsonConverter.toJson(plutusData);
+        System.out.println(json);
+
+        PlutusData dePlutusData = PlutusDataJsonConverter.toPlutusData(json);
+        System.out.println(PlutusDataJsonConverter.toJson(dePlutusData));
+
+        String serHex = dePlutusData.serializeToHex();
+        assertThat(serHex).isEqualTo(datumHex);
+    }
+}


### PR DESCRIPTION
Added support for
  - PlutusData to Json
  - Json to PlutusData

- Added custom serializers to support json conversion (Detail schema based)

Refer to below links for format details
https://github.com/input-output-hk/cardano-node/blob/master/cardano-api/src/Cardano/Api/ScriptData.hs#L254
https://github.com/Emurgo/cardano-serialization-lib/blob/2b775e8b92331885d4caf2f4a579ba86c69eea61/rust/src/plutus.rs#L1009

Usage:

```
//To json
String json = PlutusDataJsonConverter.toJson(plutusData);

//From json
PlutusData dePlutusData = PlutusDataJsonConverter.toPlutusData(json)
```

