### PR TITLE
fix: #280 Use guava's UnsignedBytes.lexicographicalComparator to avoi…

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     api(libs.co.nstant.in.cbor)
     api(libs.jackson.databind)
+    implementation(libs.guava)
 }
 
 publishing {

--- a/common/src/main/java/com/bloxbean/cardano/client/common/cbor/custom/CustomMapEncoder.java
+++ b/common/src/main/java/com/bloxbean/cardano/client/common/cbor/custom/CustomMapEncoder.java
@@ -7,10 +7,10 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.MajorType;
 import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.SimpleValue;
+import com.google.common.primitives.UnsignedBytes;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.TreeMap;
 
@@ -76,7 +76,7 @@ public class CustomMapEncoder extends MapEncoder {
          * lexical order sorts earlier.
          */
 
-        TreeMap<byte[], byte[]> sortedMap = new TreeMap<>(Arrays::compareUnsigned);
+        TreeMap<byte[], byte[]> sortedMap = new TreeMap<>(UnsignedBytes.lexicographicalComparator());
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         CborEncoder e = new CustomCborEncoder(byteArrayOutputStream);


### PR DESCRIPTION
To fix #280 

- To avoid no such method error, use Guava's UnsignedBytes.lexicographicalComparator instead of Java's Arrays::compareUnsigned 