### PR TITLE
Add mergeOutputs option to control whether to merge outputs or not

### DIFF
--- a/function/src/main/java/com/bloxbean/cardano/client/function/TxBuilderContext.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/TxBuilderContext.java
@@ -15,7 +15,9 @@ import com.bloxbean.cardano.client.coinselection.impl.DefaultUtxoSelector;
 import com.bloxbean.cardano.client.plutus.spec.CostMdls;
 import com.bloxbean.cardano.client.transaction.spec.MultiAsset;
 import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -42,6 +44,9 @@ public class TxBuilderContext {
     //Stores utxos used in the transaction.
     //This list is cleared after each build() call.
     private Set<Utxo> utxos = new HashSet<>();
+
+    @Setter(AccessLevel.NONE)
+    private boolean mergeOutputs = true;
 
     public TxBuilderContext(UtxoSupplier utxoSupplier, ProtocolParamsSupplier protocolParamsSupplier) {
         this(utxoSupplier, protocolParamsSupplier.getProtocolParams());
@@ -93,6 +98,15 @@ public class TxBuilderContext {
 
     public TxBuilderContext withCostMdls(CostMdls costMdls) {
         this.costMdls = costMdls;
+        return this;
+    }
+
+    /**
+     * If true, the outputs will be merged if there are multiple outputs with same address. Default is true.
+     * @param mergeOutputs
+     */
+    public TxBuilderContext mergeOutputs(boolean mergeOutputs) {
+        this.mergeOutputs = mergeOutputs;
         return this;
     }
 

--- a/function/src/test/java/com/bloxbean/cardano/client/function/helper/OutputBuildersTest.java
+++ b/function/src/test/java/com/bloxbean/cardano/client/function/helper/OutputBuildersTest.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
 import static com.bloxbean.cardano.client.common.CardanoConstants.LOVELACE;
 import static com.bloxbean.cardano.client.common.CardanoConstants.ONE_ADA;
 import static com.bloxbean.cardano.client.function.helper.OutputBuilders.createFromOutput;
@@ -157,7 +158,7 @@ class OutputBuildersTest extends BaseTest {
         assertThat(list.get(0).getAddress()).isEqualTo(output1.getAddress());
         assertThat(list.get(0).getValue().getCoin()).isGreaterThan(BigInteger.valueOf(900000)); //approx min ada value
         assertThat(list.get(0).getInlineDatum()).isEqualTo(new BytesPlutusData("hello".getBytes()));
-        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[] {-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
+        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[]{-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
         assertThat(list.get(0).getDatumHash()).isNull();
 
         assertThat(list.get(1).getAddress()).isEqualTo(output2.getAddress());
@@ -210,7 +211,7 @@ class OutputBuildersTest extends BaseTest {
         assertThat(list.get(0).getValue().getMultiAssets().get(0).getAssets().get(0).getName()).isEqualTo(HexUtil.encodeHexString(output2.getAssetName().getBytes(), true));
         assertThat(list.get(0).getValue().getMultiAssets().get(0).getAssets().get(0).getValue()).isEqualTo(output2.getQty());
         assertThat(list.get(0).getInlineDatum()).isEqualTo(new BytesPlutusData("hello".getBytes()));
-        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[] {-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
+        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[]{-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
         assertThat(list.get(1).getDatumHash()).isNull();
 
         assertThat(list.get(1).getAddress()).isEqualTo(output3.getAddress());
@@ -259,7 +260,7 @@ class OutputBuildersTest extends BaseTest {
 
         assertThat(list).hasSize(2);
         assertThat(list.get(0).getInlineDatum()).isEqualTo(new BytesPlutusData("hello".getBytes()));
-        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[] {-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
+        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[]{-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
         assertThat(list.get(1).getDatumHash()).isNull();
 
         assertThat(list.get(1).getAddress()).isEqualTo(output3.getAddress());
@@ -308,7 +309,7 @@ class OutputBuildersTest extends BaseTest {
 
         assertThat(list).hasSize(2);
         assertThat(list.get(0).getInlineDatum()).isEqualTo(new BytesPlutusData("hello".getBytes()));
-        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[] {-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
+        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[]{-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
         assertThat(list.get(1).getDatumHash()).isNull();
 
         assertThat(list.get(1).getAddress()).isEqualTo(output3.getAddress());
@@ -439,7 +440,7 @@ class OutputBuildersTest extends BaseTest {
     }
 
     @Test
-    void testCreateFromOutput_withTransactionOutput()throws Exception {
+    void testCreateFromOutput_withTransactionOutput() throws Exception {
         Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("abc-policy", 1);
         MultiAsset multiAsset1 = MultiAsset.builder()
                 .policyId(policy.getPolicyId())
@@ -463,7 +464,7 @@ class OutputBuildersTest extends BaseTest {
         Value value = Value.builder()
                 .coin(BigInteger.valueOf(1000))
                 .multiAssets(List.of(
-                    multiAsset1, multiAsset2
+                        multiAsset1, multiAsset2
                 )).build();
 
         Integer datum = 200;
@@ -501,7 +502,7 @@ class OutputBuildersTest extends BaseTest {
     }
 
     @Test
-    void testCreateFromOutput_withTransactionOutput_withInlineDatumAndScriptRef()throws Exception {
+    void testCreateFromOutput_withTransactionOutput_withInlineDatumAndScriptRef() throws Exception {
         Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("abc-policy", 1);
         MultiAsset multiAsset1 = MultiAsset.builder()
                 .policyId(policy.getPolicyId())
@@ -556,7 +557,7 @@ class OutputBuildersTest extends BaseTest {
         assertThat(list.get(0).getValue().getMultiAssets()).contains(multiAsset1, multiAsset2);
         assertThat(list.get(0).getDatumHash()).isNull();
         assertThat(list.get(0).getInlineDatum()).isEqualTo(BigIntPlutusData.of(200));
-        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[] {-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
+        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[]{-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
 
         assertThat(list.get(1).getAddress()).isEqualTo(output2.getAddress());
         assertThat(list.get(1).getValue().getCoin()).isEqualTo(output2.getValue().getCoin());
@@ -633,11 +634,11 @@ class OutputBuildersTest extends BaseTest {
     }
 
     @Test
-    void testCreateFromOutput2_whenTransactionOutputAndCustomMinAdaChecker() throws Exception{
+    void testCreateFromOutput2_whenTransactionOutputAndCustomMinAdaChecker() throws Exception {
         TransactionOutput output1 = TransactionOutput.builder()
                 .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
                 .value(Value.builder()
-                    .coin(BigInteger.valueOf(12000)).build()
+                        .coin(BigInteger.valueOf(12000)).build()
                 )
                 .datumHash(BytesPlutusData.of("hello").getDatumHashAsBytes())
                 .build();
@@ -664,4 +665,540 @@ class OutputBuildersTest extends BaseTest {
         assertThat(list.get(1).getValue().getCoin()).isEqualTo(ONE_ADA.multiply(BigInteger.valueOf(20)));
         assertThat(list.get(1).getDatumHash()).isNull();
     }
+
+    @Test
+    void createFromOutput_whenMergeOutputs_isFalse() throws CborException, CborSerializationException {
+        Output output1 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(10))
+                .datum(new BytesPlutusData("output1".getBytes()))
+                .build();
+
+        Output output2 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .assetName(LOVELACE)
+                .qty(ONE_ADA.multiply(BigInteger.valueOf(20)))
+                .build();
+
+        Output output3 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(40))
+                .datum(new BytesPlutusData("hello".getBytes())) //This should be ignored as output1 already has a datum
+                .inlineDatum(true)
+                .build();
+
+        Output output4 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(0.5))
+                .datum(new BytesPlutusData("output4".getBytes()))
+                .build();
+
+        TxBuilderContext context = new TxBuilderContext(utxoSupplier, protocolParams);
+        context.mergeOutputs(false);
+        List<TransactionOutput> list = new ArrayList<>();
+
+        output1.outputBuilder()
+                .and(output2.outputBuilder())
+                .and(output3.outputBuilder())
+                .and(output4.outputBuilder())
+                .accept(context, list);
+
+        assertThat(list).hasSize(4);
+        assertThat(list.get(0).getAddress()).isEqualTo(output1.getAddress());
+        assertThat(list.get(0).getValue().getCoin()).isEqualTo(adaToLovelace(10));
+        assertThat(list.get(0).getDatumHash()).isEqualTo(new BytesPlutusData("output1".getBytes()).getDatumHashAsBytes());
+
+        assertThat(list.get(1).getAddress()).isEqualTo(output2.getAddress());
+        assertThat(list.get(1).getValue().getCoin()).isEqualTo(ONE_ADA.multiply(BigInteger.valueOf(20)));
+        assertThat(list.get(1).getDatumHash()).isNull();
+        assertThat(list.get(1).getInlineDatum()).isNull();
+
+        assertThat(list.get(2).getAddress()).isEqualTo(output3.getAddress());
+        assertThat(list.get(2).getValue().getCoin()).isEqualTo(adaToLovelace(40));
+        assertThat(list.get(2).getDatumHash()).isNull();
+        assertThat(list.get(2).getInlineDatum()).isEqualTo(new BytesPlutusData("hello".getBytes()));
+
+        assertThat(list.get(3).getAddress()).isEqualTo(output4.getAddress());
+        assertThat(list.get(3).getValue().getCoin()).isGreaterThan(adaToLovelace(1));
+        assertThat(list.get(3).getDatumHash()).isEqualTo(new BytesPlutusData("output4".getBytes()).getDatumHashAsBytes());
+        assertThat(list.get(3).getInlineDatum()).isNull();
+    }
+
+    @Test
+    void createFromOutput_whenMergeOutputs_isTrue() throws CborException, CborSerializationException {
+        Output output1 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(10))
+                .datum(new BytesPlutusData("output1".getBytes()))
+                .build();
+
+        Output output2 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .assetName(LOVELACE)
+                .qty(ONE_ADA.multiply(BigInteger.valueOf(20)))
+                .build();
+
+        Output output3 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(40))
+                .datum(new BytesPlutusData("hello".getBytes()))
+                .inlineDatum(true)
+                .build();
+
+        Output output4 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(0.5))
+                .datum(new BytesPlutusData("output4".getBytes()))
+                .inlineDatum(true)
+                .build();
+
+        TxBuilderContext context = new TxBuilderContext(utxoSupplier, protocolParams);
+        List<TransactionOutput> list = new ArrayList<>();
+
+        output1.outputBuilder()
+                .and(output2.outputBuilder())
+                .and(output3.outputBuilder())
+                .and(output4.outputBuilder())
+                .accept(context, list);
+
+        assertThat(list).hasSize(2);
+        assertThat(list.get(0).getAddress()).isEqualTo(output1.getAddress());
+        assertThat(list.get(0).getValue().getCoin()).isEqualTo(adaToLovelace(50));
+        assertThat(list.get(0).getDatumHash()).isEqualTo(new BytesPlutusData("output1".getBytes()).getDatumHashAsBytes());
+
+        assertThat(list.get(1).getAddress()).isEqualTo(output2.getAddress());
+        assertThat(list.get(1).getValue().getCoin()).isEqualTo(adaToLovelace(20.5));
+        assertThat(list.get(1).getDatumHash()).isNull();
+        assertThat(list.get(1).getInlineDatum()).isEqualTo(new BytesPlutusData("output4".getBytes()));
+    }
+
+    @Test
+    void createFromOutput_withMultiAsset_isMergeOutputsTrue() throws CborSerializationException {
+        Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("abc-policy", 1);
+        Policy policy2 = PolicyUtil.createMultiSigScriptAllPolicy("xyz-policy", 1);
+
+        Output output1 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(10))
+                .build();
+
+        Output output2 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .policyId(policy.getPolicyId())
+                .assetName("abc")
+                .qty(BigInteger.valueOf(1000))
+                .datum(new BytesPlutusData("output2".getBytes()))
+                .inlineDatum(true)
+                .scriptRef(PlutusV2Script.builder().cborHex("49480100002221200101").build())
+                .build();
+
+        Output output3 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .policyId(policy.getPolicyId())
+                .assetName("xyz")
+                .qty(BigInteger.valueOf(2000))
+                .datum(new BytesPlutusData("output3".getBytes())) //This should be ignored as it's already set in output2
+                .inlineDatum(true)
+                .build();
+
+        Output output4 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .policyId(policy2.getPolicyId())
+                .assetName("xyz")
+                .qty(BigInteger.valueOf(7000))
+                .datum(new BytesPlutusData("output4".getBytes())) //This should be ignored as it's already set in output2
+                .inlineDatum(true)
+                .build();
+
+        Output output5 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(20))
+                .build();
+
+        Output output6 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .policyId(policy2.getPolicyId())
+                .assetName("xyz")
+                .qty(BigInteger.valueOf(50))
+                .build();
+
+        TxBuilderContext context = new TxBuilderContext(utxoSupplier, protocolParams);
+        List<TransactionOutput> list = new ArrayList<>();
+
+        output1.outputBuilder()
+                .and(output2.outputBuilder())
+                .and(output3.outputBuilder())
+                .and(output4.outputBuilder())
+                .and(output5.outputBuilder())
+                .and(output6.outputBuilder())
+                .accept(context, list);
+
+        assertThat(list).hasSize(2);
+        assertThat(list.get(0).getAddress()).isEqualTo(output1.getAddress());
+        assertThat(list.get(0).getValue().getCoin()).isEqualTo(adaToLovelace(10));
+        assertThat(list.get(0).getValue().getMultiAssets()).containsExactlyInAnyOrder(
+                MultiAsset.builder()
+                        .policyId(policy.getPolicyId())
+                        .assets(List.of(
+                                new Asset("abc", BigInteger.valueOf(1000)),
+                                new Asset("xyz", BigInteger.valueOf(2000))
+                        )).build(),
+                MultiAsset.builder()
+                        .policyId(policy2.getPolicyId())
+                        .assets(List.of(
+                                new Asset("xyz", BigInteger.valueOf(7000))
+                        )).build()
+        );
+        assertThat(list.get(0).getInlineDatum()).isEqualTo(new BytesPlutusData("output2".getBytes()));
+        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[]{-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
+        assertThat(list.get(0).getDatumHash()).isNull();
+
+        assertThat(list.get(1).getAddress()).isEqualTo(output5.getAddress());
+        assertThat(list.get(1).getValue().getCoin()).isEqualTo(adaToLovelace(20));
+        assertThat(list.get(1).getValue().getMultiAssets()).containsExactly(
+                MultiAsset.builder()
+                        .policyId(policy2.getPolicyId())
+                        .assets(List.of(
+                                new Asset("xyz", BigInteger.valueOf(50))
+                        )).build()
+        );
+
+        assertThat(list.get(1).getInlineDatum()).isNull();
+        assertThat(list.get(1).getScriptRef()).isNull();
+        assertThat(list.get(1).getDatumHash()).isNull();
+    }
+
+    @Test
+    void createFromOutput_withMultiAsset_isMergeOutputsFalse() throws CborSerializationException {
+        Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("abc-policy", 1);
+        Policy policy2 = PolicyUtil.createMultiSigScriptAllPolicy("xyz-policy", 1);
+
+        Output output1 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(10))
+                .build();
+
+        Output output2 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .policyId(policy.getPolicyId())
+                .assetName("abc")
+                .qty(BigInteger.valueOf(1000))
+                .datum(new BytesPlutusData("output2".getBytes()))
+                .inlineDatum(true)
+                .scriptRef(PlutusV2Script.builder().cborHex("49480100002221200101").build())
+                .build();
+
+        Output output3 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .policyId(policy.getPolicyId())
+                .assetName("xyz")
+                .qty(BigInteger.valueOf(2000))
+                .datum(new BytesPlutusData("output3".getBytes())) //This should be ignored as it's already set in output2
+                .inlineDatum(true)
+                .build();
+
+        Output output4 = Output.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .policyId(policy2.getPolicyId())
+                .assetName("xyz")
+                .qty(BigInteger.valueOf(7000))
+                .datum(new BytesPlutusData("output4".getBytes())) //This should be ignored as it's already set in output2
+                .inlineDatum(true)
+                .build();
+
+        Output output5 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(20))
+                .build();
+
+        Output output6 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .policyId(policy2.getPolicyId())
+                .assetName("xyz")
+                .qty(BigInteger.valueOf(50))
+                .build();
+
+        TxBuilderContext context = new TxBuilderContext(utxoSupplier, protocolParams);
+        context.mergeOutputs(false);
+        List<TransactionOutput> list = new ArrayList<>();
+
+        output1.outputBuilder()
+                .and(output2.outputBuilder())
+                .and(output3.outputBuilder())
+                .and(output4.outputBuilder())
+                .and(output5.outputBuilder())
+                .and(output6.outputBuilder())
+                .accept(context, list);
+
+        assertThat(list).hasSize(6);
+
+        assertThat(list.get(0).getAddress()).isEqualTo(output1.getAddress());
+        assertThat(list.get(0).getValue().getCoin()).isEqualTo(adaToLovelace(10));
+        assertThat(list.get(0).getValue().getMultiAssets()).isEmpty();
+        assertThat(list.get(0).getInlineDatum()).isNull();
+        assertThat(list.get(0).getScriptRef()).isNull();
+        assertThat(list.get(0).getDatumHash()).isNull();
+
+        assertThat(list.get(1).getAddress()).isEqualTo(output1.getAddress());
+        assertThat(list.get(1).getValue().getCoin()).isGreaterThan(adaToLovelace(1));
+        assertThat(list.get(1).getValue().getCoin()).isLessThan(adaToLovelace(2)); //min ada
+        assertThat(list.get(1).getValue().getMultiAssets()).containsExactly(
+                MultiAsset.builder()
+                        .policyId(policy.getPolicyId())
+                        .assets(List.of(
+                                new Asset("abc", BigInteger.valueOf(1000))
+                        )).build()
+        );
+        assertThat(list.get(1).getInlineDatum()).isEqualTo(new BytesPlutusData("output2".getBytes()));
+        assertThat(list.get(1).getScriptRef()).isEqualTo(new byte[]{-126, 2, 73, 72, 1, 0, 0, 34, 33, 32, 1, 1});
+        assertThat(list.get(1).getDatumHash()).isNull();
+
+        assertThat(list.get(2).getAddress()).isEqualTo(output3.getAddress());
+        assertThat(list.get(2).getValue().getCoin()).isGreaterThan(adaToLovelace(1));
+        assertThat(list.get(2).getValue().getCoin()).isLessThan(adaToLovelace(2)); //min ada
+        assertThat(list.get(2).getValue().getMultiAssets()).containsExactly(
+                MultiAsset.builder()
+                        .policyId(policy.getPolicyId())
+                        .assets(List.of(
+                                new Asset("xyz", BigInteger.valueOf(2000))
+                        )).build()
+        );
+        assertThat(list.get(2).getInlineDatum()).isEqualTo(new BytesPlutusData("output3".getBytes()));
+        assertThat(list.get(2).getScriptRef()).isNull();
+        assertThat(list.get(2).getDatumHash()).isNull();
+
+        assertThat(list.get(3).getAddress()).isEqualTo(output4.getAddress());
+        assertThat(list.get(3).getValue().getCoin()).isGreaterThan(adaToLovelace(1));
+        assertThat(list.get(3).getValue().getCoin()).isLessThan(adaToLovelace(2)); //min ada
+        assertThat(list.get(3).getValue().getMultiAssets()).containsExactly(
+                MultiAsset.builder()
+                        .policyId(policy2.getPolicyId())
+                        .assets(List.of(
+                                new Asset("xyz", BigInteger.valueOf(7000))
+                        )).build()
+        );
+        assertThat(list.get(3).getInlineDatum()).isEqualTo(new BytesPlutusData("output4".getBytes()));
+        assertThat(list.get(3).getScriptRef()).isNull();
+        assertThat(list.get(3).getDatumHash()).isNull();
+
+        assertThat(list.get(4).getAddress()).isEqualTo(output5.getAddress());
+        assertThat(list.get(4).getValue().getCoin()).isEqualTo(adaToLovelace(20));
+        assertThat(list.get(4).getValue().getMultiAssets()).isEmpty();
+        assertThat(list.get(4).getInlineDatum()).isNull();
+        assertThat(list.get(4).getScriptRef()).isNull();
+        assertThat(list.get(4).getDatumHash()).isNull();
+
+
+        assertThat(list.get(5).getAddress()).isEqualTo(output5.getAddress());
+        assertThat(list.get(5).getValue().getCoin()).isGreaterThan(adaToLovelace(1));
+        assertThat(list.get(5).getValue().getCoin()).isLessThan(adaToLovelace(2)); //min ada
+        assertThat(list.get(5).getValue().getMultiAssets()).containsExactly(
+                MultiAsset.builder()
+                        .policyId(policy2.getPolicyId())
+                        .assets(List.of(
+                                new Asset("xyz", BigInteger.valueOf(50))
+                        )).build()
+        );
+        assertThat(list.get(5).getInlineDatum()).isNull();
+        assertThat(list.get(5).getScriptRef()).isNull();
+        assertThat(list.get(5).getDatumHash()).isNull();
+    }
+
+    @Test
+    void testCreateFromOutput2_isMergeOutputsTrue() throws Exception {
+        Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("abc-policy", 1);
+
+        TransactionOutput output1 = TransactionOutput.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .value(Value.builder()
+                        .coin(adaToLovelace(10))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policy.getPolicyId())
+                                        .assets(List.of(
+                                                new Asset("abc", BigInteger.valueOf(1000))
+                                        )).build()
+                        )).build()
+                )
+                .datumHash(BytesPlutusData.of("output1").getDatumHashAsBytes())
+                .scriptRef(new byte[]{1, 2, 3, 4})
+                .build();
+
+        Output output2 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(210))
+                .build();
+
+        TransactionOutput output3 = TransactionOutput.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .value(Value.builder()
+                        .coin(adaToLovelace(20))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policy.getPolicyId())
+                                        .assets(List.of(
+                                                new Asset("abc", BigInteger.valueOf(2000))
+                                        )).build(),
+                                MultiAsset.builder()
+                                        .policyId(policy.getPolicyId())
+                                        .assets(List.of(
+                                                new Asset("xyz", BigInteger.valueOf(50))
+                                        )).build()
+                        )).build()
+                )
+                .datumHash(new BytesPlutusData("output3".getBytes()).getDatumHashAsBytes())
+                .build();
+
+        TransactionOutput output4 = TransactionOutput.builder()
+                .address("addr_test1qq8phk43ndg0zf2l4xc5vd7gu4f85swkm3dy7fjmfkf6q249ygmm3ascevccsq5l5ym6khc3je5plx9t5vsa06jvlzls8el07z")
+                .value(Value.builder()
+                        .coin(adaToLovelace(20)).build()
+                )
+                .inlineDatum(new BytesPlutusData("output4".getBytes()))
+                .build();
+
+        TxBuilderContext context = new TxBuilderContext(utxoSupplier, protocolParams);
+        List<TransactionOutput> list = new ArrayList<>();
+
+        createFromOutput(output1)
+                .and(output2.outputBuilder())
+                .and(createFromOutput(output3))
+                .and(createFromOutput(output4))
+                .accept(context, list);
+
+        assertThat(list).hasSize(3);
+        assertThat(list.get(0).getAddress()).isEqualTo(output1.getAddress());
+        assertThat(list.get(0).getValue().getCoin()).isEqualTo(adaToLovelace(30));
+        assertThat(list.get(0).getValue().getMultiAssets()).containsOnly(
+                MultiAsset.builder()
+                        .policyId(policy.getPolicyId())
+                        .assets(List.of(
+                                new Asset("abc", BigInteger.valueOf(3000)),
+                                new Asset("xyz", BigInteger.valueOf(50))
+                        )).build()
+        );
+        assertThat(list.get(0).getDatumHash()).isEqualTo(BytesPlutusData.of("output1").getDatumHashAsBytes());
+        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[]{1, 2, 3, 4});
+
+        assertThat(list.get(1).getAddress()).isEqualTo(output2.getAddress());
+        assertThat(list.get(1).getValue().getCoin()).isEqualTo(adaToLovelace(210));
+        assertThat(list.get(1).getDatumHash()).isNull();
+        assertThat(list.get(1).getInlineDatum()).isNull();
+
+        assertThat(list.get(2).getAddress()).isEqualTo(output4.getAddress());
+        assertThat(list.get(2).getValue().getCoin()).isEqualTo(adaToLovelace(20));
+        assertThat(list.get(2).getDatumHash()).isNull();
+        assertThat(list.get(2).getInlineDatum()).isEqualTo(new BytesPlutusData("output4".getBytes()));
+    }
+
+    @Test
+    void testCreateFromOutput2_isMergeOutputsFalse() throws Exception {
+        Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("abc-policy", 1);
+
+        TransactionOutput output1 = TransactionOutput.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .value(Value.builder()
+                        .coin(adaToLovelace(10))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policy.getPolicyId())
+                                        .assets(List.of(
+                                                new Asset("abc", BigInteger.valueOf(1000))
+                                        )).build()
+                        )).build()
+                )
+                .datumHash(BytesPlutusData.of("output1").getDatumHashAsBytes())
+                .scriptRef(new byte[]{1, 2, 3, 4})
+                .build();
+
+        Output output2 = Output.builder()
+                .address("addr_test1qq46hhhpppek6e33hqakqyu2z5xeqwlc4pc0xynwamn34l6vps306wwr475xeh2lnt4hqjm4mfyjqnvla9j5wtc3fxespv67ka")
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(210))
+                .build();
+
+        TransactionOutput output3 = TransactionOutput.builder()
+                .address("addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c")
+                .value(Value.builder()
+                        .coin(adaToLovelace(20))
+                        .multiAssets(List.of(
+                                MultiAsset.builder()
+                                        .policyId(policy.getPolicyId())
+                                        .assets(List.of(
+                                                new Asset("abc", BigInteger.valueOf(2000)),
+                                                new Asset("xyz", BigInteger.valueOf(50))
+                                        )).build()
+                        )).build()
+                )
+                .inlineDatum(new BytesPlutusData("output3".getBytes()))
+                .build();
+
+        TransactionOutput output4 = TransactionOutput.builder()
+                .address("addr_test1qq8phk43ndg0zf2l4xc5vd7gu4f85swkm3dy7fjmfkf6q249ygmm3ascevccsq5l5ym6khc3je5plx9t5vsa06jvlzls8el07z")
+                .value(Value.builder()
+                        .coin(adaToLovelace(20)).build()
+                )
+                .inlineDatum(new BytesPlutusData("output4".getBytes()))
+                .build();
+
+        TxBuilderContext context = new TxBuilderContext(utxoSupplier, protocolParams);
+        context.mergeOutputs(false);
+        List<TransactionOutput> list = new ArrayList<>();
+
+        createFromOutput(output1)
+                .and(output2.outputBuilder())
+                .and(createFromOutput(output3))
+                .and(createFromOutput(output4))
+                .accept(context, list);
+
+        assertThat(list).hasSize(4);
+        assertThat(list.get(0).getAddress()).isEqualTo(output1.getAddress());
+        assertThat(list.get(0).getValue().getCoin()).isEqualTo(adaToLovelace(10));
+        assertThat(list.get(0).getValue().getMultiAssets()).containsOnly(
+                MultiAsset.builder()
+                        .policyId(policy.getPolicyId())
+                        .assets(List.of(
+                                new Asset("abc", BigInteger.valueOf(1000))
+                        )).build()
+        );
+        assertThat(list.get(0).getDatumHash()).isEqualTo(BytesPlutusData.of("output1").getDatumHashAsBytes());
+        assertThat(list.get(0).getScriptRef()).isEqualTo(new byte[]{1, 2, 3, 4});
+
+        assertThat(list.get(1).getAddress()).isEqualTo(output2.getAddress());
+        assertThat(list.get(1).getValue().getCoin()).isEqualTo(adaToLovelace(210));
+        assertThat(list.get(1).getDatumHash()).isNull();
+        assertThat(list.get(1).getInlineDatum()).isNull();
+
+        assertThat(list.get(2).getAddress()).isEqualTo(output1.getAddress());
+        assertThat(list.get(2).getValue().getCoin()).isEqualTo(adaToLovelace(20));
+        assertThat(list.get(2).getValue().getMultiAssets()).containsExactlyInAnyOrder(
+                MultiAsset.builder()
+                        .policyId(policy.getPolicyId())
+                        .assets(List.of(
+                                new Asset("abc", BigInteger.valueOf(2000)),
+                                new Asset("xyz", BigInteger.valueOf(50))
+                        )).build()
+        );
+        assertThat(list.get(2).getInlineDatum()).isEqualTo(BytesPlutusData.of("output3"));
+        assertThat(list.get(2).getDatumHash()).isNull();
+        assertThat(list.get(2).getScriptRef()).isNull();
+
+        assertThat(list.get(3).getAddress()).isEqualTo(output4.getAddress());
+        assertThat(list.get(3).getValue().getCoin()).isEqualTo(adaToLovelace(20));
+        assertThat(list.get(3).getDatumHash()).isNull();
+        assertThat(list.get(3).getInlineDatum()).isEqualTo(new BytesPlutusData("output4".getBytes()));
+    }
+
+
 }

--- a/function/src/test/resources/utxos-function.json
+++ b/function/src/test/resources/utxos-function.json
@@ -450,5 +450,36 @@
       "block": "eee6cd082d297f85406cff49f83aa3ebd1083dae3c8997ec03f4a17f49297bf6",
       "data_hash": null
     }
+  ],
+
+  "list9-merge_outputs_true": [
+    {
+      "tx_hash": "d60669420bc15d3f359b74f5177cd4035325c22f7a67cf96d466472acf145ecb",
+      "tx_index": 0,
+      "output_index": 0,
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "3200000"
+        }
+      ],
+      "block": "eee6cd082d297f85406cff49f83aa3ebd1083dae3c8997ec03f4a17f49297bf6",
+      "data_hash": null
+    }
+  ],
+  "list10-merge_outputs_false": [
+    {
+      "tx_hash": "d60669420bc15d3f359b74f5177cd4035325c22f7a67cf96d466472acf145ecb",
+      "tx_index": 0,
+      "output_index": 0,
+      "amount": [
+        {
+          "unit": "lovelace",
+          "quantity": "5000000"
+        }
+      ],
+      "block": "eee6cd082d297f85406cff49f83aa3ebd1083dae3c8997ec03f4a17f49297bf6",
+      "data_hash": null
+    }
   ]
 }

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/function/TxBuilderContextIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/function/TxBuilderContextIT.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.client.api.UtxoSupplier;
 import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.client.api.model.ProtocolParams;
 import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.api.util.PolicyUtil;
 import com.bloxbean.cardano.client.backend.api.BackendService;
 import com.bloxbean.cardano.client.backend.api.BaseITTest;
 import com.bloxbean.cardano.client.backend.api.DefaultUtxoSupplier;
