### PR TITLE
Support to verify the transaction content before submission through Verifier(s) 

### DIFF
--- a/core-api/src/main/java/com/bloxbean/cardano/client/api/model/Amount.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/client/api/model/Amount.java
@@ -37,6 +37,10 @@ public class Amount {
                 .build();
     }
 
+    public static Amount ada(long ada) {
+        return ada((double) ada);
+    }
+
     public static Amount asset(String unit, BigInteger quantity) {
         return Amount.builder()
                 .unit(unit)

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
@@ -121,6 +121,7 @@ public class QuickTxBuilder {
 
         private TransactionEvaluator txnEvaluator;
         private UtxoSelectionStrategy utxoSelectionStrategy;
+        private Verifier txVerifier;
 
         TxContext(AbstractTx... txs) {
             this.txList = txs;
@@ -315,6 +316,9 @@ public class QuickTxBuilder {
             if (txInspector != null)
                 txInspector.accept(transaction);
 
+            if (txVerifier != null)
+                txVerifier.verify(transaction);
+
             try {
                 Result<String> result = transactionProcessor.submitTransaction(transaction.serialize());
                 if (!result.isSuccessful()) {
@@ -445,6 +449,19 @@ public class QuickTxBuilder {
          */
         public TxContext withUtxoSelectionStrategy(UtxoSelectionStrategy utxoSelectionStrategy) {
             this.utxoSelectionStrategy = utxoSelectionStrategy;
+            return this;
+        }
+
+        /**
+         * Verify the transaction with the given verifier before submitting
+         * @param txVerifier TxVerifier
+         * @return TxContext
+         */
+        public TxContext withVerifier(Verifier txVerifier) {
+            if (this.txVerifier == null)
+                this.txVerifier = txVerifier;
+            else
+                this.txVerifier = this.txVerifier.andThen(txVerifier);
             return this;
         }
     }

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/Verifier.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/Verifier.java
@@ -1,0 +1,35 @@
+package com.bloxbean.cardano.client.quicktx;
+
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+
+import java.util.Objects;
+
+/**
+ * Verifier interface to verify a transaction before submitting to the network.
+ * Implement this interface to add verification logic. You can chain multiple verifiers using andThen method.
+ * If any of the verifier fails, the transaction submission will fail.
+ */
+@FunctionalInterface
+public interface Verifier {
+
+    /**
+     * Verify the transaction
+     * @param txn transaction to verify
+     * @throws VerifierException if verification fails
+     */
+    void verify(Transaction txn) throws VerifierException;
+
+    /**
+     * Chain multiple verifiers
+     * @param after verifier to chain
+     * @return chained verifier
+     */
+    default Verifier andThen(Verifier after) {
+        Objects.requireNonNull(after);
+
+        return (txn) -> {
+            verify(txn);
+            after.verify(txn);
+        };
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/VerifierException.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/VerifierException.java
@@ -1,0 +1,10 @@
+package com.bloxbean.cardano.client.quicktx;
+
+/**
+ * Thrown when verification fails
+ */
+public class VerifierException extends RuntimeException {
+    public VerifierException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/verifiers/OutputAmountVerifier.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/verifiers/OutputAmountVerifier.java
@@ -1,0 +1,75 @@
+package com.bloxbean.cardano.client.quicktx.verifiers;
+
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.util.AssetUtil;
+import com.bloxbean.cardano.client.quicktx.Verifier;
+import com.bloxbean.cardano.client.quicktx.VerifierException;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.util.Tuple;
+
+import java.math.BigInteger;
+
+import static com.bloxbean.cardano.client.common.CardanoConstants.LOVELACE;
+
+/**
+ * Verifies the output amount for a given address
+ */
+public class OutputAmountVerifier implements Verifier {
+
+    private final String address;
+    private final Amount amount;
+    private final String customMsg;
+
+    /**
+     * Verifies the output amount for a given address
+     * @param address address to verify
+     * @param amount amount to verify
+     * @param customMsg custom message to throw in case of verification failure
+     */
+    public OutputAmountVerifier(String address, Amount amount, String customMsg) {
+        this.address = address;
+        this.amount = amount;
+        this.customMsg = customMsg;
+    }
+
+    @Override
+    public void verify(Transaction txn) throws VerifierException {
+        if (LOVELACE.equals(amount.getUnit())) {
+            BigInteger lovelaceAmt = txn.getBody()
+                    .getOutputs().stream()
+                    .filter(o -> o.getAddress().equals(address))
+                    .map(o -> o.getValue().getCoin())
+                    .reduce(BigInteger.ZERO, (amount1, amount2) -> amount1.add(amount2));
+
+            if (lovelaceAmt.compareTo(amount.getQuantity()) != 0) {
+                String expectedMsg = formatExceptionMessage(customMsg, address, amount, lovelaceAmt);
+                throw new VerifierException(expectedMsg);
+            }
+        } else {
+            BigInteger assetAmount = txn.getBody()
+                    .getOutputs().stream()
+                    .filter(o -> o.getAddress().equals(address) && o.getValue().getMultiAssets() != null)
+                    .flatMap(transactionOutput -> transactionOutput.getValue().getMultiAssets().stream())
+                    .flatMap(multiAsset -> multiAsset.getAssets().stream().map(asset -> new Tuple<>(multiAsset.getPolicyId(), asset)))
+                    .filter(assetTuple -> {
+                        String unit = AssetUtil.getUnit(assetTuple._1, assetTuple._2);
+                        return unit != null && unit.equals(amount.getUnit());
+                    }).map(assetTuple -> assetTuple._2.getValue())
+                    .reduce(BigInteger.ZERO, (amount1, amount2) -> amount1.add(amount2));
+
+            String expectedMsg = formatExceptionMessage(customMsg, address, amount, assetAmount);
+            if (assetAmount.compareTo(amount.getQuantity()) != 0) {
+                throw new VerifierException(expectedMsg);
+            }
+        }
+    }
+
+    private String formatExceptionMessage(String customMsg, String address, Amount expectedAmount, BigInteger actualAmount) {
+        String expectedMsg = String.format("Expected amount %s(%s) for address %s, \nbut got %s",
+                expectedAmount.getQuantity(), expectedAmount.getUnit(), address, actualAmount);
+        if(customMsg != null)
+            expectedMsg = customMsg + ".\n" + expectedMsg;
+
+        return expectedMsg;
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/verifiers/TxVerifiers.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/verifiers/TxVerifiers.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.client.quicktx.verifiers;
+
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.quicktx.Verifier;
+
+/**
+ * Helper class to create verifiers
+ */
+public class TxVerifiers {
+
+    /**
+     * Verifier to verify the output amount for a given address
+     * @param address address to verify
+     * @param amount amount to verify
+     * @return Verifier
+     */
+    public static Verifier outputAmountVerifier(String address, Amount amount) {
+        return new OutputAmountVerifier(address, amount, null);
+    }
+
+    /**
+     * Verifier to verify the output amount for a given address
+     * @param address address to verify
+     * @param amount amount to verify
+     * @param customMsg custom message to throw in case of verification failure
+     * @return Verifier
+     */
+    public static Verifier outputAmountVerifier(String address, Amount amount, String customMsg) {
+        return new OutputAmountVerifier(address, amount, customMsg);
+    }
+}

--- a/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/verifiers/OutputAmountVerifierTest.java
+++ b/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/verifiers/OutputAmountVerifierTest.java
@@ -1,0 +1,178 @@
+package com.bloxbean.cardano.client.quicktx.verifiers;
+
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.quicktx.Verifier;
+import com.bloxbean.cardano.client.quicktx.VerifierException;
+import com.bloxbean.cardano.client.transaction.spec.*;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OutputAmountVerifierTest {
+
+    @Test
+    void verify_loveLaceAndAssetAmounts() {
+        //Transaction to verify
+        Transaction transaction = new Transaction();
+        String policyId1 = "a9a750f73f678495ccc869ba300c983814d3079367f0cf909afea8d6";
+        String policyId2 = "5ac3d4bdca238105a040a565e5d7e734b7c9e1630aec7650e809e34a";
+        String policyId3 = "5ac3d4bdca238105a040a565e5d7e734b7c9e1630aec7650e809e34a";
+
+        String address1 = "addr1q8vqpw8tedwx649q3xlt4g5ezk5wdyegwwwmgx3jzx5nkqkekhfqfxcm4uxzaw7fdc6sq77qlgm280d6mpgrtqazcx4sam04xx";
+        String address2 = "addr1wx3937ykmlcaqxkf4z7stxpsfwfn4re7ncy48yu8vutcpxgg67me2";
+        String address3 = "addr1wx2527ykmlcaqxkf4z7stxpsfwfn4re7ncy48yu8vutcpxgg67me4";
+
+        TransactionOutput transactionOutput1 = TransactionOutput.builder()
+                .address(address1)
+                .value(Value.builder()
+                        .coin(adaToLovelace(100))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policyId1)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset1")
+                                                        .value(BigInteger.valueOf(5))
+                                                        .build(),
+                                                Asset.builder()
+                                                        .name("asset2")
+                                                        .value(BigInteger.valueOf(8))
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build()).build();
+
+        TransactionOutput transactionOutput2 = TransactionOutput.builder()
+                .address(address2)
+                .value(Value.builder()
+                        .coin(adaToLovelace(2100))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policyId1)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset1")
+                                                        .value(BigInteger.valueOf(10))
+                                                        .build()
+                                        ))
+                                        .build(),
+                                MultiAsset.builder()
+                                        .policyId(policyId2)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset3")
+                                                        .value(BigInteger.valueOf(50))
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build()).build();
+
+        TransactionOutput transactionOutput3 = TransactionOutput.builder()
+                .address(address1)
+                .value(Value.builder()
+                        .coin(adaToLovelace(600))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policyId1)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset1")
+                                                        .value(BigInteger.valueOf(40))
+                                                        .build(),
+                                                Asset.builder()
+                                                        .name("asset4")
+                                                        .value(BigInteger.valueOf(90))
+                                                        .build()
+                                        ))
+                                        .build(),
+                                MultiAsset.builder()
+                                        .policyId(policyId2)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset1")
+                                                        .value(BigInteger.valueOf(60))
+                                                        .build(),
+                                                Asset.builder()
+                                                        .name("asset4")
+                                                        .value(BigInteger.valueOf(9))
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build()).build();
+
+        TransactionOutput transactionOutput4 = TransactionOutput.builder()
+                .address(address3)
+                .value(Value.builder()
+                        .coin(adaToLovelace(7))
+                        .build()).build();
+
+        TransactionBody transactionBody = TransactionBody.builder()
+                .outputs(List.of(transactionOutput1, transactionOutput2, transactionOutput3, transactionOutput4))
+                .build();
+        transaction.setBody(transactionBody);
+
+        //Verify Lovelace amount
+        Verifier outputAmountVerifier11 = new OutputAmountVerifier(address1, Amount.ada(700.0), "Lovelace amount mismatch");
+        assertDoesNotThrow(() -> outputAmountVerifier11.verify(transaction));
+
+        Verifier outputAmountVerifier12 = new OutputAmountVerifier(address2, Amount.ada(2100), "Lovelace amount mismatch");
+        assertDoesNotThrow(() -> outputAmountVerifier12.verify(transaction));
+
+        Verifier outputAmountVerifier13 = new OutputAmountVerifier(address3, Amount.ada(7), "Lovelace amount mismatch");
+        assertDoesNotThrow(() -> outputAmountVerifier13.verify(transaction));
+
+        //wrong coin value for address1, should throw exception
+        Verifier outputAmountVerifier21 = new OutputAmountVerifier(address1, Amount.ada(900.0), "Lovelace amount mismatch");
+        assertThrows(VerifierException.class, () -> outputAmountVerifier21.verify(transaction));
+
+        //wrong value for address2, should throw exception
+        Verifier outputAmountVerifier22 = new OutputAmountVerifier(address2, Amount.ada(2000), "Lovelace amount mismatch");
+        assertThrows(VerifierException.class, () -> outputAmountVerifier22.verify(transaction));
+
+        //wrong value for address3, should throw exception
+        Verifier outputAmountVerifier23 = new OutputAmountVerifier(address3, Amount.ada(2000), "Lovelace amount mismatch");
+        assertThrows(VerifierException.class, () -> outputAmountVerifier23.verify(transaction));
+
+        //Verify MultiAsset amount
+        Verifier outputAmountVerifier31 = new OutputAmountVerifier(address1, Amount.asset(policyId1, "asset1", 45), null);
+        assertDoesNotThrow(() -> outputAmountVerifier31.verify(transaction));
+
+        Verifier outputAmountVerifier32 = new OutputAmountVerifier(address2, Amount.asset(policyId1, "asset1", 10), "Asset amount mismatch");
+        assertDoesNotThrow(() -> outputAmountVerifier32.verify(transaction));
+
+        Verifier outputAmountVerifier33 = new OutputAmountVerifier(address2, Amount.asset(policyId2, "asset3", 50), "Asset amount mismatch");
+        assertDoesNotThrow(() -> outputAmountVerifier33.verify(transaction));
+
+        Verifier outputAmountVerifier34 = new OutputAmountVerifier(address1, Amount.asset(policyId1, "asset4", 90), "Asset amount mismatch");
+        assertDoesNotThrow(() -> outputAmountVerifier34.verify(transaction));
+
+        Verifier outputAmountVerifier35 = new OutputAmountVerifier(address1, Amount.asset(policyId1, "asset2", 8), "Asset amount mismatch");
+        assertDoesNotThrow(() -> outputAmountVerifier35.verify(transaction));
+
+        //wrong value for address1, should throw exception
+        Verifier outputAmountVerifier41 = new OutputAmountVerifier(address1, Amount.asset(policyId1, "asset1", 555), "Asset amount mismatch");
+        assertThrows(VerifierException.class, () -> outputAmountVerifier41.verify(transaction));
+
+        Verifier outputAmountVerifier42 = new OutputAmountVerifier(address2, Amount.asset(policyId2, "asset3", 33), "Asset amount mismatch");
+        assertThrows(VerifierException.class, () -> outputAmountVerifier42.verify(transaction));
+
+        Verifier outputAmountVerifier43 = new OutputAmountVerifier(address1, Amount.asset(policyId1, "asset4", 100), "Asset amount mismatch");
+        assertThrows(VerifierException.class, () -> outputAmountVerifier43.verify(transaction));
+
+        Verifier outputAmountVerifier44 = new OutputAmountVerifier(address1, Amount.asset(policyId1, "asset2", 9), "Asset amount mismatch");
+        assertThrows(VerifierException.class, () -> outputAmountVerifier44.verify(transaction));
+
+        Verifier outputAmountVerifier45 = new OutputAmountVerifier(address2, Amount.asset(policyId1, "asset1", 11), "Asset amount mismatch for address2");
+        assertThatThrownBy(() -> outputAmountVerifier45.verify(transaction))
+                .isInstanceOf(VerifierException.class)
+                .hasMessageStartingWith("Asset amount mismatch for address2");
+    }
+}

--- a/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/verifiers/TxVerifiersTest.java
+++ b/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/verifiers/TxVerifiersTest.java
@@ -1,0 +1,137 @@
+package com.bloxbean.cardano.client.quicktx.verifiers;
+
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.quicktx.Verifier;
+import com.bloxbean.cardano.client.quicktx.VerifierException;
+import com.bloxbean.cardano.client.transaction.spec.*;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TxVerifiersTest {
+    String address1 = "addr1q8vqpw8tedwx649q3xlt4g5ezk5wdyegwwwmgx3jzx5nkqkekhfqfxcm4uxzaw7fdc6sq77qlgm280d6mpgrtqazcx4sam04xx";
+    String address2 = "addr1wx3937ykmlcaqxkf4z7stxpsfwfn4re7ncy48yu8vutcpxgg67me2";
+
+    @Test
+    void outputAmountVerifier_verifyWithNullMsg() {
+        Transaction transaction = buildTransaction();
+        assertThrows(VerifierException.class, () -> {
+            Verifier verifier = TxVerifiers.outputAmountVerifier(address1, Amount.ada(1000));
+            verifier.verify(transaction);
+        });
+    }
+
+    @Test
+    void setOutputAmountVerifier_verifyWithCustomMsg() {
+        Transaction transaction = buildTransaction();
+        assertThatThrownBy( () -> {
+            Verifier verifier = TxVerifiers.outputAmountVerifier(address1, Amount.ada(700), "Lovelace amount is not matching")
+                    .andThen(TxVerifiers.outputAmountVerifier(address2, Amount.ada(2200), "Lovelace amount is not matching for address2"));
+            verifier.verify(transaction);
+        }).isInstanceOf(VerifierException.class)
+                .hasMessageStartingWith("Lovelace amount is not matching for address2");
+    }
+
+    private Transaction buildTransaction() {
+        //Transaction to verify
+        Transaction transaction = new Transaction();
+        String policyId1 = "a9a750f73f678495ccc869ba300c983814d3079367f0cf909afea8d6";
+        String policyId2 = "5ac3d4bdca238105a040a565e5d7e734b7c9e1630aec7650e809e34a";
+
+        String address1 = "addr1q8vqpw8tedwx649q3xlt4g5ezk5wdyegwwwmgx3jzx5nkqkekhfqfxcm4uxzaw7fdc6sq77qlgm280d6mpgrtqazcx4sam04xx";
+        String address2 = "addr1wx3937ykmlcaqxkf4z7stxpsfwfn4re7ncy48yu8vutcpxgg67me2";
+
+        TransactionOutput transactionOutput1 = TransactionOutput.builder()
+                .address(address1)
+                .value(Value.builder()
+                        .coin(adaToLovelace(100))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policyId1)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset1")
+                                                        .value(BigInteger.valueOf(5))
+                                                        .build(),
+                                                Asset.builder()
+                                                        .name("asset2")
+                                                        .value(BigInteger.valueOf(8))
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build()).build();
+
+        TransactionOutput transactionOutput2 = TransactionOutput.builder()
+                .address(address2)
+                .value(Value.builder()
+                        .coin(adaToLovelace(2100))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policyId1)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset1")
+                                                        .value(BigInteger.valueOf(10))
+                                                        .build()
+                                        ))
+                                        .build(),
+                                MultiAsset.builder()
+                                        .policyId(policyId2)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset3")
+                                                        .value(BigInteger.valueOf(50))
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build()).build();
+
+        TransactionOutput transactionOutput3 = TransactionOutput.builder()
+                .address(address1)
+                .value(Value.builder()
+                        .coin(adaToLovelace(600))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policyId1)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset1")
+                                                        .value(BigInteger.valueOf(40))
+                                                        .build(),
+                                                Asset.builder()
+                                                        .name("asset4")
+                                                        .value(BigInteger.valueOf(90))
+                                                        .build()
+                                        ))
+                                        .build(),
+                                MultiAsset.builder()
+                                        .policyId(policyId2)
+                                        .assets(List.of(
+                                                Asset.builder()
+                                                        .name("asset1")
+                                                        .value(BigInteger.valueOf(60))
+                                                        .build(),
+                                                Asset.builder()
+                                                        .name("asset4")
+                                                        .value(BigInteger.valueOf(9))
+                                                        .build()
+                                        ))
+                                        .build()
+                        ))
+                        .build()).build();
+
+        TransactionBody transactionBody = TransactionBody.builder()
+                .outputs(List.of(transactionOutput1, transactionOutput2, transactionOutput3))
+                .build();
+        transaction.setBody(transactionBody);
+
+        return transaction;
+    }
+}


### PR DESCRIPTION
To fix #259 

- Added a new method ```withVerifier(Verifier)``` to provide Verifier or chain of verifiers to verify the transaction before submission.
- TxVerifiers helper to provide out-of-box verifier for output amount for an address
- Application can implement ``Verifier`` interface to provide application specific custom verifiers.
- VerificationException is thrown when verification fails

Example:
```
import static com.bloxbean.cardano.client.quicktx.verifiers.TxVerifiers.outputAmountVerifier;

...

Result<String> result = quickTxBuilder.compose(tx1, tx2)
                .withSigner(SignerProviders.signerFrom(sender1))
                .withSigner(SignerProviders.signerFrom(policy))
                .withVerifier(
                        outputAmountVerifier(receiver2, Amount.ada(3.0))
                                .andThen(outputAmountVerifier(receiver3, Amount.ada(2.13)))
                                .andThen(outputAmountVerifier(receiver2, Amount.asset(policy.getPolicyId(), assetName, qty)))
                )
                .complete();
```
