### PR TITLE
Added AssetService.getTransactions, added Tuple.toString + equals & hashCode, change AddressProvider visibility

### DIFF
--- a/address/src/main/java/com/bloxbean/cardano/client/address/AddressProvider.java
+++ b/address/src/main/java/com/bloxbean/cardano/client/address/AddressProvider.java
@@ -375,7 +375,7 @@ public class AddressProvider {
         }
     }
 
-    public static Address getAddress(byte[] paymentKeyHash, byte[] stakeKeyHash, byte headerKind, Network networkInfo, AddressType addressType) {
+    private static Address getAddress(byte[] paymentKeyHash, byte[] stakeKeyHash, byte headerKind, Network networkInfo, AddressType addressType) {
         NetworkId network = getNetworkId(networkInfo);
 
         //get prefix

--- a/address/src/main/java/com/bloxbean/cardano/client/address/AddressProvider.java
+++ b/address/src/main/java/com/bloxbean/cardano/client/address/AddressProvider.java
@@ -388,7 +388,7 @@ public class AddressProvider {
         return new Address(prefix, addressArray);
     }
 
-    public static byte[] getAddressBytes(byte[] paymentKeyHash, byte[] stakeKeyHash, AddressType addressType, byte header) {
+    private static byte[] getAddressBytes(byte[] paymentKeyHash, byte[] stakeKeyHash, AddressType addressType, byte header) {
         //get body
         byte[] addressArray;
         switch (addressType) {

--- a/address/src/main/java/com/bloxbean/cardano/client/address/AddressProvider.java
+++ b/address/src/main/java/com/bloxbean/cardano/client/address/AddressProvider.java
@@ -375,7 +375,7 @@ public class AddressProvider {
         }
     }
 
-    private static Address getAddress(byte[] paymentKeyHash, byte[] stakeKeyHash, byte headerKind, Network networkInfo, AddressType addressType) {
+    public static Address getAddress(byte[] paymentKeyHash, byte[] stakeKeyHash, byte headerKind, Network networkInfo, AddressType addressType) {
         NetworkId network = getNetworkId(networkInfo);
 
         //get prefix
@@ -388,7 +388,7 @@ public class AddressProvider {
         return new Address(prefix, addressArray);
     }
 
-    private static byte[] getAddressBytes(byte[] paymentKeyHash, byte[] stakeKeyHash, AddressType addressType, byte header) {
+    public static byte[] getAddressBytes(byte[] paymentKeyHash, byte[] stakeKeyHash, AddressType addressType, byte header) {
         //get body
         byte[] addressArray;
         switch (addressType) {

--- a/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/BFAssetService.java
+++ b/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/BFAssetService.java
@@ -1,13 +1,14 @@
 package com.bloxbean.cardano.client.backend.blockfrost.service;
 
-import com.bloxbean.cardano.client.backend.api.AssetService;
 import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.backend.api.AssetService;
 import com.bloxbean.cardano.client.backend.blockfrost.service.http.AssetsApi;
 import com.bloxbean.cardano.client.backend.model.Asset;
 import com.bloxbean.cardano.client.backend.model.AssetAddress;
+import com.bloxbean.cardano.client.backend.model.AssetTransactionContent;
 import com.bloxbean.cardano.client.backend.model.PolicyAsset;
-import com.bloxbean.cardano.client.api.model.Result;
 import retrofit2.Call;
 import retrofit2.Response;
 
@@ -118,5 +119,24 @@ public class BFAssetService extends BFBaseService implements AssetService {
     @Override
     public Result<List<PolicyAsset>> getPolicyAssets(String policyId, int count, int page) throws ApiException {
         return getPolicyAssets(policyId, count, page, OrderEnum.asc);
+    }
+
+    @Override
+    public Result<List<AssetTransactionContent>> getTransactions(String unit, int count, int page, OrderEnum order) throws ApiException {
+        if(order == null)
+            order = OrderEnum.asc;
+
+        Call<List<AssetTransactionContent>> call = assetsApi.getTransactions(getProjectId(), unit, count, page, order.toString());
+
+        try {
+            Response<List<AssetTransactionContent>> response = call.execute();
+            if (response.isSuccessful())
+                return Result.success(response.toString()).withValue(response.body()).code(response.code());
+            else
+                return Result.error(response.errorBody().string()).code(response.code());
+
+        } catch (IOException e) {
+            throw new ApiException("Error getting asset transactions for " + unit , e);
+        }
     }
 }

--- a/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/BFAssetService.java
+++ b/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/BFAssetService.java
@@ -130,11 +130,7 @@ public class BFAssetService extends BFBaseService implements AssetService {
 
         try {
             Response<List<AssetTransactionContent>> response = call.execute();
-            if (response.isSuccessful())
-                return Result.success(response.toString()).withValue(response.body()).code(response.code());
-            else
-                return Result.error(response.errorBody().string()).code(response.code());
-
+            return processResponse(response);
         } catch (IOException e) {
             throw new ApiException("Error getting asset transactions for " + unit , e);
         }

--- a/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/http/AssetsApi.java
+++ b/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/http/AssetsApi.java
@@ -1,7 +1,9 @@
 package com.bloxbean.cardano.client.backend.blockfrost.service.http;
 
+import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.client.backend.model.Asset;
 import com.bloxbean.cardano.client.backend.model.AssetAddress;
+import com.bloxbean.cardano.client.backend.model.AssetTransactionContent;
 import com.bloxbean.cardano.client.backend.model.PolicyAsset;
 import retrofit2.Call;
 import retrofit2.http.GET;
@@ -48,4 +50,16 @@ public interface AssetsApi {
      */
     @GET("assets/policy/{policy_id}")
     Call<List<PolicyAsset>> assetsPolicyPolicyIdGet(@Header("project_id") String projectId, @Path("policy_id") String policyId, @Query("count") Integer count, @Query("page") Integer page, @Query("order") String order);
+
+    /**
+     * List of a specific asset transactions
+     *
+     * @param asset    Concatenation of the policy_id and hex-encoded asset_name (required)
+     * @param count    The number of results displayed on one page. (&lt;=100).
+     * @param page     The page number for listing the results.
+     * @param order    The ordering of items from the point of view of the blockchain, not the page listing itself. By default, we return oldest first, newest last.
+     * @return a list of a specific asset transactions
+     */
+    @GET("assets/{asset}/transactions")
+    Call<List<AssetTransactionContent>> getTransactions(@Header("project_id") String projectId, @Path("asset") String asset, @Query("count") Integer count, @Query("page") Integer page, @Query("order") String order);
 }

--- a/backend-modules/koios/src/main/java/com/bloxbean/cardano/client/backend/koios/KoiosAssetService.java
+++ b/backend-modules/koios/src/main/java/com/bloxbean/cardano/client/backend/koios/KoiosAssetService.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.api.util.AssetUtil;
 import com.bloxbean.cardano.client.backend.api.AssetService;
 import com.bloxbean.cardano.client.backend.model.Asset;
 import com.bloxbean.cardano.client.backend.model.AssetAddress;
+import com.bloxbean.cardano.client.backend.model.AssetTransactionContent;
 import com.bloxbean.cardano.client.backend.model.PolicyAsset;
 import com.bloxbean.cardano.client.util.Tuple;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -178,5 +179,10 @@ public class KoiosAssetService implements AssetService {
         if (asset == null || asset.equals("")) {
             throw new ApiException("Asset cannot be null or empty");
         }
+    }
+
+    @Override
+    public Result<List<AssetTransactionContent>> getTransactions(String asset, int count, int page, OrderEnum order) throws ApiException {
+        throw new UnsupportedOperationException("Not supported yet");
     }
 }

--- a/backend/src/main/java/com/bloxbean/cardano/client/backend/api/AssetService.java
+++ b/backend/src/main/java/com/bloxbean/cardano/client/backend/api/AssetService.java
@@ -2,9 +2,7 @@ package com.bloxbean.cardano.client.backend.api;
 
 import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.exception.ApiException;
-import com.bloxbean.cardano.client.backend.model.Asset;
-import com.bloxbean.cardano.client.backend.model.AssetAddress;
-import com.bloxbean.cardano.client.backend.model.PolicyAsset;
+import com.bloxbean.cardano.client.backend.model.*;
 import com.bloxbean.cardano.client.api.model.Result;
 
 import java.util.List;
@@ -83,4 +81,17 @@ public interface AssetService {
      * @return List&lt;PolicyAsset&gt;&gt;
      */
     Result<List<PolicyAsset>> getPolicyAssets(String policyId, int count, int page) throws ApiException;
+
+
+    /**
+     * List of a specific asset transactions
+     *
+     * @param asset    Concatenation of the policy_id and hex-encoded asset_name (required)
+     * @param count    The number of results displayed on one page. (&lt;=100).
+     * @param page     The page number for listing the results.
+     * @param order    The ordering of items from the point of view of the blockchain, not the page listing itself. By default, we return oldest first, newest last.
+     * @return a list of a specific asset transactions
+     * @throws ApiException
+     */
+    Result<List<AssetTransactionContent>> getTransactions(String asset, int count, int page, OrderEnum order) throws ApiException;
 }

--- a/backend/src/main/java/com/bloxbean/cardano/client/backend/model/AssetTransactionContent.java
+++ b/backend/src/main/java/com/bloxbean/cardano/client/backend/model/AssetTransactionContent.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.client.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AssetTransactionContent {
+    private String txHash;
+    private int txIndex;
+    private long blockHeight;
+    private long blockTime;
+}

--- a/common/src/main/java/com/bloxbean/cardano/client/util/Tuple.java
+++ b/common/src/main/java/com/bloxbean/cardano/client/util/Tuple.java
@@ -1,5 +1,10 @@
 package com.bloxbean.cardano.client.util;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
 public class Tuple<T, Z> {
     public T _1;
     public Z _2;

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/AssetServiceIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/AssetServiceIT.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.client.backend.model.Asset;
 import com.bloxbean.cardano.client.backend.model.AssetAddress;
+import com.bloxbean.cardano.client.backend.model.AssetTransactionContent;
 import com.bloxbean.cardano.client.backend.model.PolicyAsset;
 import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.util.JsonUtil;
@@ -115,5 +116,18 @@ public class AssetServiceIT extends BaseITTest {
         assertEquals(200, result.code());
         assertTrue(result.getValue().size() > 100);
         assertNotNull(result.getValue());
+    }
+
+    @Test
+    void getAssetTransactions() throws ApiException {
+        AssetService service = getBackendService().getAssetService();
+        Result<List<AssetTransactionContent>> result = service.getTransactions("0be55d262b29f564998ff81efe21bdc0022621c12f15af08d0f2ddb17cbbed4218ca44ca5a744aef7cf8b0287869b6ed5ce8fd47b012b0a21e509edc", 1, 1, OrderEnum.desc);
+
+        System.out.println(JsonUtil.getPrettyJson(result.getValue()));
+        assertTrue(result.isSuccessful());
+        assertEquals(200, result.code());
+        assertEquals(1, result.getValue().size());
+        assertNotNull(result.getValue());
+        assertNotNull(result.getValue().get(0).getTxHash());
     }
 }


### PR DESCRIPTION
- added `getTransactions` to `AssetService` (https://docs.blockfrost.io/#tag/Cardano-Assets/paths/~1assets~1%7Basset%7D~1transactions/get)
	this method is particularly useful for efficiently fetching DEX pool txs

- add `@ToString` and `@EqualsAndHashCode` to `com.bloxbean.cardano.client.util.Tuple`
	for easier debugging and comparing

- changed visibility of 1 `AddressProvider` method
	for easier conversion of stake and payment key hash to address