@@ -23,7 +24,6 @@ import com.bloxbean.cardano.client.metadata.cbor.CBORMetadataList;
 import com.bloxbean.cardano.client.metadata.cbor.CBORMetadataMap;
 import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.util.JsonUtil;
-import com.bloxbean.cardano.client.api.util.PolicyUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,9 +40,10 @@ import static com.bloxbean.cardano.client.function.helper.InputBuilders.createFr
 import static com.bloxbean.cardano.client.function.helper.MintCreators.mintCreator;
 import static com.bloxbean.cardano.client.function.helper.OutputBuilders.createFromMintOutput;
 import static com.bloxbean.cardano.client.function.helper.SignerProviders.signerFrom;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TxBuilderContextTest extends BaseITTest {
+public class TxBuilderContextIT extends BaseITTest {
     BackendService backendService;
     UtxoSupplier utxoSupplier;
     ProtocolParams protocolParams;
@@ -532,6 +533,266 @@ public class TxBuilderContextTest extends BaseITTest {
         Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
         System.out.println(result);
         assertTrue(result.isSuccessful());
+
+        if (result.isSuccessful())
+            System.out.println("Transaction Id: " + result.getValue());
+        else
+            System.out.println("Transaction failed: " + result);
+
+        waitForTransaction(result);
+    }
+
+    @Test
+    void testPayments_whenMergeOutputTrue() throws Exception {
+        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
+        Account sender = new Account(Networks.testnet(), senderMnemonic);
+        String senderAddress = sender.baseAddress();
+
+        String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
+        String receiver2 = "addr_test1qq9f6hzuwmqpe3p9h90z2rtgs0v0lsq9ln5f79fjyec7eclg7v88q9als70uzkdh5k6hw20uuwqfz477znfp5v4rga2s3ysgxu";
+        String receiver3 = "addr_test1qqqvjp4ffcdqg3fmx0k8rwamnn06wp8e575zcv8d0m3tjn2mmexsnkxp7az774522ce4h3qs4tjp9rxjjm46qf339d9sk33rqn";
+
+        Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("policy-1", 1);
+
+        //Multi asset and NFT metadata
+        //NFT-1
+        MultiAsset multiAsset1 = new MultiAsset();
+        multiAsset1.setPolicyId(policy.getPolicyId());
+        Asset asset = new Asset("TestNFT", BigInteger.valueOf(1));
+        multiAsset1.getAssets().add(asset);
+
+        NFT nft1 = NFT.create()
+                .assetName(asset.getName())
+                .name(asset.getName())
+                .image("ipfs://Qmcv6hwtmdVumrNeb42R1KmCEWdYWGcqNgs17Y3hj6CkP4")
+                .mediaType("image/png")
+                .addFile(NFTFile.create()
+                        .name("file-1")
+                        .mediaType("image/png")
+                        .src("ipfs/Qmcv6hwtmdVumrNeb42R1KmCEWdYWGcqNgs17Y3hj6CkP4"))
+                .description("This is a test NFT");
+
+        //NFT-2
+        MultiAsset multiAsset2 = new MultiAsset();
+        multiAsset2.setPolicyId(policy.getPolicyId());
+        Asset asset2 = new Asset("TestNFT", BigInteger.valueOf(1));
+        multiAsset2.getAssets().add(asset2);
+
+        NFT nft2 = NFT.create()
+                .assetName(asset.getName())
+                .name(asset.getName())
+                .image("ipfs://Qmcv6hwtmdVumrNeb42R1KmCEWdYWGcqNgs17Y3hj6CkP4")
+                .mediaType("image/png")
+                .addFile(NFTFile.create()
+                        .name("file-1")
+                        .mediaType("image/png")
+                        .src("ipfs/Qmcv6hwtmdVumrNeb42R1KmCEWdYWGcqNgs17Y3hj6CkP4"))
+                .description("This is a test NFT");
+
+        NFTMetadata nftMetadata = NFTMetadata.create()
+                .version("1.0")
+                .addNFT(policy.getPolicyId(), nft1)
+                .addNFT(policy.getPolicyId(), nft2);
+
+        //Define outputs
+        //Output using Output class
+
+        Output output1 = Output.builder()
+                .address(receiver1)
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(2.3))
+                .build();
+        Output output11 = Output.builder()
+                .address(receiver1)
+                .policyId(policy.getPolicyId())
+                .assetName("TestNFT")
+                .qty(BigInteger.valueOf(1))
+                .build();
+
+        Output output2 = Output.builder()
+                .address(receiver2)
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(1.8))
+                .build();
+        Output output21 = Output.builder()
+                .address(receiver2)
+                .policyId(policy.getPolicyId())
+                .assetName("TestNFT")
+                .qty(BigInteger.valueOf(1))
+                .build();
+
+        //Output using new Output class
+        Output output3 = Output.builder()
+                .address(receiver3)
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(4)).build();
+
+        MultiAsset mergeMultiAsset = multiAsset1.plus(multiAsset2);
+
+        //Create TxBuilder function
+        TxBuilder txBuilder =
+                output1.outputBuilder()
+                        .and(output11.mintOutputBuilder())
+                        .and(output2.outputBuilder())
+                        .and(output21.mintOutputBuilder())
+                        .and(createFromMintOutput(output3)) //An alternate way
+                        .buildInputs(createFromSender(senderAddress, senderAddress))
+                        .andThen(mintCreator(policy.getPolicyScript(), mergeMultiAsset))
+                        .andThen(metadataProvider(nftMetadata))
+                        .andThen(balanceTx(senderAddress, 2));
+
+        //Build and sign transaction
+        Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
+                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+
+        assertThat(signedTransaction.getBody().getOutputs()).hasSize(4); //Total 4 outputs including change output
+        assertThat(signedTransaction.getBody().getOutputs().get(0).getValue().getCoin()).isEqualTo(adaToLovelace(2.3));
+        assertThat(signedTransaction.getBody().getOutputs().get(0).getValue().getMultiAssets()).hasSize(1);
+        assertThat(signedTransaction.getBody().getOutputs().get(1).getValue().getCoin()).isEqualTo(adaToLovelace(1.8));
+        assertThat(signedTransaction.getBody().getOutputs().get(1).getValue().getMultiAssets()).hasSize(1);
+        assertThat(signedTransaction.getBody().getOutputs().get(2).getValue().getCoin()).isEqualTo(adaToLovelace(4));
+        assertThat(signedTransaction.getBody().getOutputs().get(2).getValue().getMultiAssets()).hasSize(0);
+
+        Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
+        System.out.println(result);
+
+        if (result.isSuccessful())
+            System.out.println("Transaction Id: " + result.getValue());
+        else
+            System.out.println("Transaction failed: " + result);
+
+        waitForTransaction(result);
+    }
+
+    @Test
+    void testPayments_whenMergeOutputFalse() throws Exception {
+        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
+        Account sender = new Account(Networks.testnet(), senderMnemonic);
+        String senderAddress = sender.baseAddress();
+
+        String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
+        String receiver2 = "addr_test1qq9f6hzuwmqpe3p9h90z2rtgs0v0lsq9ln5f79fjyec7eclg7v88q9als70uzkdh5k6hw20uuwqfz477znfp5v4rga2s3ysgxu";
+        String receiver3 = "addr_test1qqqvjp4ffcdqg3fmx0k8rwamnn06wp8e575zcv8d0m3tjn2mmexsnkxp7az774522ce4h3qs4tjp9rxjjm46qf339d9sk33rqn";
+
+        Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("policy-1", 1);
+
+        //Multi asset and NFT metadata
+        //NFT-1
+        MultiAsset multiAsset1 = new MultiAsset();
+        multiAsset1.setPolicyId(policy.getPolicyId());
+        Asset asset = new Asset("TestNFT", BigInteger.valueOf(1));
+        multiAsset1.getAssets().add(asset);
+
+        NFT nft1 = NFT.create()
+                .assetName(asset.getName())
+                .name(asset.getName())
+                .image("ipfs://Qmcv6hwtmdVumrNeb42R1KmCEWdYWGcqNgs17Y3hj6CkP4")
+                .mediaType("image/png")
+                .addFile(NFTFile.create()
+                        .name("file-1")
+                        .mediaType("image/png")
+                        .src("ipfs/Qmcv6hwtmdVumrNeb42R1KmCEWdYWGcqNgs17Y3hj6CkP4"))
+                .description("This is a test NFT");
+
+        //NFT-2
+        MultiAsset multiAsset2 = new MultiAsset();
+        multiAsset2.setPolicyId(policy.getPolicyId());
+        Asset asset2 = new Asset("TestNFT", BigInteger.valueOf(1));
+        multiAsset2.getAssets().add(asset2);
+
+        NFT nft2 = NFT.create()
+                .assetName(asset.getName())
+                .name(asset.getName())
+                .image("ipfs://Qmcv6hwtmdVumrNeb42R1KmCEWdYWGcqNgs17Y3hj6CkP4")
+                .mediaType("image/png")
+                .addFile(NFTFile.create()
+                        .name("file-1")
+                        .mediaType("image/png")
+                        .src("ipfs/Qmcv6hwtmdVumrNeb42R1KmCEWdYWGcqNgs17Y3hj6CkP4"))
+                .description("This is a test NFT");
+
+        NFTMetadata nftMetadata = NFTMetadata.create()
+                .version("1.0")
+                .addNFT(policy.getPolicyId(), nft1)
+                .addNFT(policy.getPolicyId(), nft2);
+
+        //Define outputs
+        //Output using Output class
+
+        Output output1 = Output.builder()
+                .address(receiver1)
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(2.3))
+                .build();
+        Output output11 = Output.builder()
+                .address(receiver1)
+                .policyId(policy.getPolicyId())
+                .assetName("TestNFT")
+                .qty(BigInteger.valueOf(1))
+                .build();
+
+        Output output2 = Output.builder()
+                .address(receiver2)
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(1.8))
+                .build();
+        Output output21 = Output.builder()
+                .address(receiver2)
+                .policyId(policy.getPolicyId())
+                .assetName("TestNFT")
+                .qty(BigInteger.valueOf(1))
+                .build();
+
+        //Output using new Output class
+        Output output3 = Output.builder()
+                .address(receiver3)
+                .assetName(LOVELACE)
+                .qty(adaToLovelace(4)).build();
+
+        MultiAsset mergeMultiAsset = multiAsset1.plus(multiAsset2);
+
+        //Create TxBuilder function
+        TxBuilder txBuilder =
+                output1.outputBuilder()
+                        .and(output11.mintOutputBuilder())
+                        .and(output2.outputBuilder())
+                        .and(output21.mintOutputBuilder())
+                        .and(createFromMintOutput(output3)) //An alternate way
+                        .buildInputs(createFromSender(senderAddress, senderAddress))
+                        .andThen(mintCreator(policy.getPolicyScript(), mergeMultiAsset))
+                        .andThen(metadataProvider(nftMetadata))
+                        .andThen(balanceTx(senderAddress, 2));
+
+        //Build and sign transaction
+        Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
+                .mergeOutputs(false)
+                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+
+        assertThat(signedTransaction.getBody().getOutputs()).hasSize(6); //Total 4 outputs including change output
+        assertThat(signedTransaction.getBody().getOutputs().get(0).getAddress()).isEqualTo(receiver1);
+        assertThat(signedTransaction.getBody().getOutputs().get(0).getValue().getCoin()).isEqualTo(adaToLovelace(2.3));
+        assertThat(signedTransaction.getBody().getOutputs().get(0).getValue().getMultiAssets()).isEmpty();
+
+        assertThat(signedTransaction.getBody().getOutputs().get(1).getAddress()).isEqualTo(receiver1);
+        assertThat(signedTransaction.getBody().getOutputs().get(1).getValue().getCoin()).isLessThan(adaToLovelace(2)); //min ada
+        assertThat(signedTransaction.getBody().getOutputs().get(1).getValue().getMultiAssets()).hasSize(1);
+
+        assertThat(signedTransaction.getBody().getOutputs().get(2).getAddress()).isEqualTo(receiver2);
+        assertThat(signedTransaction.getBody().getOutputs().get(2).getValue().getCoin()).isEqualTo(adaToLovelace(1.8));
+        assertThat(signedTransaction.getBody().getOutputs().get(2).getValue().getMultiAssets()).hasSize(0);
+
+        assertThat(signedTransaction.getBody().getOutputs().get(3).getAddress()).isEqualTo(receiver2);
+        assertThat(signedTransaction.getBody().getOutputs().get(3).getValue().getCoin()).isLessThan(adaToLovelace(2)); //min ada
+        assertThat(signedTransaction.getBody().getOutputs().get(3).getValue().getMultiAssets()).hasSize(1);
+
+        assertThat(signedTransaction.getBody().getOutputs().get(4).getAddress()).isEqualTo(receiver3);
+        assertThat(signedTransaction.getBody().getOutputs().get(4).getValue().getCoin()).isEqualTo(adaToLovelace(4));
+        assertThat(signedTransaction.getBody().getOutputs().get(4).getValue().getMultiAssets()).isEmpty();
+
+        assertThat(signedTransaction.getBody().getOutputs().get(5).getAddress()).isEqualTo(senderAddress);
+
+        Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
+        System.out.println(result);
 
         if (result.isSuccessful())
             System.out.println("Transaction Id: " + result.getValue());

