### PR TITLE
fix: #339 handle when asset name is invalid hex string

### DIFF
--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/Asset.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/Asset.java
@@ -25,7 +25,12 @@ public class Asset {
         if (name != null && !name.isEmpty()) {
             //Check if caller has provided a hex string as asset name
             if (name.startsWith("0x")) {
-                assetNameBytes = HexUtil.decodeHexString(name.substring(2));
+                try {
+                    assetNameBytes = HexUtil.decodeHexString(name.substring(2));
+                } catch (IllegalArgumentException e) {
+                    // name is not actually a hex string
+                    assetNameBytes = name.getBytes(StandardCharsets.UTF_8);
+                }
             } else {
                 assetNameBytes = name.getBytes(StandardCharsets.UTF_8);
             }

--- a/transaction-spec/src/test/java/com/bloxbean/cardano/client/transaction/spec/AssetSpecTest.java
+++ b/transaction-spec/src/test/java/com/bloxbean/cardano/client/transaction/spec/AssetSpecTest.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.client.transaction.spec;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -74,5 +75,13 @@ class AssetSpecTest {
         Asset asset2 = Asset.builder().name("asset1").value(BigInteger.valueOf(500L)).build();
 
         assertThat(asset1).isNotEqualTo(asset2);
+    }
+
+    @Test
+    void invalidHexName() {
+        Asset asset = Asset.builder().name("0xtest").value(BigInteger.valueOf(700L)).build();
+
+        byte[] expectedBytes = "0xtest".getBytes(StandardCharsets.UTF_8);
+        assertThat(asset.getNameAsBytes()).isEqualTo(expectedBytes);
     }
 }


### PR DESCRIPTION
Hi @satran004 , I've fixed for issue #339. Could you take a look at this PR?