### PR TITLE
[#205] Deprecated createFromUtxos(List<Utxo>) method and updated tests

### DIFF
--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/InputBuilders.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/InputBuilders.java
@@ -231,10 +231,15 @@ public class InputBuilders {
 
     /**
      * Function to create inputs from list of <code>{@link Utxo}</code>
+     * @deprecated
+     * This method should not be used as it doesn't calculate change output. Additional utxos are required to balance the
+     * outputs.
+     * <p>Use any of the other createFromUtxos method with a changeAddress</p>
      *
      * @param utxos list of <code>{@link Utxo}</code>
      * @return <code>{@link TxInputBuilder}</code> function
      */
+    @Deprecated
     public static TxInputBuilder createFromUtxos(List<Utxo> utxos) {
         return (context, outputs) -> {
             List<TransactionInput> inputs = new ArrayList<>();
@@ -252,10 +257,15 @@ public class InputBuilders {
 
     /**
      * Function to create inputs from list of <code>{@link Utxo}</code>
+     * @deprecated
+     * This method should not be used as it doesn't calculate change output. Additional utxos are required to balance the
+     * outputs.
+     * <p>Use any of the other createFromUtxos method with a changeAddress</p>
      *
      * @param supplier Supplier function to provide <code>Utxo</code> list
      * @return <code>{@link TxInputBuilder}</code> function
      */
+    @Deprecated
     public static TxInputBuilder createFromUtxos(Supplier<List<Utxo>> supplier) {
         return (context, outputs) -> {
             List<TransactionInput> inputs = new ArrayList<>();

--- a/function/src/test/java/com/bloxbean/cardano/client/function/helper/InputBuildersTest.java
+++ b/function/src/test/java/com/bloxbean/cardano/client/function/helper/InputBuildersTest.java
@@ -492,6 +492,7 @@ class InputBuildersTest extends BaseTest {
         );
     }
 
+    //TODO -- Remove when the deprecated method is removed
     @Test
     void createFromUtxos_whenNoChangeAddress() {
         List<Utxo> utxos = List.of(
@@ -532,6 +533,7 @@ class InputBuildersTest extends BaseTest {
         assertThat(inputResult.getChanges()).hasSize(0);
     }
 
+    //TODO -- Remove when the deprecated method is removed
     @Test
     void createFromUtxos_whenUtxosFromSupplier() {
         Utxo utxo = Utxo.builder()

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/function/ContractTxBuilderContextITTest.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/function/ContractTxBuilderContextITTest.java
@@ -296,7 +296,7 @@ public class ContractTxBuilderContextITTest extends BaseITTest {
 
         TxBuilder builder = customGuessContractOutput.outputBuilder()
                 .and(sumContractOutput.outputBuilder())
-                .buildInputs(createFromUtxos(List.of(customGuessUtxo, sumScriptUtxo)))
+                .buildInputs(createFromUtxos(List.of(customGuessUtxo, sumScriptUtxo), senderAddress))
                 .andThen(collateralFrom(collateral, collateralIndex))
                 .andThen((context, t) -> {
                     try {

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/function/ContractV2TxBuilderContextITTest.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/function/ContractV2TxBuilderContextITTest.java
@@ -138,7 +138,7 @@ public class ContractV2TxBuilderContextITTest extends BaseITTest {
                 .steps(BigInteger.valueOf(0)).build();
 
         TxBuilder txBuilder = output.outputBuilder()
-                .buildInputs(createFromUtxos(Arrays.asList(scriptUtxo)))
+                .buildInputs(createFromUtxos(Arrays.asList(scriptUtxo), senderAddress))
                 .andThen(collateralFrom(collateralUtxo.getTxHash(), collateralUtxo.getOutputIndex()))
                 .andThen(scriptCallContext(plutusScript, scriptUtxo, null, redeemerData, RedeemerTag.Spend, exUnits))
                 .andThen((context, txn) -> { //Evaluate ExUnits
@@ -347,7 +347,7 @@ public class ContractV2TxBuilderContextITTest extends BaseITTest {
                 .steps(BigInteger.valueOf(0)).build();
 
         TxBuilder txBuilder = createFromOutput(output)
-                .buildInputs(createFromUtxos(Arrays.asList(inputUtxo)))
+                .buildInputs(createFromUtxos(Arrays.asList(inputUtxo), senderAddress))
                 .andThen(collateralFrom(collateralUtxo.getTxHash(), collateralUtxo.getOutputIndex()))
                 .andThen(referenceInputsFrom(List.of(refScriptInput)))
                 .andThen(scriptCallContext(plutusScript, inputUtxo, null, redeemerData, RedeemerTag.Spend, exUnits))
@@ -569,7 +569,7 @@ public class ContractV2TxBuilderContextITTest extends BaseITTest {
                 .steps(BigInteger.valueOf(0)).build();
 
         TxBuilder txBuilder = createFromOutput(output)
-                .buildInputs(createFromUtxos(Arrays.asList(inputUtxo)))
+                .buildInputs(createFromUtxos(Arrays.asList(inputUtxo), senderAddress))
                 .andThen(collateralOutputs(senderAddress, List.of(collateralUtxo)))
                 .andThen((context, txn) -> {
                     txn.getBody().getReferenceInputs().add(refScriptInput);


### PR DESCRIPTION
- Deprecated following methods
 ```
createFromUtxos(List<Utxo> utxos)
```

```
createFromUtxos(Supplier<List<Utxo>> supplier)
```