### PR TITLE
[#181] Fix - Changed the generation logic for empty redeemers and non…

### DIFF
--- a/core/src/test/java/com/bloxbean/cardano/client/transaction/util/ScriptDataHashGeneratorTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/client/transaction/util/ScriptDataHashGeneratorTest.java
@@ -53,4 +53,26 @@ class ScriptDataHashGeneratorTest {
 
         assertThat(hash).isEqualTo("57240d358f8ab6128c4a66340271e4fec39b4971232add308f01a5809313adcf");
     }
+
+    @Test
+    void generate_emptyRedemeers_nonEmptyDatum() throws Exception {
+        PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString("d8799f4114d8799fd8799fd8799fd8799f581c3050f6f4d5981748bc3a2b84d8165b20c100a75057b6593befd9323cffd8799fd8799fd8799f581cc5cdc99429b4ce659f2542994c48b6c801f0b8e21ca7fb586326a545ffffffffd87a80ffd87a80ff1a002625a0d8799fd879801a0025a559d8799f01ffffff"));
+
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(), Arrays.asList(plutusData),
+                CostModelUtil.getLanguageViewsEncoding(CostModelUtil.PlutusV2CostModel));
+
+        byte[] expected = new byte[]{71, -22, -92, 74, -39, 124, 55, -108, 120, -127, -125, 119, 41, -77, 48, -72, 121, 0, -10, -77, -29, 103, -99, -9, -111, -118, 11, -126, -52, -29, -81, 105};
+        assertThat(scriptDataHash).isEqualTo(expected);
+    }
+
+    @Test
+    void generate_nullRedemeers_nonEmptyDatum() throws Exception {
+        PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString("d8799f4114d8799fd8799fd8799fd8799f581c3050f6f4d5981748bc3a2b84d8165b20c100a75057b6593befd9323cffd8799fd8799fd8799f581cc5cdc99429b4ce659f2542994c48b6c801f0b8e21ca7fb586326a545ffffffffd87a80ffd87a80ff1a002625a0d8799fd879801a0025a559d8799f01ffffff"));
+
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(null, Arrays.asList(plutusData),
+                CostModelUtil.getLanguageViewsEncoding(CostModelUtil.PlutusV2CostModel));
+
+        byte[] expected = new byte[]{71, -22, -92, 74, -39, 124, 55, -108, 120, -127, -125, 119, 41, -77, 48, -72, 121, 0, -10, -77, -29, 103, -99, -9, -111, -118, 11, -126, -52, -29, -81, 105};
+        assertThat(scriptDataHash).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
- Updated script datahash generation logic for empty redeemers and non empty datum

```
; Finally, note that in the case that a transaction includes datums but does not
; include any redeemers, the script data format becomes (in hex):
; [ 80 | datums | A0 ]
; corresponding to a CBOR empty list and an empty map.
```

https://github.com/input-output-hk/cardano-ledger/blob/8b6f8e1a75034ca66fd66a39d437252eec927d71/eras/babbage/test-suite/cddl-files/babbage.cddl#L134