### PR TITLE
New Koios + BF Support for resolving Transactions Data by Payment/Staking Addresses

### DIFF
--- a/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/BFAddressService.java
+++ b/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/BFAddressService.java
@@ -1,17 +1,18 @@
 package com.bloxbean.cardano.client.backend.blockfrost.service;
 
-import com.bloxbean.cardano.client.backend.api.AddressService;
 import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.backend.api.AddressService;
 import com.bloxbean.cardano.client.backend.blockfrost.service.http.AddressesApi;
 import com.bloxbean.cardano.client.backend.model.AddressContent;
 import com.bloxbean.cardano.client.backend.model.AddressDetails;
 import com.bloxbean.cardano.client.backend.model.AddressTransactionContent;
-import com.bloxbean.cardano.client.api.model.Result;
 import retrofit2.Call;
 import retrofit2.Response;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class BFAddressService extends BFBaseService implements AddressService {
@@ -66,6 +67,30 @@ public class BFAddressService extends BFBaseService implements AddressService {
 
         } catch (IOException e) {
             throw new ApiException("Error getting transactions for the address", e);
+        }
+    }
+
+    public Result<List<AddressTransactionContent>> getAllTransactions(String address, OrderEnum order, Integer fromBlockHeight, Integer toBlockHeight) throws ApiException {
+        List<AddressTransactionContent> addressTransactionContents = new ArrayList<>();
+        int page = 1;
+        Result<List<AddressTransactionContent>> addressTransactionContentsResult = getTransactions(address, 100, page, order, String.valueOf(fromBlockHeight), String.valueOf(toBlockHeight));
+        while (addressTransactionContentsResult.isSuccessful()) {
+            addressTransactionContents.addAll(addressTransactionContentsResult.getValue());
+            if (addressTransactionContentsResult.getValue().size() != 100) {
+                break;
+            } else {
+                page++;
+                addressTransactionContentsResult = getTransactions(address, 100, page, order, String.valueOf(fromBlockHeight), String.valueOf(toBlockHeight));
+            }
+        }
+        if (!addressTransactionContentsResult.isSuccessful()) {
+            return addressTransactionContentsResult;
+        } else {
+            addressTransactionContents.sort((o1, o2) ->
+                    order == OrderEnum.asc ?
+                            Long.compare(o1.getBlockHeight(), o2.getBlockHeight()) :
+                            Long.compare(o2.getBlockHeight(), o1.getBlockHeight()));
+            return Result.success(addressTransactionContentsResult.toString()).withValue(addressTransactionContents).code(addressTransactionContentsResult.code());
         }
     }
 }

--- a/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/BFBackendService.java
+++ b/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/BFBackendService.java
@@ -45,7 +45,7 @@ public class BFBackendService extends BFBaseService implements BackendService {
 
     @Override
     public AccountService getAccountService() {
-        return new BFAccountService(getBaseUrl(), getProjectId());
+        return new BFAccountService(getBaseUrl(), getProjectId(), getAddressService());
     }
 
     @Override

--- a/backend-modules/koios/src/it/java/com/bloxbean/cardano/client/backend/koios/it/KoiosAccountServiceIT.java
+++ b/backend-modules/koios/src/it/java/com/bloxbean/cardano/client/backend/koios/it/KoiosAccountServiceIT.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.client.backend.koios.it;
 
+import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.backend.api.AccountService;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class KoiosAccountServiceIT extends KoiosBaseTest {
@@ -82,5 +84,16 @@ class KoiosAccountServiceIT extends KoiosBaseTest {
         List<AccountAsset> accountAssets = result.getValue();
         System.out.println(JsonUtil.getPrettyJson(accountAssets));
         //TODO Find account with more than 1000 assets
+    }
+
+    @Test
+    void testGetAllAccountTransactions() throws ApiException {
+        String stakeAddress = "stake_test1upxeg0r67z4wca682l28ghg69jxaxgswdmpvnher7at697qmhymyp";
+        Result<List<AddressTransactionContent>> result = accountService.getAllAccountTransactions(stakeAddress, OrderEnum.asc, 605746, 615700);
+        assertTrue(result.isSuccessful());
+        List<AddressTransactionContent> addressTransactionContents = result.getValue();
+        assertEquals(22, addressTransactionContents.size());
+        assertEquals("bef3e28ad884c3e50d40465726da389c4c288d486a47bc700c5d273d0516ea01", addressTransactionContents.get(0).getTxHash());
+        System.out.println(JsonUtil.getPrettyJson(addressTransactionContents));
     }
 }

--- a/backend-modules/koios/src/it/java/com/bloxbean/cardano/client/backend/koios/it/KoiosAddressServiceIT.java
+++ b/backend-modules/koios/src/it/java/com/bloxbean/cardano/client/backend/koios/it/KoiosAddressServiceIT.java
@@ -78,4 +78,16 @@ class KoiosAddressServiceIT extends KoiosBaseTest {
         assertTrue(txns.get(0).getBlockHeight() != 0);
         assertTrue(txns.get(0).getBlockTime() != 0);
     }
+
+    @Test
+    public void testGetAllTransactions() throws ApiException {
+        String address = "addr_test1qzx9hu8j4ah3auytk0mwcupd69hpc52t0cw39a65ndrah86djs784u92a3m5w475w3w35tyd6v3qumkze80j8a6h5tuqq5xe8y";
+        List<AddressTransactionContent> txns = addressService.getAllTransactions(address, OrderEnum.desc, 357475, 357479).getValue();
+
+        System.out.println(txns);
+        assertThat(txns.size()).isEqualTo(3);
+        assertEquals("002dbdb2d294a61c03ec7b0876bc5d40ec3ae07ef5b72d08c107cce7566c4f96", txns.get(0).getTxHash());
+        assertTrue(txns.get(0).getBlockHeight() != 0);
+        assertTrue(txns.get(0).getBlockTime() != 0);
+    }
 }