--- a/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/ScriptTxIT.java
+++ b/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/ScriptTxIT.java
@@ -293,7 +293,7 @@ public class ScriptTxIT extends QuickTxBaseIT {
                 .feePayer(sender2Addr)
                 .withSigner(SignerProviders.signerFrom(sender1))
                 .withSigner(SignerProviders.signerFrom(sender2))
-                .mergeChangeOutputs(false)
+                .mergeOutputs(false)
                 .withTxInspector(txn -> System.out.println(JsonUtil.getPrettyJson(txn)))
                 .withTxEvaluator(!backendType.equals(BLOCKFROST)?
                         new AikenTransactionEvaluator(utxoSupplier, protocolParamsSupplier): null)
@@ -374,7 +374,7 @@ public class ScriptTxIT extends QuickTxBaseIT {
                 .withSigner(SignerProviders.signerFrom(sender2))
                 .withTxEvaluator(!backendType.equals(BLOCKFROST)?
                         new AikenTransactionEvaluator(utxoSupplier, protocolParamsSupplier): null)
-                .mergeChangeOutputs(false)
+                .mergeOutputs(false)
                 .completeAndWait(System.out::println);
 
         System.out.println(result1.getResponse());
@@ -455,7 +455,7 @@ public class ScriptTxIT extends QuickTxBaseIT {
                 .withSigner(SignerProviders.signerFrom(sender2))
                 .withTxEvaluator(!backendType.equals(BLOCKFROST)?
                         new AikenTransactionEvaluator(utxoSupplier, protocolParamsSupplier): null)
-                .mergeChangeOutputs(false)
+                .mergeOutputs(false)
                 .completeAndWait(System.out::println);
 
         System.out.println(result1.getResponse());
@@ -491,7 +491,7 @@ public class ScriptTxIT extends QuickTxBaseIT {
         Result<String> result1 = quickTxBuilder.compose(scriptTx)
                 .feePayer(sender2Addr)
                 .withSigner(SignerProviders.signerFrom(sender2))
-                .mergeChangeOutputs(false)
+                .mergeOutputs(false)
                 .withTxInspector(tx -> System.out.println(JsonUtil.getPrettyJson(tx)))
                 .withTxEvaluator(!backendType.equals(BLOCKFROST)?
                         new AikenTransactionEvaluator(utxoSupplier, protocolParamsSupplier): null)

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
@@ -20,7 +20,6 @@ import com.bloxbean.cardano.client.function.TxBuilderContext;
 import com.bloxbean.cardano.client.function.TxSigner;
 import com.bloxbean.cardano.client.function.exception.TxBuildException;
 import com.bloxbean.cardano.client.function.helper.CollateralBuilders;
-import com.bloxbean.cardano.client.function.helper.OutputMergers;
 import com.bloxbean.cardano.client.function.helper.ScriptCostEvaluators;
 import com.bloxbean.cardano.client.function.helper.ScriptBalanceTxProviders;
 import com.bloxbean.cardano.client.transaction.spec.Transaction;
@@ -121,7 +120,7 @@ public class QuickTxBuilder {
         private long validFrom;
         private long validTo;
 
-        private boolean mergeChangeOutputs = true;
+        private boolean mergeOutputs = true;
 
         private TransactionEvaluator txnEvaluator;
         private UtxoSelectionStrategy utxoSelectionStrategy;
@@ -216,6 +215,9 @@ public class QuickTxBuilder {
             int totalSigners = getTotalSigners();
 
             TxBuilderContext txBuilderContext = TxBuilderContext.init(utxoSupplier, protocolParamsSupplier);
+            //Set merge outputs flag
+            txBuilderContext.mergeOutputs(mergeOutputs);
+
             //Set tx evaluator for script cost calculation
             if (txnEvaluator != null)
                 txBuilderContext.withTxnEvaluator(txnEvaluator);
@@ -247,10 +249,6 @@ public class QuickTxBuilder {
                     collateralPayer = feePayer;
                 txBuilder = txBuilder.andThen(buildCollateralOutput(collateralPayer));
             }
-
-            //Merge outputs if required
-            if (mergeChangeOutputs)
-                txBuilder = txBuilder.andThen(OutputMergers.mergeOutputsForAddress(feePayer));
 
             if (containsScriptTx) {
                 txBuilder = txBuilder.andThen(((context, transaction) -> {
@@ -465,14 +463,14 @@ public class QuickTxBuilder {
         }
 
         /**
-         * Define if change outputs should be merged or not
+         * Define if outputs with the same address should be merged into one output.
          * Default is true
          *
          * @param merge
          * @return TxContext
          */
-        public TxContext mergeChangeOutputs(boolean merge) {
-            this.mergeChangeOutputs = merge;
+        public TxContext mergeOutputs(boolean merge) {
+            this.mergeOutputs = merge;
             return this;
         }
 


### PR DESCRIPTION
To fix #285 and enhancement

1. Added the ``mergeOutputs`` method to the ``TxBuilderContext`` of the Composable Function API. By default, this is set to true, meaning that outputs with the same address will be merged together. If mergeOutputs is set to false, the final outputs will remain as defined by the application.

2. Added the mergeOutputs method to the QuickTxBuilder of QuickTx. By default, this is also true. The behavior is exactly the same as in the first point.

## Examples:

### Composable Functions

Defined outputs and TxBuilder

```
Output mintOutput = Output.builder()
                .address(senderAddress)
                .policyId(policy.getPolicyId())
                .assetName("TestNFT")
                .qty(BigInteger.valueOf(100))
                .build();

Output feeOutput = Output.builder()
                .address(receiver1)
                .assetName(LOVELACE)
                .qty(adaToLovelace(1))
                .build();

//Create TxBuilder function
TxBuilder txBuilder =
                mintOutput.mintOutputBuilder()
                        .and(feeOutput.mintOutputBuilder())
                        .buildInputs(createFromSender(senderAddress, senderAddress))
                        .andThen(mintCreator(policy.getPolicyScript(), multiAsset1))
                        .andThen(balanceTx(senderAddress, 2));

```

**a. Example of merge outputs = true . By default, ``mergeOutputs`` is true.** 

There will be two outputs in the final transaction. One for receiver and another one is for sender

```
 //Build and sign transaction
Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
```

**b. Example of merge outputs = false .** 

If mergeOutputs flag is false, we will have total 3 outputs. 2 outputs same as application defined outputs and 1 change output.

```
 //Build and sign transaction
Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
                .mergeOutputs(false)
                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
```

### QuickTx api

For QuickTx,  mergeOutputs flag can be set through ``QuickTxBuilder.mergeOutputs(boolean)``

```
Tx tx = new Tx()
                .payToAddress(sender1Addr, Amount.ada(1))
                .mintAssets(policy.getPolicyScript(), new Asset("MyAsset", BigInteger.valueOf(1)), receiver1)
                .from(sender1Addr);
```


**a.  mergeOutput = true. By default, it's true.** 

```
 Result<String> result = quickTxBuilder.compose(tx)
                .withSigner(SignerProviders.signerFrom(sender1))
                .withSigner(SignerProviders.signerFrom(policy))
                .completeAndWait(System.out::println);
``` 

**b. mergeOutput = false**

```
 Result<String> result = quickTxBuilder.compose(tx)
                .mergeOutputs(false)
                .withSigner(SignerProviders.signerFrom(sender1))
                .withSigner(SignerProviders.signerFrom(policy))
                .completeAndWait(System.out::println);
```