### PR TITLE
Introduced SlotConfigs for Transaction Evaluators

### DIFF
--- a/common/src/main/java/com/bloxbean/cardano/client/common/model/SlotConfig.java
+++ b/common/src/main/java/com/bloxbean/cardano/client/common/model/SlotConfig.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.client.common.model;
+
+import java.util.Objects;
+
+public class SlotConfig {
+
+    private int slotLength;
+    private long zeroSlot;
+    private long zeroTime;
+
+    public SlotConfig(int slotLength, long zeroSlot, long zeroTime) {
+        this.slotLength = slotLength;
+        this.zeroSlot = zeroSlot;
+        this.zeroTime = zeroTime;
+    }
+
+    public int getSlotLength() {
+        return slotLength;
+    }
+
+    public long getZeroSlot() {
+        return zeroSlot;
+    }
+
+    public long getZeroTime() {
+        return zeroTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SlotConfig that = (SlotConfig) o;
+        return slotLength == that.slotLength && zeroSlot == that.zeroSlot && zeroTime == that.zeroTime;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(slotLength, zeroSlot, zeroTime);
+    }
+}

--- a/common/src/main/java/com/bloxbean/cardano/client/common/model/SlotConfigs.java
+++ b/common/src/main/java/com/bloxbean/cardano/client/common/model/SlotConfigs.java
@@ -1,0 +1,17 @@
+package com.bloxbean.cardano.client.common.model;
+
+public class SlotConfigs {
+
+    public static SlotConfig mainnet() {
+        return new SlotConfig(1000, 4492800L, 1596059091000L);
+    }
+
+    public static SlotConfig preprod() {
+        return new SlotConfig(1000, 86400L, 1655769600000L);
+    }
+
+    public static SlotConfig preview() {
+        return new SlotConfig(1000, 0L, 1666656000000L);
+    }
+
+}


### PR DESCRIPTION
Currently local transaction evaluators like AikentTransactionEvalutator and ScalusTE, only work for mainnet in case of contracts which require time interval validaiton.

This PR contribute to fix https://github.com/bloxbean/cardano-client-lib/issues/429