--- a/backend-modules/koios/src/it/java/com/bloxbean/cardano/client/backend/koios/it/KoiosAddressServiceIT.java
+++ b/backend-modules/koios/src/it/java/com/bloxbean/cardano/client/backend/koios/it/KoiosAddressServiceIT.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.backend.api.AddressService;
 import com.bloxbean.cardano.client.backend.model.AddressContent;
+import com.bloxbean.cardano.client.backend.model.AddressDetails;
 import com.bloxbean.cardano.client.backend.model.AddressTransactionContent;
 import com.bloxbean.cardano.client.util.JsonUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,12 +26,21 @@ class KoiosAddressServiceIT extends KoiosBaseTest {
     }
 
     @Test
-    void testGetAddressInfo() throws ApiException {
-        Result<AddressContent> result = addressService.getAddressInfo("addr_test1qzr0g2kvyknzhyez3aatyjwpaw5z5n65cwfxc5ctcqq28ed3hcc035r9r76tkxehlr9wdla9twe02dpv843nru6czj6qycpamy");
+    public void testGetAddressInfo() throws ApiException {
+        Result<AddressContent> result = addressService.getAddressInfo("addr_test1qzx9hu8j4ah3auytk0mwcupd69hpc52t0cw39a65ndrah86djs784u92a3m5w475w3w35tyd6v3qumkze80j8a6h5tuqq5xe8y");
         System.out.println(JsonUtil.getPrettyJson(result.getValue()));
 
         assertTrue(result.isSuccessful());
         assertFalse(result.getValue().getAmount().isEmpty());
+    }
+
+    @Test
+    public void testGetAddressDetails() throws ApiException {
+        Result<AddressDetails> result = addressService.getAddressDetails("addr_test1qzx9hu8j4ah3auytk0mwcupd69hpc52t0cw39a65ndrah86djs784u92a3m5w475w3w35tyd6v3qumkze80j8a6h5tuqq5xe8y");
+        System.out.println(JsonUtil.getPrettyJson(result.getValue()));
+
+        assertTrue(result.isSuccessful());
+        assertFalse(result.getValue().getReceivedSum().isEmpty());
     }
 
     @Test
@@ -40,19 +50,19 @@ class KoiosAddressServiceIT extends KoiosBaseTest {
 
         System.out.println(txns);
         assertTrue(txns.size() > 2);
-        assertEquals("bc22e5b9768fd4a639d02c9f11cbd4cce695d2c0788f8c4028b826b81bc92fdb", txns.get(0).getTxHash());
+        assertEquals("0d79289c5d11cc5e8d8e0fc234ea654abfec62b1a9643e1f33cd3da2b513d19e", txns.get(0).getTxHash());
         assertTrue(txns.get(0).getBlockHeight() != 0);
         assertTrue(txns.get(0).getBlockTime() != 0);
     }
 
     @Test
     void testGetTransactionsWithOrder() throws ApiException {
-        String address = "addr_test1qzr0g2kvyknzhyez3aatyjwpaw5z5n65cwfxc5ctcqq28ed3hcc035r9r76tkxehlr9wdla9twe02dpv843nru6czj6qycpamy";
+        String address = "addr_test1qzx9hu8j4ah3auytk0mwcupd69hpc52t0cw39a65ndrah86djs784u92a3m5w475w3w35tyd6v3qumkze80j8a6h5tuqq5xe8y";
         List<AddressTransactionContent> txns = addressService.getTransactions(address, 50, 1, OrderEnum.desc).getValue();
 
         System.out.println(txns);
         assertTrue(txns.size() > 2);
-        assertNotEquals("119a69ae496b03936335ed22416116c454a26c00c5c59b22f34535851ba3aa42", txns.get(0).getTxHash());
+        assertNotEquals("0d79289c5d11cc5e8d8e0fc234ea654abfec62b1a9643e1f33cd3da2b513d19e", txns.get(0).getTxHash());
         assertTrue(txns.get(0).getBlockHeight() != 0);
         assertTrue(txns.get(0).getBlockTime() != 0);
     }
@@ -60,11 +70,11 @@ class KoiosAddressServiceIT extends KoiosBaseTest {
     @Test
     public void testGetTransactionsWithOrder_whenFromAndToBlocksProvided() throws ApiException {
         String address = "addr_test1qzx9hu8j4ah3auytk0mwcupd69hpc52t0cw39a65ndrah86djs784u92a3m5w475w3w35tyd6v3qumkze80j8a6h5tuqq5xe8y";
-        List<AddressTransactionContent> txns = addressService.getTransactions(address, 50, 1, OrderEnum.desc, "1825606", "1825606").getValue();
+        List<AddressTransactionContent> txns = addressService.getTransactions(address, 50, 1, OrderEnum.desc, "357475", "357479").getValue();
 
         System.out.println(txns);
-        assertThat(txns.size()).isEqualTo(1);
-        assertEquals("c8c3b6161fd6430edd81ecfbefb5d136bf126d2f3e95b6c51f09eff745c53b76", txns.get(0).getTxHash());
+        assertThat(txns.size()).isEqualTo(3);
+        assertEquals("002dbdb2d294a61c03ec7b0876bc5d40ec3ae07ef5b72d08c107cce7566c4f96", txns.get(0).getTxHash());
         assertTrue(txns.get(0).getBlockHeight() != 0);
         assertTrue(txns.get(0).getBlockTime() != 0);
     }

--- a/backend/src/main/java/com/bloxbean/cardano/client/backend/api/AccountService.java
+++ b/backend/src/main/java/com/bloxbean/cardano/client/backend/api/AccountService.java
@@ -120,4 +120,25 @@ public interface AccountService {
      * @return List of Used Addresses
      */
     Result<List<AccountAsset>> getAccountAssets(String stakeAddress, int count, int page, OrderEnum order) throws ApiException;
+
+    /**
+     * Obtain information about transactions associated with a specific account.
+     * @param stakeAddress Bech32 stake address.
+     * @param count count
+     * @param page page
+     * @param order The ordering of items from the point of view of the blockchain, not the page listing itself. By default, we return oldest first, newest last.
+     * @param fromBlockHeight from block number
+     * @param toBlockHeight to block number
+     * @return List of {@link TransactionContent}
+     */
+    Result<List<AddressTransactionContent>> getAccountTransactions(String stakeAddress, int count, int page, OrderEnum order, Integer fromBlockHeight, Integer toBlockHeight) throws ApiException;
+
+    /**
+     * Obtain All information about transactions associated with a specific account.
+     * @param stakeAddress Bech32 stake address.
+     * @param order The ordering of items from the point of view of the blockchain, not the page listing itself. By default, we return oldest first, newest last.
+     * @param fromBlockHeight from block number
+     * @return List of {@link TransactionContent}
+     */
+    Result<List<AddressTransactionContent>> getAllAccountTransactions(String stakeAddress, OrderEnum order, Integer fromBlockHeight, Integer toBlockHeight) throws ApiException;
 }

--- a/backend/src/main/java/com/bloxbean/cardano/client/backend/api/AddressService.java
+++ b/backend/src/main/java/com/bloxbean/cardano/client/backend/api/AddressService.java
@@ -70,4 +70,14 @@ public interface AddressService {
     default Result<List<AddressTransactionContent>> getTransactions(String address, int count, int page, OrderEnum order, String from, String to) throws ApiException {
         return getTransactions(address, count, page, order);
     }
+
+    /**
+     * getAllTransactions
+     * @param address paymentAddress
+     * @param order order
+     * @param fromBlockHeight from block number
+     * @param toBlockHeight to block number
+     * @return List of {@link AddressTransactionContent}
+     */
+    Result<List<AddressTransactionContent>> getAllTransactions(String address, OrderEnum order, Integer fromBlockHeight, Integer toBlockHeight) throws ApiException;
 }

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/AccountServiceIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/AccountServiceIT.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.client.backend.api;
 
+import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.backend.model.*;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class AccountServiceIT extends BaseITTest {
@@ -83,6 +85,17 @@ class AccountServiceIT extends BaseITTest {
         List<AccountAsset> accountAssets = result.getValue();
         System.out.println(JsonUtil.getPrettyJson(accountAssets));
         //TODO Find account with more than 100 assets
+    }
+
+    @Test
+    void testGetAllAccountTransactions() throws ApiException {
+        String stakeAddress = "stake_test1upxeg0r67z4wca682l28ghg69jxaxgswdmpvnher7at697qmhymyp";
+        Result<List<AddressTransactionContent>> result = accountService.getAllAccountTransactions(stakeAddress, OrderEnum.asc, 605746, 615700);
+        assertTrue(result.isSuccessful());
+        List<AddressTransactionContent> addressTransactionContents = result.getValue();
+        assertEquals(22, addressTransactionContents.size());
+        assertEquals("bef3e28ad884c3e50d40465726da389c4c288d486a47bc700c5d273d0516ea01", addressTransactionContents.get(0).getTxHash());
+        System.out.println(JsonUtil.getPrettyJson(addressTransactionContents));
     }
 }
 

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/AddressServiceIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/AddressServiceIT.java
@@ -69,5 +69,17 @@ public class AddressServiceIT extends BaseITTest {
         assertTrue(txns.get(0).getBlockHeight() != 0);
         assertTrue(txns.get(0).getBlockTime() != 0);
     }
+
+    @Test
+    public void testGetAllTransactions() throws ApiException {
+        String address = "addr_test1qzx9hu8j4ah3auytk0mwcupd69hpc52t0cw39a65ndrah86djs784u92a3m5w475w3w35tyd6v3qumkze80j8a6h5tuqq5xe8y";
+        List<AddressTransactionContent> txns = addressService.getAllTransactions(address, OrderEnum.desc, 357475, 357479).getValue();
+
+        System.out.println(txns);
+        assertThat(txns.size()).isEqualTo(3);
+        assertEquals("002dbdb2d294a61c03ec7b0876bc5d40ec3ae07ef5b72d08c107cce7566c4f96", txns.get(0).getTxHash());
+        assertTrue(txns.get(0).getBlockHeight() != 0);
+        assertTrue(txns.get(0).getBlockTime() != 0);
+    }
 }
 

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/AddressServiceIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/AddressServiceIT.java
@@ -2,10 +2,9 @@ package com.bloxbean.cardano.client.backend.api;
 
 import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.exception.ApiException;
-import com.bloxbean.cardano.client.backend.model.AddressContent;
-import com.bloxbean.cardano.client.backend.model.AddressDetails;
-import com.bloxbean.cardano.client.backend.model.AddressTransactionContent;
 import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.backend.model.AddressContent;
+import com.bloxbean.cardano.client.backend.model.AddressTransactionContent;
 import com.bloxbean.cardano.client.util.JsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,15 +32,6 @@ public class AddressServiceIT extends BaseITTest {
 
         assertTrue(result.isSuccessful());
         assertFalse(result.getValue().getAmount().isEmpty());
-    }
-
-    @Test
-    public void testGetAddressDetails() throws ApiException {
-        Result<AddressDetails> result = addressService.getAddressDetails("addr_test1qzx9hu8j4ah3auytk0mwcupd69hpc52t0cw39a65ndrah86djs784u92a3m5w475w3w35tyd6v3qumkze80j8a6h5tuqq5xe8y");
-        System.out.println(JsonUtil.getPrettyJson(result.getValue()));
-
-        assertTrue(result.isSuccessful());
-        assertFalse(result.getValue().getReceivedSum().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Fix Wrong handling for Address Transactions functionality for Koios Provider
Note: Koios Provider isn't supporting filling the tx_index field in the AddressTransactionContent object