### PR TITLE
feat(address)!: #258 Add getPaymentCredential and getDelegationCreden…

### DIFF
--- a/address/src/main/java/com/bloxbean/cardano/client/address/Address.java
+++ b/address/src/main/java/com/bloxbean/cardano/client/address/Address.java
@@ -114,15 +114,31 @@ public class Address {
      * Get StakeKeyHash or ScriptHash from delegation part of a Shelley {@link Address}
      * @return StakeKeyHash or ScriptHash. For Pointer address, delegationPointerHash
      */
-    public Optional<byte[]> getDelegationCredential() {
-        return AddressProvider.getDelegationCredential(this);
+    public Optional<byte[]> getDelegationCredentialHash() {
+        return AddressProvider.getDelegationCredentialHash(this);
     }
 
     /**
      * Get PaymentCredential from {@link Address}
      * @return payment key hash or script hash
      */
-    public Optional<byte[]> getPaymentCredential() {
+    public Optional<byte[]> getPaymentCredentialHash() {
+        return AddressProvider.getPaymentCredentialHash(this);
+    }
+
+    /**
+     * Get delegation credential from {@link Address}
+     * @return Credential if address has a delegation path, otherwise empty
+     */
+    public Optional<Credential> getDelegationCredential() {
+        return AddressProvider.getDelegationCredential(this);
+    }
+
+    /**
+     * Get payment credential from {@link Address}
+     * @return Credential if address has a payment path, otherwise empty
+     */
+    public Optional<Credential> getPaymentCredential() {
         return AddressProvider.getPaymentCredential(this);
     }
 

--- a/core-api/src/main/java/com/bloxbean/cardano/client/api/util/UtxoUtil.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/client/api/util/UtxoUtil.java
@@ -91,7 +91,7 @@ public class UtxoUtil {
                 Address address = new Address(utxo.getAddress());
                 //If PubKeyHash in Payment part
                 if (AddressProvider.isPubKeyHashInPaymentPart(address)) {
-                    AddressProvider.getPaymentCredential(address)
+                    AddressProvider.getPaymentCredentialHash(address)
                             .ifPresent(bytes -> pubKeyHashes.add(HexUtil.encodeHexString(bytes)));
                 }
             } catch (Exception e) {

--- a/core/src/main/java/com/bloxbean/cardano/client/util/UtxoUtil.java
+++ b/core/src/main/java/com/bloxbean/cardano/client/util/UtxoUtil.java
@@ -93,7 +93,7 @@ public class UtxoUtil {
                 Address address = new Address(utxo.getAddress());
                 //If PubKeyHash in Payment part
                 if (AddressProvider.isPubKeyHashInPaymentPart(address)) {
-                    AddressProvider.getPaymentCredential(address)
+                    AddressProvider.getPaymentCredentialHash(address)
                             .ifPresent(bytes -> pubKeyHashes.add(HexUtil.encodeHexString(bytes)));
                 }
             } catch (Exception e) {

--- a/core/src/test/java/com/bloxbean/cardano/client/address/AddressProviderTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/client/address/AddressProviderTest.java
@@ -682,7 +682,7 @@ class AddressProviderTest {
             String entAddress = "addr_test1vzxazkxxxapq9k76aae6reskfjuzfljy4lf209kduuxjfec7msk6n";
             Address address = new Address(entAddress);
 
-            Optional<byte[]> delegationHash = AddressProvider.getDelegationCredential(address);
+            Optional<byte[]> delegationHash = AddressProvider.getDelegationCredentialHash(address);
             assertThat(delegationHash).isEmpty();
         }
 
@@ -691,7 +691,7 @@ class AddressProviderTest {
             String entAddress = "addr1vxm9rssxy335nxtph8x4jndrnxj7eyg0e66uv0u7k4dzyjsg6fr38";
             Address address = new Address(entAddress);
 
-            Optional<byte[]> delegationHash = AddressProvider.getDelegationCredential(address);
+            Optional<byte[]> delegationHash = AddressProvider.getDelegationCredentialHash(address);
             assertThat(delegationHash).isEmpty();
         }
 
@@ -700,7 +700,7 @@ class AddressProviderTest {
             String baseAddress = "addr_test1qra2kf2lzdt05j7793wz9nxgf5ywf79puqu50djvp0q804g4ee7lj7wgt0urvw6n57eklscwju3p02wu2vmdqd84hgdsc8lqcp";
             Address address = new Address(baseAddress);
 
-            byte[] delegationHash = AddressProvider.getDelegationCredential(address).get();
+            byte[] delegationHash = AddressProvider.getDelegationCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("15ce7df979c85bf8363b53a7b36fc30e972217a9dc5336d034f5ba1b");
         }
 
@@ -709,7 +709,7 @@ class AddressProviderTest {
             String baseAddress = "addr1q8hxcjnvwd2hf397kee6ptfu889r248cn0k5qzvyz78ywa5tdzj0j8al6970zz8urxtdsvwejxn89aqkp4fk6y2jt2wswpm6fz";
             Address address = new Address(baseAddress);
 
-            byte[] delegationHash = AddressProvider.getDelegationCredential(address).get();
+            byte[] delegationHash = AddressProvider.getDelegationCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("8b68a4f91fbfd17cf108fc1996d831d991a672f4160d536d11525a9d");
         }
 
@@ -718,7 +718,7 @@ class AddressProviderTest {
             String rewardAddress = "stake_test1up2gmk3f9s6l50ehm26s9kufd9y2gkektu2xy3uawvzk5ug0ze6xv";
             Address address = new Address(rewardAddress);
 
-            byte[] delegationHash = AddressProvider.getDelegationCredential(address).get();
+            byte[] delegationHash = AddressProvider.getDelegationCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("548dda292c35fa3f37dab502db896948a45b365f1462479d73056a71");
         }
 
@@ -727,7 +727,7 @@ class AddressProviderTest {
             String rewardAddress = "stake1u857f9s2s556nfedulykja499mvredrnj6qupp2f2mpumsgkw23zc";
             Address address = new Address(rewardAddress);
 
-            byte[] delegationHash = AddressProvider.getDelegationCredential(address).get();
+            byte[] delegationHash = AddressProvider.getDelegationCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("e9e4960a8529a9a72de7c96976a52ed83cb4739681c0854956c3cdc1");
         }
 
@@ -736,7 +736,7 @@ class AddressProviderTest {
             String pointerAddress = "addr_test1grl9uzketqym52kqyjrxplslh3t5zlm65vmlvgzmnycg7m48kw8hvqqqt5mz03";
             Address address = new Address(pointerAddress);
 
-            byte[] delegationHash = AddressProvider.getDelegationCredential(address).get();
+            byte[] delegationHash = AddressProvider.getDelegationCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("a7b38f760000");
         }
 
@@ -745,7 +745,7 @@ class AddressProviderTest {
             String pointerAddress = "addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant";
             Address address = new Address(pointerAddress);
 
-            byte[] delegationHash = AddressProvider.getDelegationCredential(address).get();
+            byte[] delegationHash = AddressProvider.getDelegationCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("8dcb2095eabb49cfe8c63d");
         }
 
@@ -755,7 +755,7 @@ class AddressProviderTest {
             String baseAddress = "addr1q9wf2pasguad0uy8rzxly6hxc4yk4vhlj4ufv7xg973fvu9l7f23amv6dqy99nrlezg38y3797tgel0udlxfsjp26ensg63c8u";
             Address address = new Address(baseAddress);
 
-            byte[] paymentKeyHash = AddressProvider.getPaymentCredential(address).get();
+            byte[] paymentKeyHash = AddressProvider.getPaymentCredentialHash(address).get();
             System.out.println(HexUtil.encodeHexString(paymentKeyHash));
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("5c9507b0473ad7f087188df26ae6c5496ab2ff95789678c82fa29670");
         }
@@ -765,7 +765,7 @@ class AddressProviderTest {
             String baseAddress = "addr_test1qz96la9s5xa0ad67vvprdrl8dw79gs7nqf58czr409xynscttpxxc9w2gmdewjwzlv8lx255q7z3mqymv0umkygycskqyf227e";
             Address address = new Address(baseAddress);
 
-            byte[] paymentKeyHash = AddressProvider.getPaymentCredential(address).get();
+            byte[] paymentKeyHash = AddressProvider.getPaymentCredentialHash(address).get();
             System.out.println(HexUtil.encodeHexString(paymentKeyHash));
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("8baff4b0a1bafeb75e6302368fe76bbc5443d302687c0875794c49c3");
         }
@@ -775,7 +775,7 @@ class AddressProviderTest {
             String baseAddress = "addr_test1wzdtu0djc76qyqak9cj239udezj2544nyk3ksmfqvaksv7c9xanpg";
             Address address = new Address(baseAddress);
 
-            byte[] paymentKeyHash = AddressProvider.getPaymentCredential(address).get();
+            byte[] paymentKeyHash = AddressProvider.getPaymentCredentialHash(address).get();
             System.out.println(HexUtil.encodeHexString(paymentKeyHash));
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("9abe3db2c7b40203b62e24a8978dc8a4aa56b325a3686d20676d067b");
         }
@@ -785,7 +785,7 @@ class AddressProviderTest {
             String baseAddress = "addr1vypj5jf999edw02khvy8e63ec9w0wk39y2pels36ntn3gxsqlvq6t";
             Address address = new Address(baseAddress);
 
-            byte[] paymentKeyHash = AddressProvider.getPaymentCredential(address).get();
+            byte[] paymentKeyHash = AddressProvider.getPaymentCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("032a49252972d73d56bb087cea39c15cf75a2522839fc23a9ae7141a");
         }
 
@@ -794,7 +794,7 @@ class AddressProviderTest {
             String baseAddress = "stake1uytvm7mh3xvpqgef9fh6f5llwktk0urg7q23cs5h20x9qesrphuw7";
             Address address = new Address(baseAddress);
 
-            Optional<byte[]> paymentKeyHash = AddressProvider.getPaymentCredential(address);
+            Optional<byte[]> paymentKeyHash = AddressProvider.getPaymentCredentialHash(address);
             assertThat(paymentKeyHash).isEmpty();
         }
 
@@ -803,7 +803,7 @@ class AddressProviderTest {
             String pointerAddress = "addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant";
             Address address = new Address(pointerAddress);
 
-            byte[] paymentKeyHash = AddressProvider.getPaymentCredential(address).get();
+            byte[] paymentKeyHash = AddressProvider.getPaymentCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("736dfcaa011821cb7d71ad7d546a750c3d6d059a13b35d56bc36d1e3");
         }
 
@@ -812,10 +812,245 @@ class AddressProviderTest {
             String pointerAddress = "addr_test1grl9uzketqym52kqyjrxplslh3t5zlm65vmlvgzmnycg7m48kw8hvqqqt5mz03";
             Address address = new Address(pointerAddress);
 
-            byte[] paymentKeyHash = AddressProvider.getPaymentCredential(address).get();
+            byte[] paymentKeyHash = AddressProvider.getPaymentCredentialHash(address).get();
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("fe5e0ad95809ba2ac0248660fe1fbc57417f7aa337f6205b99308f6e");
         }
     }
+
+    @Nested
+    class GetDelegationAndPaymentCredentialTest {
+        @Test
+        void getStakeCredential_fromTestnetEntAddress_returnsNull() {
+            String entAddress = "addr_test1vzxazkxxxapq9k76aae6reskfjuzfljy4lf209kduuxjfec7msk6n";
+            Address address = new Address(entAddress);
+
+            Optional<Credential> delegationCredential = AddressProvider.getDelegationCredential(address);
+            assertThat(delegationCredential).isEmpty();
+        }
+
+        @Test
+        void getStakeCredential_fromMainetEntAddress_returnsNull() {
+            String entAddress = "addr1vxm9rssxy335nxtph8x4jndrnxj7eyg0e66uv0u7k4dzyjsg6fr38";
+            Address address = new Address(entAddress);
+
+            Optional<Credential> credential = AddressProvider.getDelegationCredential(address);
+            assertThat(credential).isEmpty();
+        }
+
+        @Test
+        void getStakeCredential_fromBaseAddress_testnet() {
+            String baseAddress = "addr_test1qra2kf2lzdt05j7793wz9nxgf5ywf79puqu50djvp0q804g4ee7lj7wgt0urvw6n57eklscwju3p02wu2vmdqd84hgdsc8lqcp";
+            Address address = new Address(baseAddress);
+
+            Credential credential = AddressProvider.getDelegationCredential(address).get();
+            assertThat(HexUtil.encodeHexString(credential.getBytes())).isEqualTo("15ce7df979c85bf8363b53a7b36fc30e972217a9dc5336d034f5ba1b");
+        }
+
+        @Test
+        void getStakeCredential_fromBaseAddress_mainnet() {
+            String baseAddress = "addr1q8hxcjnvwd2hf397kee6ptfu889r248cn0k5qzvyz78ywa5tdzj0j8al6970zz8urxtdsvwejxn89aqkp4fk6y2jt2wswpm6fz";
+            Address address = new Address(baseAddress);
+
+            Credential delegCredential = AddressProvider.getDelegationCredential(address).get();
+            assertThat(HexUtil.encodeHexString(delegCredential.getBytes())).isEqualTo("8b68a4f91fbfd17cf108fc1996d831d991a672f4160d536d11525a9d");
+        }
+
+        @Test
+        void getStakeCredential_fromRewardAddress_testnet() {
+            String rewardAddress = "stake_test1up2gmk3f9s6l50ehm26s9kufd9y2gkektu2xy3uawvzk5ug0ze6xv";
+            Address address = new Address(rewardAddress);
+
+            Credential delegCred = AddressProvider.getDelegationCredential(address).get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("548dda292c35fa3f37dab502db896948a45b365f1462479d73056a71");
+        }
+
+        @Test
+        void getStakeCredential_fromRewardAddress_mainnet() {
+            String rewardAddress = "stake1u857f9s2s556nfedulykja499mvredrnj6qupp2f2mpumsgkw23zc";
+            Address address = new Address(rewardAddress);
+
+            Credential delegCred = AddressProvider.getDelegationCredential(address).get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("e9e4960a8529a9a72de7c96976a52ed83cb4739681c0854956c3cdc1");
+        }
+
+        @Test
+        void getStakeCredential_fromPointerAddress_testnet() {
+            String pointerAddress = "addr_test1grl9uzketqym52kqyjrxplslh3t5zlm65vmlvgzmnycg7m48kw8hvqqqt5mz03";
+            Address address = new Address(pointerAddress);
+
+            Credential delegCred = AddressProvider.getDelegationCredential(address).get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("a7b38f760000");
+        }
+
+        @Test
+        void getStakeCredential_fromPointerAddress_mainnet() {
+            String pointerAddress = "addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant";
+            Address address = new Address(pointerAddress);
+
+            Credential delegCred = AddressProvider.getDelegationCredential(address).get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("8dcb2095eabb49cfe8c63d");
+        }
+
+
+        @Test
+        void getPaymentCredential_fromBaseAddress_mainnet() {
+            String baseAddress = "addr1q9wf2pasguad0uy8rzxly6hxc4yk4vhlj4ufv7xg973fvu9l7f23amv6dqy99nrlezg38y3797tgel0udlxfsjp26ensg63c8u";
+            Address address = new Address(baseAddress);
+
+            Credential paymentCred = AddressProvider.getPaymentCredential(address).get();
+            System.out.println(HexUtil.encodeHexString(paymentCred.getBytes()));
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("5c9507b0473ad7f087188df26ae6c5496ab2ff95789678c82fa29670");
+        }
+
+        @Test
+        void getPaymentCredential_fromBaseAddress_testnet() {
+            String baseAddress = "addr_test1qz96la9s5xa0ad67vvprdrl8dw79gs7nqf58czr409xynscttpxxc9w2gmdewjwzlv8lx255q7z3mqymv0umkygycskqyf227e";
+            Address address = new Address(baseAddress);
+
+            Credential paymentCred = AddressProvider.getPaymentCredential(address).get();
+            System.out.println(HexUtil.encodeHexString(paymentCred.getBytes()));
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("8baff4b0a1bafeb75e6302368fe76bbc5443d302687c0875794c49c3");
+        }
+
+        @Test
+        void getPaymentCredential_fromEntAddress_testnet() {
+            String baseAddress = "addr_test1wzdtu0djc76qyqak9cj239udezj2544nyk3ksmfqvaksv7c9xanpg";
+            Address address = new Address(baseAddress);
+
+            Credential paymentCred = AddressProvider.getPaymentCredential(address).get();
+            System.out.println(HexUtil.encodeHexString(paymentCred.getBytes()));
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("9abe3db2c7b40203b62e24a8978dc8a4aa56b325a3686d20676d067b");
+        }
+
+        @Test
+        void getPaymentCredential_fromEntAddress_mainnet() {
+            String baseAddress = "addr1vypj5jf999edw02khvy8e63ec9w0wk39y2pels36ntn3gxsqlvq6t";
+            Address address = new Address(baseAddress);
+
+            Credential paymentCred = AddressProvider.getPaymentCredential(address).get();
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("032a49252972d73d56bb087cea39c15cf75a2522839fc23a9ae7141a");
+        }
+
+        @Test
+        void getPaymentCredential_fromStakeAddress_mainnet() {
+            String baseAddress = "stake1uytvm7mh3xvpqgef9fh6f5llwktk0urg7q23cs5h20x9qesrphuw7";
+            Address address = new Address(baseAddress);
+
+            Optional<Credential> paymentCred = AddressProvider.getPaymentCredential(address);
+            assertThat(paymentCred).isEmpty();
+        }
+
+        @Test
+        void getPaymentCredential_fromPointerAddress_mainnet() {
+            String pointerAddress = "addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant";
+            Address address = new Address(pointerAddress);
+
+            Credential paymentCred = AddressProvider.getPaymentCredential(address).get();
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("736dfcaa011821cb7d71ad7d546a750c3d6d059a13b35d56bc36d1e3");
+        }
+
+        @Test
+        void getPaymentCredential_fromPointerAddress_testnet() {
+            String pointerAddress = "addr_test1grl9uzketqym52kqyjrxplslh3t5zlm65vmlvgzmnycg7m48kw8hvqqqt5mz03";
+            Address address = new Address(pointerAddress);
+
+            Credential paymentCred = AddressProvider.getPaymentCredential(address).get();
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("fe5e0ad95809ba2ac0248660fe1fbc57417f7aa337f6205b99308f6e");
+        }
+
+        @Test
+        void getPaymentDelegationCred_fromBaseAddress() {
+            Account account = new Account();
+            Address address = new Address(account.baseAddress());
+
+            Optional<Credential> paymentCred = address.getPaymentCredential();
+            Optional<Credential> delegationCred = address.getDelegationCredential();
+
+            assertThat(paymentCred).isPresent();
+            assertThat(paymentCred.get().getType()).isEqualTo(CredentialType.Key);
+            assertThat(delegationCred).isPresent();
+            assertThat(delegationCred.get().getType()).isEqualTo(CredentialType.Key);
+        }
+
+        @Test
+        void getPaymentDelegationCred_fromRewardAddress_hasEmptyPaymentCred() {
+            Account account = new Account();
+            Address address = new Address(account.stakeAddress());
+
+            Optional<Credential> paymentCred = address.getPaymentCredential();
+            Optional<Credential> delegationCred = address.getDelegationCredential();
+
+            assertThat(paymentCred).isEmpty();
+            assertThat(delegationCred).isPresent();
+            assertThat(delegationCred.get().getType()).isEqualTo(CredentialType.Key);
+        }
+
+        @Test
+        void getPaymentDelegationCred_fromRewardAddressWithScriptInDelegationPart_hasEmptyPaymentCred() {
+            PlutusV2Script script = PlutusV2Script.builder()
+                    .type("PlutusScriptV2")
+                    .cborHex("49480100002221200101")
+                    .build();
+
+            Address rewardAddress = AddressProvider.getRewardAddress(script, Networks.mainnet());
+
+            Optional<Credential> paymentCred = rewardAddress.getPaymentCredential();
+            Optional<Credential> delegationCred = rewardAddress.getDelegationCredential();
+
+            assertThat(paymentCred).isEmpty();
+            assertThat(delegationCred).isPresent();
+            assertThat(delegationCred.get().getType()).isEqualTo(CredentialType.Script);
+        }
+
+        @Test
+        void getPaymentDelegationCred_withScriptInPaymentAndDelegationPart() {
+            PlutusV2Script script = PlutusV2Script.builder()
+                    .type("PlutusScriptV2")
+                    .cborHex("49480100002221200101")
+                    .build();
+
+            Address rewardAddress = AddressProvider.getBaseAddress(script, script, Networks.mainnet());
+
+            Optional<Credential> paymentCred = rewardAddress.getPaymentCredential();
+            Optional<Credential> delegationCred = rewardAddress.getDelegationCredential();
+
+            assertThat(paymentCred).isPresent();
+            assertThat(paymentCred.get().getType()).isEqualTo(CredentialType.Script);
+            assertThat(delegationCred).isPresent();
+            assertThat(delegationCred.get().getType()).isEqualTo(CredentialType.Script);
+        }
+
+        @Test
+        void getPaymentDelegationCred_fromEntAddressWithScriptInDelegationPart_hasEmptyDelegationCred() {
+            PlutusV2Script script = PlutusV2Script.builder()
+                    .type("PlutusScriptV2")
+                    .cborHex("49480100002221200101")
+                    .build();
+
+            Address entAddress = AddressProvider.getEntAddress(script, Networks.mainnet());
+
+            Optional<Credential> paymentCred = entAddress.getPaymentCredential();
+            Optional<Credential> delegationCred = entAddress.getDelegationCredential();
+
+            assertThat(paymentCred).isPresent();
+            assertThat(paymentCred.get().getType()).isEqualTo(CredentialType.Script);
+            assertThat(delegationCred).isEmpty();
+        }
+
+        @Test
+        void getPaymentDelegationCred_fromEntAddress_hasEmptyDelegationCred() {
+            Account account = new Account();
+            Address entAddress = new Address(account.enterpriseAddress());
+
+            Optional<Credential> paymentCred = entAddress.getPaymentCredential();
+            Optional<Credential> delegationCred = entAddress.getDelegationCredential();
+
+            assertThat(paymentCred).isPresent();
+            assertThat(paymentCred.get().getType()).isEqualTo(CredentialType.Key);
+            assertThat(delegationCred).isEmpty();
+        }
+    }
+
 
     @Nested
     class IsPubKeyHashOrScriptHashInPaymentPartTest {
@@ -1099,8 +1334,8 @@ class AddressProviderTest {
             Address baseAddress = AddressProvider.getBaseAddress(paymentKeyPair.getPublicKey(), stakeKeyPair.getPublicKey(), Networks.mainnet());
             String expectedBaseAddress = baseAddress.getAddress();
 
-            Credential paymentCredential = Credential.fromKey(baseAddress.getPaymentCredential().get());
-            Credential stakeCredential = Credential.fromKey(baseAddress.getDelegationCredential().get());
+            Credential paymentCredential = baseAddress.getPaymentCredential().get();
+            Credential stakeCredential = baseAddress.getDelegationCredential().get();
 
             Address baseAddressFromCredentials = AddressProvider.getBaseAddress(paymentCredential, stakeCredential, Networks.mainnet());
 
@@ -1119,8 +1354,8 @@ class AddressProviderTest {
             Address baseAddress = AddressProvider.getBaseAddress(paymentPlutusScript, stakeKeyPair.getPublicKey(), Networks.mainnet());
             String expectedBaseAddress = baseAddress.getAddress();
 
-            Credential paymentCredential = Credential.fromScript(baseAddress.getPaymentCredential().get());
-            Credential stakeCredential = Credential.fromKey(baseAddress.getDelegationCredential().get());
+            Credential paymentCredential = baseAddress.getPaymentCredential().get();
+            Credential stakeCredential = baseAddress.getDelegationCredential().get();
 
             Address baseAddressFromCredentials = AddressProvider.getBaseAddress(paymentCredential, stakeCredential, Networks.mainnet());
 
@@ -1139,8 +1374,8 @@ class AddressProviderTest {
             Address baseAddress = AddressProvider.getBaseAddress(paymentKeyPair.getPublicKey(), stakePlutusScript, Networks.mainnet());
             String expectedBaseAddress = baseAddress.getAddress();
 
-            Credential paymentCredential = Credential.fromKey(baseAddress.getPaymentCredential().get());
-            Credential stakeCredential = Credential.fromScript(baseAddress.getDelegationCredential().get());
+            Credential paymentCredential = baseAddress.getPaymentCredential().get();
+            Credential stakeCredential = baseAddress.getDelegationCredential().get();
 
             Address baseAddressFromCredentials = AddressProvider.getBaseAddress(paymentCredential, stakeCredential, Networks.mainnet());
 
@@ -1162,8 +1397,8 @@ class AddressProviderTest {
             Address baseAddress = AddressProvider.getBaseAddress(paymentScript, stakeScript, Networks.mainnet());
             String expectedBaseAddress = baseAddress.getAddress();
 
-            Credential paymentCredential = Credential.fromScript(baseAddress.getPaymentCredential().get());
-            Credential stakeCredential = Credential.fromScript(baseAddress.getDelegationCredential().get());
+            Credential paymentCredential = baseAddress.getPaymentCredential().get();
+            Credential stakeCredential = baseAddress.getDelegationCredential().get();
 
             Address baseAddressFromCredentials = AddressProvider.getBaseAddress(paymentCredential, stakeCredential, Networks.mainnet());
 
@@ -1180,7 +1415,7 @@ class AddressProviderTest {
             Address pointerAddr = AddressProvider.getPointerAddress(paymentKeyPair.getPublicKey(), pointer, Networks.mainnet());
             String expectedPtrAddr = pointerAddr.getAddress();
 
-            Credential paymentCredential = Credential.fromKey(pointerAddr.getPaymentCredential().get());
+            Credential paymentCredential = pointerAddr.getPaymentCredential().get();
             Address pointerAddrFromCredentials = AddressProvider.getPointerAddress(paymentCredential, pointer, Networks.mainnet());
 
             assertThat(pointerAddrFromCredentials.getAddress()).isEqualTo(expectedPtrAddr);
@@ -1198,7 +1433,7 @@ class AddressProviderTest {
             Address pointerAddr = AddressProvider.getPointerAddress(paymentScript, pointer, Networks.mainnet());
             String expectedPtrAddr = pointerAddr.getAddress();
 
-            Credential paymentCredential = Credential.fromScript(pointerAddr.getPaymentCredential().get());
+            Credential paymentCredential = pointerAddr.getPaymentCredential().get();
             Address pointerAddrFromCredentials = AddressProvider.getPointerAddress(paymentCredential, pointer, Networks.mainnet());
 
             assertThat(pointerAddrFromCredentials.getAddress()).isEqualTo(expectedPtrAddr);
@@ -1212,7 +1447,7 @@ class AddressProviderTest {
             Address entAddr = AddressProvider.getEntAddress(paymentKeyPair.getPublicKey(), Networks.mainnet());
             String expectedEntAddr = entAddr.getAddress();
 
-            Credential paymentCredential = Credential.fromKey(entAddr.getPaymentCredential().get());
+            Credential paymentCredential = entAddr.getPaymentCredential().get();
             Address entAddrFromCredentials = AddressProvider.getEntAddress(paymentCredential, Networks.mainnet());
 
             assertThat(entAddrFromCredentials.getAddress()).isEqualTo(expectedEntAddr);
@@ -1228,7 +1463,7 @@ class AddressProviderTest {
             Address entAddr = AddressProvider.getEntAddress(paymentScript, Networks.mainnet());
             String expectedEntAddr = entAddr.getAddress();
 
-            Credential paymentCredential = Credential.fromScript(entAddr.getPaymentCredential().get());
+            Credential paymentCredential = entAddr.getPaymentCredential().get();
             Address entAddrFromCredentials = AddressProvider.getEntAddress(paymentCredential, Networks.mainnet());
 
             assertThat(entAddrFromCredentials.getAddress()).isEqualTo(expectedEntAddr);
@@ -1242,7 +1477,8 @@ class AddressProviderTest {
             Address rewardAddress = AddressProvider.getRewardAddress(paymentKeyPair.getPublicKey(), Networks.mainnet());
             String expectedRwdAddr = rewardAddress.getAddress();
 
-            Credential paymentCredential = Credential.fromKey(HexUtil.encodeHexString(rewardAddress.getDelegationCredential().get()));
+
+            Credential paymentCredential = rewardAddress.getDelegationCredential().get();
             Address pointerAddrFromCredentials = AddressProvider.getRewardAddress(paymentCredential, Networks.mainnet());
 
             assertThat(pointerAddrFromCredentials.getAddress()).isEqualTo(expectedRwdAddr);
@@ -1258,7 +1494,7 @@ class AddressProviderTest {
             Address rewardAddress = AddressProvider.getRewardAddress(paymentScript, Networks.mainnet());
             String expectedRwdAddr = rewardAddress.getAddress();
 
-            Credential paymentCredential = Credential.fromScript(HexUtil.encodeHexString(rewardAddress.getDelegationCredential().get()));
+            Credential paymentCredential = rewardAddress.getDelegationCredential().get();
             Address pointerAddrFromCredentials = AddressProvider.getRewardAddress(paymentCredential, Networks.mainnet());
 
             assertThat(pointerAddrFromCredentials.getAddress()).isEqualTo(expectedRwdAddr);

--- a/core/src/test/java/com/bloxbean/cardano/client/address/AddressTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/client/address/AddressTest.java
@@ -177,7 +177,7 @@ public class AddressTest {
             String entAddress = "addr_test1vzxazkxxxapq9k76aae6reskfjuzfljy4lf209kduuxjfec7msk6n";
             Address address = new Address(entAddress);
 
-            Optional<byte[]> delegationHash = address.getDelegationCredential();
+            Optional<byte[]> delegationHash = address.getDelegationCredentialHash();
             assertThat(delegationHash).isEmpty();
         }
 
@@ -186,7 +186,7 @@ public class AddressTest {
             String entAddress = "addr1vxm9rssxy335nxtph8x4jndrnxj7eyg0e66uv0u7k4dzyjsg6fr38";
             Address address = new Address(entAddress);
 
-            Optional<byte[]> delegationHash = address.getDelegationCredential();
+            Optional<byte[]> delegationHash = address.getDelegationCredentialHash();
             assertThat(delegationHash).isEmpty();
         }
 
@@ -195,7 +195,7 @@ public class AddressTest {
             String baseAddress = "addr_test1qra2kf2lzdt05j7793wz9nxgf5ywf79puqu50djvp0q804g4ee7lj7wgt0urvw6n57eklscwju3p02wu2vmdqd84hgdsc8lqcp";
             Address address = new Address(baseAddress);
 
-            byte[] delegationHash = address.getDelegationCredential().get();
+            byte[] delegationHash = address.getDelegationCredentialHash().get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("15ce7df979c85bf8363b53a7b36fc30e972217a9dc5336d034f5ba1b");
         }
 
@@ -204,7 +204,7 @@ public class AddressTest {
             String baseAddress = "addr1q8hxcjnvwd2hf397kee6ptfu889r248cn0k5qzvyz78ywa5tdzj0j8al6970zz8urxtdsvwejxn89aqkp4fk6y2jt2wswpm6fz";
             Address address = new Address(baseAddress);
 
-            byte[] delegationHash = address.getDelegationCredential().get();
+            byte[] delegationHash = address.getDelegationCredentialHash().get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("8b68a4f91fbfd17cf108fc1996d831d991a672f4160d536d11525a9d");
         }
 
@@ -213,7 +213,7 @@ public class AddressTest {
             String rewardAddress = "stake_test1up2gmk3f9s6l50ehm26s9kufd9y2gkektu2xy3uawvzk5ug0ze6xv";
             Address address = new Address(rewardAddress);
 
-            byte[] delegationHash = address.getDelegationCredential().get();
+            byte[] delegationHash = address.getDelegationCredentialHash().get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("548dda292c35fa3f37dab502db896948a45b365f1462479d73056a71");
         }
 
@@ -222,7 +222,7 @@ public class AddressTest {
             String rewardAddress = "stake1u857f9s2s556nfedulykja499mvredrnj6qupp2f2mpumsgkw23zc";
             Address address = new Address(rewardAddress);
 
-            byte[] delegationHash = address.getDelegationCredential().get();
+            byte[] delegationHash = address.getDelegationCredentialHash().get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("e9e4960a8529a9a72de7c96976a52ed83cb4739681c0854956c3cdc1");
         }
 
@@ -231,7 +231,7 @@ public class AddressTest {
             String pointerAddress = "addr_test1grl9uzketqym52kqyjrxplslh3t5zlm65vmlvgzmnycg7m48kw8hvqqqt5mz03";
             Address address = new Address(pointerAddress);
 
-            byte[] delegationHash = address.getDelegationCredential().get();
+            byte[] delegationHash = address.getDelegationCredentialHash().get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("a7b38f760000");
         }
 
@@ -240,7 +240,7 @@ public class AddressTest {
             String pointerAddress = "addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant";
             Address address = new Address(pointerAddress);
 
-            byte[] delegationHash = address.getDelegationCredential().get();
+            byte[] delegationHash = address.getDelegationCredentialHash().get();
             assertThat(HexUtil.encodeHexString(delegationHash)).isEqualTo("8dcb2095eabb49cfe8c63d");
         }
 
@@ -250,7 +250,7 @@ public class AddressTest {
             String baseAddress = "addr1q9wf2pasguad0uy8rzxly6hxc4yk4vhlj4ufv7xg973fvu9l7f23amv6dqy99nrlezg38y3797tgel0udlxfsjp26ensg63c8u";
             Address address = new Address(baseAddress);
 
-            byte[] paymentKeyHash = address.getPaymentCredential().get();
+            byte[] paymentKeyHash = address.getPaymentCredentialHash().get();
             System.out.println(HexUtil.encodeHexString(paymentKeyHash));
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("5c9507b0473ad7f087188df26ae6c5496ab2ff95789678c82fa29670");
         }
@@ -260,7 +260,7 @@ public class AddressTest {
             String baseAddress = "addr_test1qz96la9s5xa0ad67vvprdrl8dw79gs7nqf58czr409xynscttpxxc9w2gmdewjwzlv8lx255q7z3mqymv0umkygycskqyf227e";
             Address address = new Address(baseAddress);
 
-            byte[] paymentKeyHash = address.getPaymentCredential().get();
+            byte[] paymentKeyHash = address.getPaymentCredentialHash().get();
             System.out.println(HexUtil.encodeHexString(paymentKeyHash));
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("8baff4b0a1bafeb75e6302368fe76bbc5443d302687c0875794c49c3");
         }
@@ -270,7 +270,7 @@ public class AddressTest {
             String baseAddress = "addr_test1wzdtu0djc76qyqak9cj239udezj2544nyk3ksmfqvaksv7c9xanpg";
             Address address = new Address(baseAddress);
 
-            byte[] paymentKeyHash = address.getPaymentCredential().get();
+            byte[] paymentKeyHash = address.getPaymentCredentialHash().get();
             System.out.println(HexUtil.encodeHexString(paymentKeyHash));
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("9abe3db2c7b40203b62e24a8978dc8a4aa56b325a3686d20676d067b");
         }
@@ -280,7 +280,7 @@ public class AddressTest {
             String baseAddress = "addr1vypj5jf999edw02khvy8e63ec9w0wk39y2pels36ntn3gxsqlvq6t";
             Address address = new Address(baseAddress);
 
-            byte[] paymentKeyHash = address.getPaymentCredential().get();
+            byte[] paymentKeyHash = address.getPaymentCredentialHash().get();
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("032a49252972d73d56bb087cea39c15cf75a2522839fc23a9ae7141a");
         }
 
@@ -289,7 +289,7 @@ public class AddressTest {
             String baseAddress = "stake1uytvm7mh3xvpqgef9fh6f5llwktk0urg7q23cs5h20x9qesrphuw7";
             Address address = new Address(baseAddress);
 
-            Optional<byte[]> paymentKeyHash = address.getPaymentCredential();
+            Optional<byte[]> paymentKeyHash = address.getPaymentCredentialHash();
             assertThat(paymentKeyHash).isEmpty();
         }
 
@@ -298,7 +298,7 @@ public class AddressTest {
             String pointerAddress = "addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant";
             Address address = new Address(pointerAddress);
 
-            byte[] paymentKeyHash = address.getPaymentCredential().get();
+            byte[] paymentKeyHash = address.getPaymentCredentialHash().get();
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("736dfcaa011821cb7d71ad7d546a750c3d6d059a13b35d56bc36d1e3");
         }
 
@@ -307,8 +307,150 @@ public class AddressTest {
             String pointerAddress = "addr_test1grl9uzketqym52kqyjrxplslh3t5zlm65vmlvgzmnycg7m48kw8hvqqqt5mz03";
             Address address = new Address(pointerAddress);
 
-            byte[] paymentKeyHash = address.getPaymentCredential().get();
+            byte[] paymentKeyHash = address.getPaymentCredentialHash().get();
             assertThat(HexUtil.encodeHexString(paymentKeyHash)).isEqualTo("fe5e0ad95809ba2ac0248660fe1fbc57417f7aa337f6205b99308f6e");
+        }
+    }
+
+    @Nested
+    class GetDelegationAndPaymentCredentialTest {
+        @Test
+        void getStakeCredential_fromTestnetEntAddress_returnsNull() {
+            String entAddress = "addr_test1vzxazkxxxapq9k76aae6reskfjuzfljy4lf209kduuxjfec7msk6n";
+            Address address = new Address(entAddress);
+
+            Optional<Credential> delegCred = address.getDelegationCredential();
+            assertThat(delegCred).isEmpty();
+        }
+
+        @Test
+        void getStakeCredential_fromMainetEntAddress_returnsNull() {
+            String entAddress = "addr1vxm9rssxy335nxtph8x4jndrnxj7eyg0e66uv0u7k4dzyjsg6fr38";
+            Address address = new Address(entAddress);
+
+            Optional<Credential> delegCred = address.getDelegationCredential();
+            assertThat(delegCred).isEmpty();
+        }
+
+        @Test
+        void getStakeCredential_fromBaseAddress_testnet() {
+            String baseAddress = "addr_test1qra2kf2lzdt05j7793wz9nxgf5ywf79puqu50djvp0q804g4ee7lj7wgt0urvw6n57eklscwju3p02wu2vmdqd84hgdsc8lqcp";
+            Address address = new Address(baseAddress);
+
+            Credential delegCred = address.getDelegationCredential().get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("15ce7df979c85bf8363b53a7b36fc30e972217a9dc5336d034f5ba1b");
+        }
+
+        @Test
+        void getStakeCredential_fromBaseAddress_mainnet() {
+            String baseAddress = "addr1q8hxcjnvwd2hf397kee6ptfu889r248cn0k5qzvyz78ywa5tdzj0j8al6970zz8urxtdsvwejxn89aqkp4fk6y2jt2wswpm6fz";
+            Address address = new Address(baseAddress);
+
+            Credential delegCred = address.getDelegationCredential().get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("8b68a4f91fbfd17cf108fc1996d831d991a672f4160d536d11525a9d");
+        }
+
+        @Test
+        void getStakeCredential_fromRewardAddress_testnet() {
+            String rewardAddress = "stake_test1up2gmk3f9s6l50ehm26s9kufd9y2gkektu2xy3uawvzk5ug0ze6xv";
+            Address address = new Address(rewardAddress);
+
+            Credential delegCred = address.getDelegationCredential().get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("548dda292c35fa3f37dab502db896948a45b365f1462479d73056a71");
+        }
+
+        @Test
+        void getStakeCredential_fromRewardAddress_mainnet() {
+            String rewardAddress = "stake1u857f9s2s556nfedulykja499mvredrnj6qupp2f2mpumsgkw23zc";
+            Address address = new Address(rewardAddress);
+
+            Credential delegCred = address.getDelegationCredential().get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("e9e4960a8529a9a72de7c96976a52ed83cb4739681c0854956c3cdc1");
+        }
+
+        @Test
+        void getStakeCredential_fromPointerAddress_testnet() {
+            String pointerAddress = "addr_test1grl9uzketqym52kqyjrxplslh3t5zlm65vmlvgzmnycg7m48kw8hvqqqt5mz03";
+            Address address = new Address(pointerAddress);
+
+            Credential delegCred = address.getDelegationCredential().get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("a7b38f760000");
+        }
+
+        @Test
+        void getStakeCredential_fromPointerAddress_mainnet() {
+            String pointerAddress = "addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant";
+            Address address = new Address(pointerAddress);
+
+            Credential delegCred = address.getDelegationCredential().get();
+            assertThat(HexUtil.encodeHexString(delegCred.getBytes())).isEqualTo("8dcb2095eabb49cfe8c63d");
+        }
+
+
+        @Test
+        void getPaymentCredential_fromBaseAddress_mainnet() {
+            String baseAddress = "addr1q9wf2pasguad0uy8rzxly6hxc4yk4vhlj4ufv7xg973fvu9l7f23amv6dqy99nrlezg38y3797tgel0udlxfsjp26ensg63c8u";
+            Address address = new Address(baseAddress);
+
+            Credential paymentCred = address.getPaymentCredential().get();
+            System.out.println(HexUtil.encodeHexString(paymentCred.getBytes()));
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("5c9507b0473ad7f087188df26ae6c5496ab2ff95789678c82fa29670");
+        }
+
+        @Test
+        void getPaymentCredential_fromBaseAddress_testnet() {
+            String baseAddress = "addr_test1qz96la9s5xa0ad67vvprdrl8dw79gs7nqf58czr409xynscttpxxc9w2gmdewjwzlv8lx255q7z3mqymv0umkygycskqyf227e";
+            Address address = new Address(baseAddress);
+
+            Credential paymentCred = address.getPaymentCredential().get();
+            System.out.println(HexUtil.encodeHexString(paymentCred.getBytes()));
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("8baff4b0a1bafeb75e6302368fe76bbc5443d302687c0875794c49c3");
+        }
+
+        @Test
+        void getPaymentCredential_fromEntAddress_testnet() {
+            String baseAddress = "addr_test1wzdtu0djc76qyqak9cj239udezj2544nyk3ksmfqvaksv7c9xanpg";
+            Address address = new Address(baseAddress);
+
+            Credential paymentCred = address.getPaymentCredential().get();
+            System.out.println(HexUtil.encodeHexString(paymentCred.getBytes()));
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("9abe3db2c7b40203b62e24a8978dc8a4aa56b325a3686d20676d067b");
+        }
+
+        @Test
+        void getPaymentCredential_fromEntAddress_mainnet() {
+            String baseAddress = "addr1vypj5jf999edw02khvy8e63ec9w0wk39y2pels36ntn3gxsqlvq6t";
+            Address address = new Address(baseAddress);
+
+            Credential paymentCred = address.getPaymentCredential().get();
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("032a49252972d73d56bb087cea39c15cf75a2522839fc23a9ae7141a");
+        }
+
+        @Test
+        void getPaymentCredential_fromStakeAddress_mainnet() {
+            String baseAddress = "stake1uytvm7mh3xvpqgef9fh6f5llwktk0urg7q23cs5h20x9qesrphuw7";
+            Address address = new Address(baseAddress);
+
+            Optional<Credential> paymentCred = address.getPaymentCredential();
+            assertThat(paymentCred).isEmpty();
+        }
+
+        @Test
+        void getPaymentCredential_fromPointerAddress_mainnet() {
+            String pointerAddress = "addr1g9ekml92qyvzrjmawxkh64r2w5xr6mg9ngfmxh2khsmdrcudevsft64mf887333adamant";
+            Address address = new Address(pointerAddress);
+
+            Credential paymentCred = address.getPaymentCredential().get();
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("736dfcaa011821cb7d71ad7d546a750c3d6d059a13b35d56bc36d1e3");
+        }
+
+        @Test
+        void getPaymentCredential_fromPointerAddress_testnet() {
+            String pointerAddress = "addr_test1grl9uzketqym52kqyjrxplslh3t5zlm65vmlvgzmnycg7m48kw8hvqqqt5mz03";
+            Address address = new Address(pointerAddress);
+
+            Credential paymentCred = address.getPaymentCredential().get();
+            assertThat(HexUtil.encodeHexString(paymentCred.getBytes())).isEqualTo("fe5e0ad95809ba2ac0248660fe1fbc57417f7aa337f6205b99308f6e");
         }
     }
 

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/StakeTx.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/StakeTx.java
@@ -47,7 +47,7 @@ class StakeTx {
      * @return T
      */
     public StakeTx registerStakeAddress(@NonNull Address address) {
-        byte[] delegationHash = address.getDelegationCredential()
+        byte[] delegationHash = address.getDelegationCredentialHash()
                 .orElseThrow(() -> new TxBuildException("Invalid stake address. Address does not have delegation credential"));
 
         StakeCredential stakeCredential = null;
@@ -75,7 +75,7 @@ class StakeTx {
      * @return T
      */
     public StakeTx deregisterStakeAddress(@NonNull Address address, PlutusData redeemer, String refundAddr) {
-        byte[] delegationHash = address.getDelegationCredential()
+        byte[] delegationHash = address.getDelegationCredentialHash()
                 .orElseThrow(() -> new TxBuildException("Invalid stake address. Address does not have delegation credential"));
 
         StakeCredential stakeCredential = null;
@@ -117,7 +117,7 @@ class StakeTx {
      * @return T
      */
     public StakeTx delegateTo(@NonNull Address address, @NonNull String poolId, PlutusData redeemer) {
-        byte[] delegationHash = address.getDelegationCredential()
+        byte[] delegationHash = address.getDelegationCredentialHash()
                 .orElseThrow(() -> new TxBuildException("Invalid stake address. Address does not have delegation credential"));
 
         StakeCredential stakeCredential = null;


### PR DESCRIPTION
- Existing ```Optional<byte[]> getPaymentCredential(address)```, ```Optional<byte[]> getDelegationCredential(address)``` are changed to ```Optional<byte[]> getPaymentCredentialHash(address)``` and ```Optional<byte[]> getDelegationCredentialHash(address)```

- Added new methods ```Optional<Credential> getPaymentCredential(address)``` and ```Optional<Credential> getDelegationCredential(address)```