### PR TITLE
0.5.0 alpha fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     api project(':core')
     api project(':function')
     api project(':cip')
+    api project(':quicktx')
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.bloxbean.cardano
 artifactId = cardano-client-lib
-version = 0.5.0-alpha.2-SNAPSHOT
+version = 0.5.0-alpha.2

--- a/plutus/src/main/java/com/bloxbean/cardano/client/plutus/util/PlutusUtil.java
+++ b/plutus/src/main/java/com/bloxbean/cardano/client/plutus/util/PlutusUtil.java
@@ -1,0 +1,33 @@
+package com.bloxbean.cardano.client.plutus.util;
+
+import co.nstant.in.cbor.CborException;
+import co.nstant.in.cbor.model.ByteString;
+import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
+import com.bloxbean.cardano.client.exception.CborRuntimeException;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
+import com.bloxbean.cardano.client.util.HexUtil;
+
+/**
+ * Utility class for Plutus scripts
+ */
+public class PlutusUtil {
+
+    /**
+     * Get PlutusV2Script from compiled code. It double encodes the compiled code and returns a PlutusV2Script instance.
+     * This method is useful when compiled code is from smart contract language like Aiken (https://aiken-lang.org/)
+     *
+     * @param compiledCode
+     * @return PlutusV2Script
+     */
+    public static PlutusV2Script getPlutusV2Script(String compiledCode) {
+        ByteString bs = new ByteString(HexUtil.decodeHexString(compiledCode));
+        try {
+            String cborHex = HexUtil.encodeHexString(CborSerializationUtil.serialize(bs));
+            return PlutusV2Script.builder()
+                    .cborHex(cborHex)
+                    .build();
+        } catch (CborException e) {
+            throw new CborRuntimeException(e);
+        }
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
@@ -105,7 +105,7 @@ public class QuickTxBuilder {
     /**
      * TxContext is created for group of transactions which are to be submitted as a single transaction.
      */
-    class TxContext {
+    public class TxContext {
         private AbstractTx[] txList;
         private String feePayer;
         private String collateralPayer;


### PR DESCRIPTION
Some quick fixes:
1. Change scope of TxContext to public
2. Utility class to double cbor encode. It is required for aiken compiled code.