### PR TITLE
Add era-specific serialization support for transactions

### DIFF
--- a/common-spec/src/main/java/com/bloxbean/cardano/client/spec/Era.java
+++ b/common-spec/src/main/java/com/bloxbean/cardano/client/spec/Era.java
@@ -1,11 +1,9 @@
 package com.bloxbean.cardano.client.spec;
 
+/**
+ * List of Eras which can be used during transaction serialization
+ */
 public enum Era {
-    Byron(1),
-    Shelley(2),
-    Allegra(3),
-    Mary(4),
-    Alonzo(5),
     Babbage(6),
     Conway(7);
 

--- a/common-spec/src/main/java/com/bloxbean/cardano/client/spec/EraSerializationConfig.java
+++ b/common-spec/src/main/java/com/bloxbean/cardano/client/spec/EraSerializationConfig.java
@@ -9,10 +9,6 @@ public enum EraSerializationConfig {
         this.era = Era.Conway;
     }
 
-    public void setEra(Era era) {
-        this.era = era;
-    }
-
     public Era getEra() {
         return era;
     }

--- a/core/src/test/java/com/bloxbean/cardano/client/account/AccountTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/client/account/AccountTest.java
@@ -10,8 +10,6 @@ import com.bloxbean.cardano.client.crypto.bip32.key.HdPublicKey;
 import com.bloxbean.cardano.client.exception.AddressExcepion;
 import com.bloxbean.cardano.client.exception.AddressRuntimeException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
-import com.bloxbean.cardano.client.spec.Era;
-import com.bloxbean.cardano.client.spec.EraSerializationConfig;
 import com.bloxbean.cardano.client.spec.NetworkId;
 import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.util.HexUtil;

--- a/core/src/test/java/com/bloxbean/cardano/client/transaction/spec/CBORSerializationTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/client/transaction/spec/CBORSerializationTest.java
@@ -14,7 +14,6 @@ import com.bloxbean.cardano.client.metadata.cbor.CBORMetadataList;
 import com.bloxbean.cardano.client.metadata.cbor.CBORMetadataMap;
 import com.bloxbean.cardano.client.plutus.spec.PlutusV1Script;
 import com.bloxbean.cardano.client.spec.Era;
-import com.bloxbean.cardano.client.spec.EraSerializationConfig;
 import com.bloxbean.cardano.client.transaction.TransactionSigner;
 import com.bloxbean.cardano.client.transaction.spec.script.ScriptAtLeast;
 import com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey;
@@ -872,30 +871,22 @@ public class CBORSerializationTest {
     class NamiCompatibility {
         @Test
         public void testCompatibilityWithNamiTxnHex_1() throws Exception {
-            var defaultEra = EraSerializationConfig.INSTANCE.getEra();
-            EraSerializationConfig.INSTANCE.setEra(Era.Babbage);
-
             String namiTxnHex = "84a30082825820a149b3c9740b8f8b957415442336bec65bb393dfa93e88473c71a8fb7959c6d005825820297b1e742de3e7dd5f013424f5ff62d82fdf65f9d7194de1eff286a8232a196c00018282583900aff761fc1d70474cfeec6d86a2e428231949ebeb8b71464791256205167590ce95c329c8b4ba3e8e254bcc2d1e8db792dc66aa0117f94047821a0014851ea1581cac6d9e75ca58379c394378a64ae24eddf72b2e78d73f635bac32d03da143434144194e20825839003175d03902583e82037438cc86732f6e539f803f9a8b2d4ee164b9d0c77e617030631811f60a1f8a8be26d65a57ff71825b336cc6b76361d821a045c5f93a2581c0f39b76d79c90289b42af0a4759f04c2cb0adcc42ae19787ff8084eea14541444d494e01581cac6d9e75ca58379c394378a64ae24eddf72b2e78d73f635bac32d03da1434341441a23c19850021a0002aaeda0f5f6";
             Transaction desTxn = Transaction.deserialize(HexUtil.decodeHexString(namiTxnHex));
+            desTxn.setEra(Era.Babbage);
 
             assertThat(desTxn.serializeToHex()).isEqualTo(namiTxnHex);
-
-            EraSerializationConfig.INSTANCE.setEra(defaultEra);
         }
 
         @Test
         public void testCompatibilityWithNamiTxnHex_2() throws Exception {
-            var defaultEra = EraSerializationConfig.INSTANCE.getEra();
-            EraSerializationConfig.INSTANCE.setEra(Era.Babbage);
-
             String namiTxnHex = "84a300838258209f213609a073f632b0f38c8bf0a2b525f6899a0e5ee006117a5734d3bef2585c048258208a1df7d5c860bb63f3b344c03f4ddd8a34a7619ce223fdb8a73f6e8a92d3813b008258201c4859ad2027aa4d8e17f66e266ea83928d575c9dd9e72ca271db9ca1bf11b4f000182825839009cc9fc0f9d97e92ef5c40931bdc9a327be94f6c9d0390d4cbd8b62d16791a7c8e95c53ffb72600ea13051f03854eef6267298760265f5bbb821a1c528901a3581c0df4e527fb4ed572c6aca78a0e641701c70715261810fa6ee98db9efa1434f50441a0bebc214581c0f39b76d79c90289b42af0a4759f04c2cb0adcc42ae19787ff8084eea14541444d494e01581cac6d9e75ca58379c394378a64ae24eddf72b2e78d73f635bac32d03da143434144148258390015cabc8bf1382d2dae1f317c862c3cd3de6400c8db7de092483ce9c91bfb8f3e334b0d42cf6f28e536bcb3151d64484c5c78d47d849d4291821a0014851ea1581cac6d9e75ca58379c394378a64ae24eddf72b2e78d73f635bac32d03da143434144194e0c021a0002c851a0f5f6";
 
             Transaction namiTxn = Transaction.deserialize(HexUtil.decodeHexString(namiTxnHex));
+            namiTxn.setEra(Era.Babbage);
             String finalTxnHex = namiTxn.serializeToHex();
 
             assertThat(finalTxnHex).isEqualTo(namiTxnHex);
-
-            EraSerializationConfig.INSTANCE.setEra(defaultEra);
         }
 
         @Test
@@ -942,22 +933,19 @@ public class CBORSerializationTest {
 
         @Test
         void testCompatibilityWithNamiWitness() throws Exception {
-            var defaultEra = EraSerializationConfig.INSTANCE.getEra();
-            EraSerializationConfig.INSTANCE.setEra(Era.Babbage);
             String namiTxnHex = "84a300838258206deb8993fa4b541892b5b698fef4fbb9ea73265395b5837fe45581b37efb3b7a01825820297b1e742de3e7dd5f013424f5ff62d82fdf65f9d7194de1eff286a8232a196c00825820538586beedfbac419ca3a5983c0efa3f486ffddbebf053824abc778a55c06078000182825839005a512f32ebdd33cbb6525d9fe041b0044ecbb24dec402b5c2c8bf98a1bfb8f3e334b0d42cf6f28e536bcb3151d64484c5c78d47d849d4291821a0014851ea1581cac6d9e75ca58379c394378a64ae24eddf72b2e78d73f635bac32d03da143434144194da8825839003175d03902583e82037438cc86732f6e539f803f9a8b2d4ee164b9d0c77e617030631811f60a1f8a8be26d65a57ff71825b336cc6b76361d821a003040c9a3581c0f39b76d79c90289b42af0a4759f04c2cb0adcc42ae19787ff8084eea14541444d494e01581c869708e97e418f1422e22f8b026559a565aab320184fdd98efff4f4ca14a2142466426544d6d704001581cac6d9e75ca58379c394378a64ae24eddf72b2e78d73f635bac32d03da14343414414021a0002c8d5a0f5f6";
             String namiWitness = "a10081825820a5f73966e73d0bb9eadc75c5857eafd054a0202d716ac6dde00303ee9c0019e358402bfb7ba45583f5826e02d1cee544ab37398a72c0db5e01048f88ebd7c97deff7b49492be0f0edabebe67b14cb8b12a3e68c42cbb0b4970ec2e60919c3a5b6b02";
             String namiMnemonic = "round stomach concert dizzy pluck express inject seminar satoshi vote essence artist pink awful bubble frog bullet horror spoil risk false dolphin limit sock";
 
             Transaction transaction = Transaction.deserialize(HexUtil.decodeHexString(namiTxnHex));
+            transaction.setEra(Era.Babbage);
             Account namiAcc = new Account(Networks.testnet(), namiMnemonic);
             Transaction signedTxn = namiAcc.sign(transaction);
 
-            String finalWitnessHex = HexUtil.encodeHexString(CborSerializationUtil.serialize(signedTxn.getWitnessSet().serialize()));
+            String finalWitnessHex = HexUtil.encodeHexString(CborSerializationUtil.serialize(signedTxn.getWitnessSet().serialize(Era.Babbage)));
 
             assertThat(finalWitnessHex).isEqualTo(namiWitness);
             assertThat(transaction.serializeToHex()).isEqualTo(namiTxnHex);
-
-            EraSerializationConfig.INSTANCE.setEra(defaultEra);
         }
     }
 

--- a/core/src/test/java/com/bloxbean/cardano/client/transaction/util/ScriptDataHashGeneratorTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/client/transaction/util/ScriptDataHashGeneratorTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+import static com.bloxbean.cardano.client.api.util.CostModelUtil.PlutusV1CostModel;
+import static com.bloxbean.cardano.client.api.util.CostModelUtil.PlutusV2CostModel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 //TODO -- Move this test to spec module later
@@ -62,6 +64,162 @@ class ScriptDataHashGeneratorTest {
         System.out.println(hash);
 
         assertThat(hash).isEqualTo("57240d358f8ab6128c4a66340271e4fec39b4971232add308f01a5809313adcf");
+    }
+
+    @Test
+    void generate_plutusV1_noEraSet() throws CborException, CborSerializationException {
+        ListPlutusData listPlutusData = new ListPlutusData();
+        PlutusData plutusData = new BigIntPlutusData(new BigInteger("1000"));
+        listPlutusData.add(plutusData);
+
+        Redeemer redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.valueOf(1))
+                .data(new BigIntPlutusData(new BigInteger("2000")))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.valueOf(0))
+                        .steps(BigInteger.valueOf(0))
+                        .build()
+                ).build();
+
+        byte[] hashBytes = ScriptDataHashGenerator.generate(Arrays.asList(redeemer), Arrays.asList(plutusData), costMdls);
+        String hash = HexUtil.encodeHexString(hashBytes);
+        System.out.println(hash);
+
+        assertThat(hash).isEqualTo("57240d358f8ab6128c4a66340271e4fec39b4971232add308f01a5809313adcf");
+    }
+
+    @Test
+    void generate_plutusV1_eraSet_shouldNotUseBabbageEra() throws CborException, CborSerializationException { //negative test
+        ListPlutusData listPlutusData = new ListPlutusData();
+        PlutusData plutusData = new BigIntPlutusData(new BigInteger("1000"));
+        listPlutusData.add(plutusData);
+
+        Redeemer redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.valueOf(1))
+                .data(new BigIntPlutusData(new BigInteger("2000")))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.valueOf(0))
+                        .steps(BigInteger.valueOf(0))
+                        .build()
+                ).build();
+
+        byte[] hashBytes = ScriptDataHashGenerator.generate(Era.Conway, Arrays.asList(redeemer), Arrays.asList(plutusData), costMdls);
+        String hash = HexUtil.encodeHexString(hashBytes);
+        System.out.println(hash);
+
+        assertThat(hash).isNotEqualTo("57240d358f8ab6128c4a66340271e4fec39b4971232add308f01a5809313adcf");
+    }
+
+    @Test
+    void generate_plutusV2() throws CborException, CborSerializationException {
+        ListPlutusData listPlutusData = new ListPlutusData();
+        PlutusData plutusData = new BigIntPlutusData(new BigInteger("1000"));
+        listPlutusData.add(plutusData);
+
+        Redeemer redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.valueOf(1))
+                .data(new BigIntPlutusData(new BigInteger("2000")))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.valueOf(0))
+                        .steps(BigInteger.valueOf(0))
+                        .build()
+                ).build();
+
+        var _costMdls = new CostMdls();
+        _costMdls.add(PlutusV2CostModel);
+
+        byte[] hashBytes = ScriptDataHashGenerator.generate(Arrays.asList(redeemer), Arrays.asList(plutusData), _costMdls);
+        String hash = HexUtil.encodeHexString(hashBytes);
+        System.out.println(hash);
+
+        assertThat(hash).isEqualTo("83d39add124e06e9cf8c4fee28c8b8063932c4bdfc3d4900fb08f49beffef601");
+    }
+
+    @Test
+    void generate_plutusV2_eraSetToBabbage() throws CborException, CborSerializationException { //negative test
+        ListPlutusData listPlutusData = new ListPlutusData();
+        PlutusData plutusData = new BigIntPlutusData(new BigInteger("1000"));
+        listPlutusData.add(plutusData);
+
+        Redeemer redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.valueOf(1))
+                .data(new BigIntPlutusData(new BigInteger("2000")))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.valueOf(0))
+                        .steps(BigInteger.valueOf(0))
+                        .build()
+                ).build();
+
+        var _costMdls = new CostMdls();
+        _costMdls.add(PlutusV2CostModel);
+
+        byte[] hashBytes = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer), Arrays.asList(plutusData), _costMdls);
+        String hash = HexUtil.encodeHexString(hashBytes);
+        System.out.println(hash);
+
+        assertThat(hash).isNotEqualTo("83d39add124e06e9cf8c4fee28c8b8063932c4bdfc3d4900fb08f49beffef601");
+    }
+
+    @Test
+    void generate_plutusV2_eraSetToConway() throws CborException, CborSerializationException {
+        ListPlutusData listPlutusData = new ListPlutusData();
+        PlutusData plutusData = new BigIntPlutusData(new BigInteger("1000"));
+        listPlutusData.add(plutusData);
+
+        Redeemer redeemer = Redeemer.builder()
+                .tag(RedeemerTag.Spend)
+                .index(BigInteger.valueOf(1))
+                .data(new BigIntPlutusData(new BigInteger("2000")))
+                .exUnits(ExUnits.builder()
+                        .mem(BigInteger.valueOf(0))
+                        .steps(BigInteger.valueOf(0))
+                        .build()
+                ).build();
+
+        var _costMdls = new CostMdls();
+        _costMdls.add(PlutusV2CostModel);
+
+        byte[] hashBytes = ScriptDataHashGenerator.generate(Era.Conway, Arrays.asList(redeemer), Arrays.asList(plutusData), _costMdls);
+        String hash = HexUtil.encodeHexString(hashBytes);
+        System.out.println(hash);
+
+        assertThat(hash).isEqualTo("83d39add124e06e9cf8c4fee28c8b8063932c4bdfc3d4900fb08f49beffef601");
+    }
+
+    @Test
+    void generate_plutusV2_emptyRedeemer() throws CborException, CborSerializationException {
+        ListPlutusData listPlutusData = new ListPlutusData();
+        PlutusData plutusData = new BigIntPlutusData(new BigInteger("1000"));
+        listPlutusData.add(plutusData);
+
+        var _costMdls = new CostMdls();
+        _costMdls.add(PlutusV2CostModel);
+
+        byte[] hashBytes = ScriptDataHashGenerator.generate(Era.Conway, Arrays.asList(), Arrays.asList(plutusData), _costMdls);
+        String hash = HexUtil.encodeHexString(hashBytes);
+        System.out.println(hash);
+
+        assertThat(hash).isEqualTo("62d142288edfbd6b5bceec2bd476a22e6856c0904fcf26116fc4dd54440c038e");
+    }
+
+    @Test
+    void generate_plutusV1_emptyRedeemer() throws CborException, CborSerializationException {
+        ListPlutusData listPlutusData = new ListPlutusData();
+        PlutusData plutusData = new BigIntPlutusData(new BigInteger("1000"));
+        listPlutusData.add(plutusData);
+
+        var _costMdls = new CostMdls();
+        _costMdls.add(PlutusV1CostModel);
+
+        byte[] hashBytes = ScriptDataHashGenerator.generate(Arrays.asList(), Arrays.asList(plutusData), _costMdls);
+        String hash = HexUtil.encodeHexString(hashBytes);
+        System.out.println(hash);
+
+        assertThat(hash).isEqualTo("d6e05995f657a2bf1a3dd246756733f9e680487df08c5d958617e5eec70b9fc2");
     }
 
     @Test

--- a/core/src/test/java/com/bloxbean/cardano/client/transaction/util/ScriptDataHashGeneratorTest.java
+++ b/core/src/test/java/com/bloxbean/cardano/client/transaction/util/ScriptDataHashGeneratorTest.java
@@ -4,6 +4,7 @@ import co.nstant.in.cbor.CborException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.plutus.spec.*;
 import com.bloxbean.cardano.client.plutus.util.ScriptDataHashGenerator;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.util.HexUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ class ScriptDataHashGeneratorTest {
                         .build()
                 ).build();
 
-        byte[] hashBytes = ScriptDataHashGenerator.generate(Arrays.asList(redeemer), Arrays.asList(plutusData), costMdls);
+        byte[] hashBytes = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer), Arrays.asList(plutusData), costMdls);
         String hash = HexUtil.encodeHexString(hashBytes);
         System.out.println(hash);
 
@@ -67,7 +68,7 @@ class ScriptDataHashGeneratorTest {
     void generate_emptyRedemeers_nonEmptyDatum() throws Exception {
         PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString("d8799f4114d8799fd8799fd8799fd8799f581c3050f6f4d5981748bc3a2b84d8165b20c100a75057b6593befd9323cffd8799fd8799fd8799f581cc5cdc99429b4ce659f2542994c48b6c801f0b8e21ca7fb586326a545ffffffffd87a80ffd87a80ff1a002625a0d8799fd879801a0025a559d8799f01ffffff"));
 
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(), Arrays.asList(plutusData),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(), Arrays.asList(plutusData),
                 costMdls);
 
         byte[] expected = new byte[]{71, -22, -92, 74, -39, 124, 55, -108, 120, -127, -125, 119, 41, -77, 48, -72, 121, 0, -10, -77, -29, 103, -99, -9, -111, -118, 11, -126, -52, -29, -81, 105};
@@ -78,7 +79,7 @@ class ScriptDataHashGeneratorTest {
     void generate_nullRedemeers_nonEmptyDatum() throws Exception {
         PlutusData plutusData = PlutusData.deserialize(HexUtil.decodeHexString("d8799f4114d8799fd8799fd8799fd8799f581c3050f6f4d5981748bc3a2b84d8165b20c100a75057b6593befd9323cffd8799fd8799fd8799f581cc5cdc99429b4ce659f2542994c48b6c801f0b8e21ca7fb586326a545ffffffffd87a80ffd87a80ff1a002625a0d8799fd879801a0025a559d8799f01ffffff"));
 
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(null, Arrays.asList(plutusData),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, null, Arrays.asList(plutusData),
                 costMdls);
 
         byte[] expected = new byte[]{71, -22, -92, 74, -39, 124, 55, -108, 120, -127, -125, 119, 41, -77, 48, -72, 121, 0, -10, -77, -29, 103, -99, -9, -111, -118, 11, -126, -52, -29, -81, 105};

--- a/function/src/main/java/com/bloxbean/cardano/client/function/TxBuilderContext.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/TxBuilderContext.java
@@ -16,14 +16,12 @@ import com.bloxbean.cardano.client.coinselection.impl.DefaultUtxoSelector;
 import com.bloxbean.cardano.client.plutus.spec.CostMdls;
 import com.bloxbean.cardano.client.plutus.spec.Language;
 import com.bloxbean.cardano.client.plutus.spec.PlutusScript;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.MultiAsset;
 import com.bloxbean.cardano.client.transaction.spec.Transaction;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.util.Tuple;
-import lombok.AccessLevel;
-import lombok.Data;
-import lombok.Setter;
-import lombok.SneakyThrows;
+import lombok.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -55,6 +53,10 @@ public class TxBuilderContext {
 
     @Setter(AccessLevel.NONE)
     private boolean mergeOutputs = true;
+
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private Era serializationEra;
 
     public TxBuilderContext(UtxoSupplier utxoSupplier, ProtocolParamsSupplier protocolParamsSupplier) {
         this(utxoSupplier, protocolParamsSupplier.getProtocolParams());
@@ -164,6 +166,24 @@ public class TxBuilderContext {
     }
 
     /**
+     * Set the serialization era for the transaction
+     * @param era
+     * @return TxBuilderContext
+     */
+    public TxBuilderContext withSerializationEra(Era era) {
+        this.serializationEra = era;
+        return this;
+    }
+
+    /**
+     * Get the serialization era for the transaction
+     * @return Era or null if not set
+     */
+    public Era getSerializationEra() {
+        return serializationEra;
+    }
+
+    /**
      * @deprecated
      * Use {@link #withCostMdls(CostMdls)} instead
      * @param costMdls
@@ -235,6 +255,7 @@ public class TxBuilderContext {
      */
     public Transaction build(TxBuilder txBuilder) {
         Transaction transaction = new Transaction();
+        transaction.setEra(getSerializationEra());
         txBuilder.apply(this, transaction);
         clearTempStates();
         return transaction;

--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/FeeCalculators.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/FeeCalculators.java
@@ -6,7 +6,6 @@ import com.bloxbean.cardano.client.api.exception.ApiRuntimeException;
 import com.bloxbean.cardano.client.api.helper.FeeCalculationService;
 import com.bloxbean.cardano.client.api.util.ReferenceScriptUtil;
 import com.bloxbean.cardano.client.common.model.Networks;
-import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborRuntimeException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.function.TxBuilder;
@@ -15,6 +14,7 @@ import com.bloxbean.cardano.client.function.exception.TxBuildException;
 import com.bloxbean.cardano.client.plutus.spec.ExUnits;
 import com.bloxbean.cardano.client.plutus.spec.Redeemer;
 import com.bloxbean.cardano.client.transaction.spec.*;
+import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
 import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigInteger;
@@ -150,17 +150,14 @@ public class FeeCalculators {
 
     private static Transaction createTransactionWithDummyWitnesses(Transaction transaction, int noOfSigners) {
         Transaction cloneTxn;
-        try {
-            BigInteger orginalFee = transaction.getBody().getFee();
-            transaction.getBody().setFee(BigInteger.valueOf(170000)); //To avoid any NPE due to null fee
 
-            cloneTxn = Transaction.deserialize(transaction.serialize());
+        BigInteger orginalFee = transaction.getBody().getFee();
+        transaction.getBody().setFee(BigInteger.valueOf(170000)); //To avoid any NPE due to null fee
 
-            //reset fee
-            transaction.getBody().setFee(orginalFee);
-        } catch (CborDeserializationException | CborSerializationException e) {
-            throw new CborRuntimeException("Error cloning the transaction", e);
-        }
+        cloneTxn = TransactionUtil.createCopy(transaction);
+
+        //reset fee
+        transaction.getBody().setFee(orginalFee);
 
         //Dummy account sign
         for (int i = 0; i < noOfSigners; i++) {

--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/ScriptDataHashCalculator.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/ScriptDataHashCalculator.java
@@ -76,7 +76,7 @@ public class ScriptDataHashCalculator {
             //Script dataHash
             byte[] scriptDataHash;
             try {
-                scriptDataHash = ScriptDataHashGenerator.generate(transaction.getWitnessSet().getRedeemers(),
+                scriptDataHash = ScriptDataHashGenerator.generate(ctx.getSerializationEra(), transaction.getWitnessSet().getRedeemers(),
                         transaction.getWitnessSet().getPlutusDataList(), costMdls);
             } catch (CborSerializationException | CborException e) {
                 throw new CborRuntimeException(e);

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/BaseITTest.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/BaseITTest.java
@@ -20,11 +20,11 @@ import java.util.Optional;
 
 public class BaseITTest {
     public static final String DEVKIT_ADMIN_BASE_URL = "http://localhost:10000/";
-    protected String BLOCKFROST = "blockfrost";
-    protected String KOIOS = "koios";
-    protected String OGMIOS = "ogmios";
-    protected String DEVKIT = "devkit";
-    protected String backendType = BLOCKFROST;
+    protected static String BLOCKFROST = "blockfrost";
+    protected static String KOIOS = "koios";
+    protected static String OGMIOS = "ogmios";
+    protected static String DEVKIT = "devkit";
+    protected static String backendType = BLOCKFROST;
 
     public BackendService getBackendService() {
         if (BLOCKFROST.equals(backendType)) {

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/helper/ContractTransactionIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/helper/ContractTransactionIT.java
@@ -32,6 +32,7 @@ import com.bloxbean.cardano.client.metadata.cbor.CBORMetadataMap;
 import com.bloxbean.cardano.client.plutus.annotation.Constr;
 import com.bloxbean.cardano.client.plutus.annotation.PlutusField;
 import com.bloxbean.cardano.client.plutus.spec.*;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.spec.NetworkId;
 import com.bloxbean.cardano.client.transaction.model.PaymentTransaction;
 import com.bloxbean.cardano.client.transaction.model.TransactionDetailsParams;
@@ -167,7 +168,7 @@ public class ContractTransactionIT extends BaseITTest {
 
         var costMdls = new CostMdls();
         costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -311,7 +312,7 @@ public class ContractTransactionIT extends BaseITTest {
         var costMdls = new CostMdls();
         costMdls.add(CostModelUtil.PlutusV1CostModel);
 
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -441,7 +442,7 @@ public class ContractTransactionIT extends BaseITTest {
 
         var costMdls = new CostMdls();
         costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -578,7 +579,7 @@ public class ContractTransactionIT extends BaseITTest {
 
         var costMdls = new CostMdls();
         costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -713,7 +714,7 @@ public class ContractTransactionIT extends BaseITTest {
 
         var costMdls = new CostMdls();
         costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -846,7 +847,7 @@ public class ContractTransactionIT extends BaseITTest {
 
         var costMdls = new CostMdls();
         costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -979,7 +980,7 @@ public class ContractTransactionIT extends BaseITTest {
 
         var costMdls = new CostMdls();
         costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
                 Arrays.asList(plutusData),  costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -1134,7 +1135,7 @@ public class ContractTransactionIT extends BaseITTest {
 
         var costMdls = new CostMdls();
         costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
                 Collections.emptyList(), costMdls);
 
         body.setScriptDataHash(scriptDataHash);
@@ -1393,7 +1394,10 @@ public class ContractTransactionIT extends BaseITTest {
     private long getTtl() throws ApiException {
         Block block = blockService.getLatestBlock().getValue();
         long slot = block.getSlot();
-        return slot + 2000;
+        if (backendType.equals(DEVKIT))
+            return slot + 50;
+        else
+            return slot + 2000;
     }
 
     private void waitForTransaction(Result<String> result) {

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/function/ContractV2TxBuilderContextITTest.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/function/ContractV2TxBuilderContextITTest.java
@@ -31,6 +31,7 @@ import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.transaction.util.CostModelUtil;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.util.JsonUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -61,8 +62,20 @@ public class ContractV2TxBuilderContextITTest extends BaseITTest {
     ProtocolParams protocolParams;
     UtxoSupplier utxoSupplier;
 
-    Account sender;
-    String senderAddress;
+    static Account sender;
+    static String senderAddress;
+
+    @BeforeAll
+    public static void setupAll() {
+        //addr_test1qp73ljurtknpm5fgey5r2y9aympd33ksgw0f8rc5khheg83y35rncur9mjvs665cg4052985ry9rzzmqend9sqw0cdksxvefah
+        String senderMnemonic = "drive useless envelope shine range ability time copper alarm museum near flee wrist live type device meadow allow churn purity wisdom praise drop code";
+        sender = new Account(Networks.testnet(), senderMnemonic);
+        senderAddress = sender.baseAddress();
+
+        if (backendType.equals(DEVKIT)) {
+            topUpFund(senderAddress, 50000);
+        }
+    }
 
     @BeforeEach
     public void setup() throws ApiException {
@@ -77,12 +90,6 @@ public class ContractV2TxBuilderContextITTest extends BaseITTest {
 
         protocolParams = backendService.getEpochService().getProtocolParameters().getValue();
         utxoSupplier = new DefaultUtxoSupplier(utxoService);
-
-//        String senderMnemonic = "company coast prison denial unknown design paper engage sadness employ phone cherry thunder chimney vapor cake lock afraid frequent myself engage lumber between tip";
-        //addr_test1qp73ljurtknpm5fgey5r2y9aympd33ksgw0f8rc5khheg83y35rncur9mjvs665cg4052985ry9rzzmqend9sqw0cdksxvefah
-        String senderMnemonic = "drive useless envelope shine range ability time copper alarm museum near flee wrist live type device meadow allow churn purity wisdom praise drop code";
-        sender = new Account(Networks.testnet(), senderMnemonic);
-        senderAddress = sender.baseAddress();
     }
 
     @Test
@@ -693,7 +700,10 @@ public class ContractV2TxBuilderContextITTest extends BaseITTest {
     private long getTtl() throws ApiException {
         Block block = blockService.getLatestBlock().getValue();
         long slot = block.getSlot();
-        return slot + 2000;
+        if (backendType == DEVKIT)
+            return slot + 30;
+        else
+            return slot + 2000;
     }
 
     private Utxo checkCollateral(Account sender, final String collateralUtxoHash, final int collateralIndex) throws ApiException, AddressExcepion, CborSerializationException {

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/function/RedeemerUtilSortingInputsITTest.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/function/RedeemerUtilSortingInputsITTest.java
@@ -19,6 +19,7 @@ import com.bloxbean.cardano.client.function.helper.CollateralBuilders;
 import com.bloxbean.cardano.client.plutus.spec.*;
 import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.util.JsonUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,8 +45,20 @@ public class RedeemerUtilSortingInputsITTest extends BaseITTest {
     ProtocolParams protocolParams;
     UtxoSupplier utxoSupplier;
 
-    Account sender;
-    String senderAddress;
+    static Account sender;
+    static String senderAddress;
+
+    @BeforeAll
+    public static void setupAll() {
+        //addr_test1qrurqpg3dxvkk4g45negeyaj7gju4mp3napqf36jsek9nw7xdzk39aguj8rcmq3es5ym6z7vgv6xungaypq56r72t2wq9ypt03
+        String senderMnemonic = "olive that walk sorry chat leisure attract river adult void host brand student income spy charge roast kiss balcony craft crouch kite agree south";
+        sender = new Account(Networks.testnet(), senderMnemonic);
+        senderAddress = sender.baseAddress();
+
+        if (backendType.equals(DEVKIT)) {
+            topUpFund(senderAddress, 50000);
+        }
+    }
 
     @BeforeEach
     public void setup() throws ApiException {
@@ -54,11 +67,6 @@ public class RedeemerUtilSortingInputsITTest extends BaseITTest {
         transactionService = backendService.getTransactionService();
         protocolParams = backendService.getEpochService().getProtocolParameters().getValue();
         utxoSupplier = new DefaultUtxoSupplier(utxoService);
-
-        //addr_test1qrurqpg3dxvkk4g45negeyaj7gju4mp3napqf36jsek9nw7xdzk39aguj8rcmq3es5ym6z7vgv6xungaypq56r72t2wq9ypt03
-        String senderMnemonic = "olive that walk sorry chat leisure attract river adult void host brand student income spy charge roast kiss balcony craft crouch kite agree south";
-        sender = new Account(Networks.testnet(), senderMnemonic);
-        senderAddress = sender.baseAddress();
     }
 
     @Test

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/function/StakeTransactionIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/function/StakeTransactionIT.java
@@ -49,6 +49,85 @@ public class StakeTransactionIT extends BaseITTest {
 
     ProtocolParams protocolParams;
 
+    static String senderMnemonic1 = "song dignity manage hub picture rival thumb gain picture leave rich axis eight scheme coral vendor guard paper report come cat draw educate group";
+    private static Account senderAccount1;
+    private static String senderAddr1;
+
+    static String senderMnemonic2 = "song dignity manage hub picture rival thumb gain picture leave rich axis eight scheme coral vendor guard paper report come cat draw educate group";
+
+    static Account senderAccount2;
+    static String senderAddr2;
+
+    static String senderMnemonic3 = "song dignity manage hub picture rival thumb gain picture leave rich axis eight scheme coral vendor guard paper report come cat draw educate group";
+    static Account senderAccount3;
+    static String senderAddr3;
+
+    static String senderMnemonic4 = "farm hunt wasp believe happy palm skull apple execute paddle asthma absorb misery unlock broom turkey few dry focus vacuum novel crumble dish token";
+    static Account senderAccount4;
+    static String senderAddr4;
+
+    static String senderMnemonic5 = "farm hunt wasp believe happy palm skull apple execute paddle asthma absorb misery unlock broom turkey few dry focus vacuum novel crumble dish token";
+    static Account senderAccount5;
+    static String senderAddr5;
+
+    static String senderMnemonic6 = "limb myself better pyramid home measure quality smile also reveal used sleep kind trend destroy output guide test memory clever spoil polar salon artist";
+    static Account senderAccount6;
+    static String senderAddr6;
+
+    static String senderMnemonic7 = "ready tree spawn ozone permit vacuum weasel lunar foster letter income melody chalk cat define lecture seek biology small lesson require artwork exact gorilla";
+    static Account senderAccount7;
+    static String senderAddr7;
+
+    static String senderMnemonic8 = "ready tree spawn ozone permit vacuum weasel lunar foster letter income melody chalk cat define lecture seek biology small lesson require artwork exact gorilla";
+    static Account senderAccount8;
+    static String senderAddr8;
+
+    static String senderMnemonic9 = "ready tree spawn ozone permit vacuum weasel lunar foster letter income melody chalk cat define lecture seek biology small lesson require artwork exact gorilla";
+    static Account senderAccount9;
+    static String senderAddr9;
+
+    @BeforeAll
+    public static void setupAll() {
+        senderAccount1 = new Account(Networks.testnet(), senderMnemonic1);
+        senderAddr1 = senderAccount1.baseAddress();
+
+        senderAccount2 = new Account(Networks.testnet(), senderMnemonic2);
+        senderAddr2 = senderAccount2.baseAddress();
+
+        senderAccount3 = new Account(Networks.testnet(), senderMnemonic3);
+        senderAddr3 = senderAccount3.baseAddress();
+
+        senderAccount4 = new Account(Networks.testnet(), senderMnemonic4);
+        senderAddr4 = senderAccount4.baseAddress();
+
+        senderAccount5 = new Account(Networks.testnet(), senderMnemonic5);
+        senderAddr5 = senderAccount5.baseAddress();
+
+        senderAccount6 = new Account(Networks.testnet(), senderMnemonic6);
+        senderAddr6 = senderAccount6.baseAddress();
+
+        senderAccount7 = new Account(Networks.testnet(), senderMnemonic7);
+        senderAddr7 = senderAccount7.baseAddress();
+
+        senderAccount8 = new Account(Networks.testnet(), senderMnemonic8);
+        senderAddr8 = senderAccount8.baseAddress();
+
+        senderAccount9 = new Account(Networks.testnet(), senderMnemonic9);
+        senderAddr9 = senderAccount9.baseAddress();
+
+        if (backendType.equals(DEVKIT)) {
+            topUpFund(senderAddr1, 50000);
+            topUpFund(senderAddr2, 50000);
+            topUpFund(senderAddr3, 50000);
+            topUpFund(senderAddr4, 50000);
+            topUpFund(senderAddr5, 50000);
+            topUpFund(senderAddr6, 50000);
+            topUpFund(senderAddr7, 50000);
+            topUpFund(senderAddr8, 50000);
+            topUpFund(senderAddr9, 50000);
+        }
+    }
+
     @BeforeEach
     public void setup() throws ApiException {
         protocolParams = getBackendService().getEpochService().getProtocolParameters().getValue();
@@ -57,23 +136,18 @@ public class StakeTransactionIT extends BaseITTest {
     @Test
     @Order(1)
     void testStakeRegistration_addressKeyAsStakeKey() throws ApiException, CborSerializationException {
-        String senderMnemonic = "song dignity manage hub picture rival thumb gain picture leave rich axis eight scheme coral vendor guard paper report come cat draw educate group";
-
-        Account senderAccount = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddr = senderAccount.baseAddress();
-
         //protocol params
         String depositStr = getBackendService().getEpochService().getProtocolParameters().getValue().getKeyDeposit();
         BigInteger deposit = new BigInteger(depositStr);
 
         UtxoSelectionStrategy selectionStrategy = new DefaultUtxoSelectionStrategyImpl(new DefaultUtxoSupplier(getBackendService().getUtxoService()));
 
-        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
+        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr2, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
 
         if (utxos == null || utxos.size() == 0)
             throw new RuntimeException("No utxo found");
 
-        HdKeyPair stakeHdKeyPair = senderAccount.stakeHdKeyPair();
+        HdKeyPair stakeHdKeyPair = senderAccount2.stakeHdKeyPair();
         byte[] stakePublicKey = stakeHdKeyPair.getPublicKey().getKeyData();
 
         //-- Stake key registration
@@ -83,19 +157,19 @@ public class StakeTransactionIT extends BaseITTest {
         };
 
         TxBuilder builder = txOutBuilder
-                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr))
+                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr2))
                 .andThen((context, txn) -> {
                     txn.getBody().getCerts().add(stakeRegistration);
                 })
                 .andThen((context, txn) -> {
-                    txn.getBody().getOutputs().stream().filter(transactionOutput -> senderAddr.equals(transactionOutput.getAddress()))
+                    txn.getBody().getOutputs().stream().filter(transactionOutput -> senderAddr2.equals(transactionOutput.getAddress()))
                             .findFirst()
                             .ifPresent(transactionOutput -> transactionOutput.getValue().setCoin(transactionOutput.getValue().getCoin().subtract(deposit)));
                 })
-                .andThen(feeCalculator(senderAddr, 2))
-                .andThen(adjustChangeOutput(senderAddr, 2));
+                .andThen(feeCalculator(senderAddr2, 2))
+                .andThen(adjustChangeOutput(senderAddr2, 2));
 
-        TxSigner signer = SignerProviders.signerFrom(senderAccount);
+        TxSigner signer = SignerProviders.signerFrom(senderAccount2);
 
         Transaction signedTransaction = TxBuilderContext.init(new DefaultUtxoSupplier(getBackendService().getUtxoService()),
                 new DefaultProtocolParamsSupplier(getBackendService().getEpochService()))
@@ -111,23 +185,18 @@ public class StakeTransactionIT extends BaseITTest {
     @Test
     @Order(2)
     void testStakeDelegation_addressKeyAsStakeKey() throws ApiException, CborSerializationException {
-        String senderMnemonic = "song dignity manage hub picture rival thumb gain picture leave rich axis eight scheme coral vendor guard paper report come cat draw educate group";
-
-        Account senderAccount = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddr = senderAccount.baseAddress();
-
         //protocol params
         String depositStr = getBackendService().getEpochService().getProtocolParameters().getValue().getKeyDeposit();
         BigInteger deposit = new BigInteger(depositStr);
 
         UtxoSelectionStrategy selectionStrategy = new DefaultUtxoSelectionStrategyImpl(new DefaultUtxoSupplier(getBackendService().getUtxoService()));
 
-        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
+        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr1, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
 
         if (utxos == null || utxos.size() == 0)
             throw new RuntimeException("No utxo found");
 
-        HdKeyPair stakeHdKeyPair = senderAccount.stakeHdKeyPair();
+        HdKeyPair stakeHdKeyPair = senderAccount1.stakeHdKeyPair();
         byte[] stakePublicKey = stakeHdKeyPair.getPublicKey().getKeyData();
 
         //-- Stake key delegation
@@ -141,16 +210,16 @@ public class StakeTransactionIT extends BaseITTest {
         };
 
         TxBuilder builder = txOutBuilder
-                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr))
+                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr1))
                 .andThen((context, txn) -> {
                     txn.getBody().getCerts().add(stakeDelegation);
                 })
                 .andThen(AuxDataProviders.metadataProvider(metadata))
-                .andThen(feeCalculator(senderAddr, 2))
-                .andThen(adjustChangeOutput(senderAddr, 2));
+                .andThen(feeCalculator(senderAddr1, 2))
+                .andThen(adjustChangeOutput(senderAddr1, 2));
 
-        TxSigner signer = SignerProviders.signerFrom(senderAccount)
-                .andThen(transaction -> senderAccount.signWithStakeKey(transaction));
+        TxSigner signer = SignerProviders.signerFrom(senderAccount1)
+                .andThen(transaction -> senderAccount1.signWithStakeKey(transaction));
 
         Transaction signedTransaction = TxBuilderContext.init(new DefaultUtxoSupplier(getBackendService().getUtxoService()), protocolParams)
                 .buildAndSign(builder, signer);
@@ -165,23 +234,18 @@ public class StakeTransactionIT extends BaseITTest {
     @Test
     @Order(3)
     void testStakeDeRegistration_addressKeyAsStakeKey() throws ApiException, CborSerializationException {
-        String senderMnemonic = "song dignity manage hub picture rival thumb gain picture leave rich axis eight scheme coral vendor guard paper report come cat draw educate group";
-
-        Account senderAccount = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddr = senderAccount.baseAddress();
-
         //protocol params
         String depositStr = getBackendService().getEpochService().getProtocolParameters().getValue().getKeyDeposit();
         BigInteger deposit = new BigInteger(depositStr);
 
         UtxoSelectionStrategy selectionStrategy = new DefaultUtxoSelectionStrategyImpl(new DefaultUtxoSupplier(getBackendService().getUtxoService()));
 
-        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
+        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr3, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
 
         if (utxos == null || utxos.size() == 0)
             throw new RuntimeException("No utxo found");
 
-        HdKeyPair stakeHdKeyPair = senderAccount.stakeHdKeyPair();
+        HdKeyPair stakeHdKeyPair = senderAccount3.stakeHdKeyPair();
         byte[] stakePublicKey = stakeHdKeyPair.getPublicKey().getKeyData();
 
         //-- Stake key deregistration
@@ -191,19 +255,19 @@ public class StakeTransactionIT extends BaseITTest {
         };
 
         TxBuilder builder = txOutBuilder
-                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr))
+                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr3))
                 .andThen((context, txn) -> {
                     txn.getBody().getCerts().add(stakeRegistration);
                 })
                 .andThen((context, txn) -> {
-                    txn.getBody().getOutputs().stream().filter(transactionOutput -> senderAddr.equals(transactionOutput.getAddress()))
+                    txn.getBody().getOutputs().stream().filter(transactionOutput -> senderAddr3.equals(transactionOutput.getAddress()))
                             .findFirst()
                             .ifPresent(transactionOutput -> transactionOutput.getValue().setCoin(transactionOutput.getValue().getCoin().add(deposit)));
                 })
-                .andThen(feeCalculator(senderAddr, 2))
-                .andThen(adjustChangeOutput(senderAddr, 2));
+                .andThen(feeCalculator(senderAddr3, 2))
+                .andThen(adjustChangeOutput(senderAddr3, 2));
 
-        TxSigner signer = SignerProviders.signerFrom(senderAccount)
+        TxSigner signer = SignerProviders.signerFrom(senderAccount3)
                 .andThen(transaction -> TransactionSigner.INSTANCE.sign(transaction, stakeHdKeyPair));
 
         Transaction signedTransaction = TxBuilderContext.init(new DefaultUtxoSupplier(getBackendService().getUtxoService()), protocolParams)
@@ -221,24 +285,18 @@ public class StakeTransactionIT extends BaseITTest {
     @Test
     @Order(4)
     void testStakeDelegationAnotherAccount() throws ApiException, CborSerializationException {
-        String senderMnemonic = "farm hunt wasp believe happy palm skull apple execute paddle asthma absorb misery unlock broom turkey few dry focus vacuum novel crumble dish token";
-
-        Account senderAccount = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddr = senderAccount.baseAddress();
-        System.out.println(senderAddr);
-
         //protocol params
         String depositStr = getBackendService().getEpochService().getProtocolParameters().getValue().getKeyDeposit();
         BigInteger deposit = new BigInteger(depositStr);
 
         UtxoSelectionStrategy selectionStrategy = new DefaultUtxoSelectionStrategyImpl(new DefaultUtxoSupplier(getBackendService().getUtxoService()));
 
-        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
+        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr4, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
 
         if (utxos == null || utxos.size() == 0)
             throw new RuntimeException("No utxo found");
 
-        HdKeyPair stakeHdKeyPair = senderAccount.stakeHdKeyPair();
+        HdKeyPair stakeHdKeyPair = senderAccount4.stakeHdKeyPair();
         byte[] stakePublicKey = stakeHdKeyPair.getPublicKey().getKeyData();
 
         //-- Stake key delegation
@@ -252,16 +310,16 @@ public class StakeTransactionIT extends BaseITTest {
         };
 
         TxBuilder builder = txOutBuilder
-                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr))
+                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr4))
                 .andThen((context, txn) -> {
                     txn.getBody().getCerts().add(stakeDelegation);
                 })
                 .andThen(AuxDataProviders.metadataProvider(metadata))
-                .andThen(feeCalculator(senderAddr, 2))
-                .andThen(adjustChangeOutput(senderAddr, 2));
+                .andThen(feeCalculator(senderAddr4, 2))
+                .andThen(adjustChangeOutput(senderAddr4, 2));
 
-        TxSigner signer = SignerProviders.signerFrom(senderAccount)
-                .andThen(transaction -> senderAccount.signWithStakeKey(transaction));
+        TxSigner signer = SignerProviders.signerFrom(senderAccount4)
+                .andThen(transaction -> senderAccount4.signWithStakeKey(transaction));
 
         Transaction signedTransaction = TxBuilderContext.init(new DefaultUtxoSupplier(getBackendService().getUtxoService()), protocolParams)
                 .buildAndSign(builder, signer);
@@ -275,34 +333,26 @@ public class StakeTransactionIT extends BaseITTest {
 
     @Test
     void testWithdrawal() throws ApiException, CborSerializationException {
-        String senderMnemonic = "farm hunt wasp believe happy palm skull apple execute paddle asthma absorb misery unlock broom turkey few dry focus vacuum novel crumble dish token";
-
-        Account senderAccount = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddr = senderAccount.baseAddress();
-
-        String senderMnemonic2 = "limb myself better pyramid home measure quality smile also reveal used sleep kind trend destroy output guide test memory clever spoil polar salon artist";
-        Account senderAccount2 = new Account(Networks.testnet(), senderMnemonic2);
-
         //protocol params
         String depositStr = getBackendService().getEpochService().getProtocolParameters().getValue().getKeyDeposit();
         BigInteger deposit = new BigInteger(depositStr);
 
         UtxoSelectionStrategy selectionStrategy = new DefaultUtxoSelectionStrategyImpl(new DefaultUtxoSupplier(getBackendService().getUtxoService()));
 
-        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
+        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr5, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
 
         if (utxos == null || utxos.size() == 0)
             throw new RuntimeException("No utxo found");
 
         //-- Stake addresses
-        String stakeAddress = senderAccount.stakeAddress();
-        String stakeAddress2 = senderAccount2.stakeAddress();
+        String stakeAddress = senderAccount5.stakeAddress();
+        String stakeAddress2 = senderAccount6.stakeAddress();
 
         TxOutputBuilder txOutBuilder = (context, outputs) -> {
         };
 
         TxBuilder builder = txOutBuilder
-                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr))
+                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr5))
                 .andThen((context, txn) -> {
                     //Currently zero for testing as there is no reward available. But update this value later once reward is available.
                     BigInteger rewardAmt = BigInteger.ZERO;
@@ -311,12 +361,12 @@ public class StakeTransactionIT extends BaseITTest {
                     //Add reward amount to output
                     txn.getBody().getOutputs().get(0).getValue().getCoin().add(rewardAmt);
                 })
-                .andThen(feeCalculator(senderAddr, 3))
-                .andThen(adjustChangeOutput(senderAddr, 3));
+                .andThen(feeCalculator(senderAddr5, 3))
+                .andThen(adjustChangeOutput(senderAddr5, 3));
 
-        TxSigner signer = SignerProviders.signerFrom(senderAccount)
-                .andThen(transaction -> senderAccount.signWithStakeKey(transaction))
-                .andThen(transaction -> senderAccount2.signWithStakeKey(transaction));
+        TxSigner signer = SignerProviders.signerFrom(senderAccount5)
+                .andThen(transaction -> senderAccount5.signWithStakeKey(transaction))
+                .andThen(transaction -> senderAccount6.signWithStakeKey(transaction));
 
         Transaction signedTransaction = TxBuilderContext.init(new DefaultUtxoSupplier(getBackendService().getUtxoService()), protocolParams)
                 .buildAndSign(builder, signer);
@@ -331,18 +381,13 @@ public class StakeTransactionIT extends BaseITTest {
     @Test
     @Order(5)
     void testStakeRegistration_scriptHashAsStakeKey() throws ApiException, CborSerializationException, IOException {
-        String senderMnemonic = "ready tree spawn ozone permit vacuum weasel lunar foster letter income melody chalk cat define lecture seek biology small lesson require artwork exact gorilla";
-
-        Account senderAccount = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddr = senderAccount.baseAddress();
-
         //protocol params
         String depositStr = getBackendService().getEpochService().getProtocolParameters().getValue().getKeyDeposit();
         BigInteger deposit = new BigInteger(depositStr);
 
         UtxoSelectionStrategy selectionStrategy = new DefaultUtxoSelectionStrategyImpl(new DefaultUtxoSupplier(getBackendService().getUtxoService()));
 
-        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
+        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr7, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
 
         if (utxos == null || utxos.size() == 0)
             throw new RuntimeException("No utxo found");
@@ -358,19 +403,19 @@ public class StakeTransactionIT extends BaseITTest {
         };
 
         TxBuilder builder = txOutBuilder
-                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr))
+                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr7))
                 .andThen((context, txn) -> {
                     txn.getBody().getCerts().add(stakeRegistration);
                 })
                 .andThen((context, txn) -> {
-                    txn.getBody().getOutputs().stream().filter(transactionOutput -> senderAddr.equals(transactionOutput.getAddress()))
+                    txn.getBody().getOutputs().stream().filter(transactionOutput -> senderAddr7.equals(transactionOutput.getAddress()))
                             .findFirst()
                             .ifPresent(transactionOutput -> transactionOutput.getValue().setCoin(transactionOutput.getValue().getCoin().subtract(deposit)));
                 })
-                .andThen(feeCalculator(senderAddr, 1))
-                .andThen(adjustChangeOutput(senderAddr, 1));
+                .andThen(feeCalculator(senderAddr7, 1))
+                .andThen(adjustChangeOutput(senderAddr7, 1));
 
-        TxSigner signer = SignerProviders.signerFrom(senderAccount);
+        TxSigner signer = SignerProviders.signerFrom(senderAccount7);
 
         Transaction signedTransaction = TxBuilderContext.init(new DefaultUtxoSupplier(getBackendService().getUtxoService()), protocolParams)
                 .buildAndSign(builder, signer);
@@ -385,13 +430,10 @@ public class StakeTransactionIT extends BaseITTest {
     @Test
     @Order(6)
     void testStakeDelegation_scriptHashAsStakeKey() throws Exception {
-        String stakingPaymentAccountMnemonic = "ready tree spawn ozone permit vacuum weasel lunar foster letter income melody chalk cat define lecture seek biology small lesson require artwork exact gorilla";
-        Account stakingPaymentAccount = new Account(Networks.testnet(), stakingPaymentAccountMnemonic);
-
         Policy policy = loadJsonPolicyScript(STAKEREGISTRATION_POLICY_JSON);
 
         //Get a address for payment key (Account at address 0) and Script as delegation key
-        Address address = AddressProvider.getBaseAddress(stakingPaymentAccount.hdKeyPair().getPublicKey(), policy.getPolicyScript(), Networks.testnet());
+        Address address = AddressProvider.getBaseAddress(senderAccount8.hdKeyPair().getPublicKey(), policy.getPolicyScript(), Networks.testnet());
         String baseAddress = address.toBech32();
         System.out.println(baseAddress);
 
@@ -445,18 +487,13 @@ public class StakeTransactionIT extends BaseITTest {
     @Test
     @Order(7)
     void testStakeDeRegistration_scriptHashAsStakeKey() throws ApiException, CborSerializationException, IOException {
-        String senderMnemonic = "ready tree spawn ozone permit vacuum weasel lunar foster letter income melody chalk cat define lecture seek biology small lesson require artwork exact gorilla";
-
-        Account senderAccount = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddr = senderAccount.baseAddress();
-
         //protocol params
         String depositStr = getBackendService().getEpochService().getProtocolParameters().getValue().getKeyDeposit();
         BigInteger deposit = new BigInteger(depositStr);
 
         UtxoSelectionStrategy selectionStrategy = new DefaultUtxoSelectionStrategyImpl(new DefaultUtxoSupplier(getBackendService().getUtxoService()));
 
-        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
+        List<Utxo> utxos = selectionStrategy.selectUtxos(senderAddr9, LOVELACE, deposit.add(adaToLovelace(2)), Collections.EMPTY_SET);
 
         if (utxos == null || utxos.size() == 0)
             throw new RuntimeException("No utxo found");
@@ -472,22 +509,22 @@ public class StakeTransactionIT extends BaseITTest {
         };
 
         TxBuilder builder = txOutBuilder
-                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr))
+                .buildInputs(InputBuilders.createFromUtxos(utxos, senderAddr9))
                 .andThen((context, txn) -> {
                     txn.getBody().getCerts().add(stakeDeregistration);
                 })
                 .andThen((context, txn) -> {
-                    txn.getBody().getOutputs().stream().filter(transactionOutput -> senderAddr.equals(transactionOutput.getAddress()))
+                    txn.getBody().getOutputs().stream().filter(transactionOutput -> senderAddr9.equals(transactionOutput.getAddress()))
                             .findFirst()
                             .ifPresent(transactionOutput -> transactionOutput.getValue().setCoin(transactionOutput.getValue().getCoin().add(deposit)));
                 })
                 .andThen((context, txn) -> {
                     txn.getWitnessSet().getNativeScripts().add(policy.getPolicyScript());
                 })
-                .andThen(feeCalculator(senderAddr, 3))
-                .andThen(adjustChangeOutput(senderAddr, 3));
+                .andThen(feeCalculator(senderAddr9, 3))
+                .andThen(adjustChangeOutput(senderAddr9, 3));
 
-        TxSigner signer = SignerProviders.signerFrom(senderAccount)
+        TxSigner signer = SignerProviders.signerFrom(senderAccount9)
                 .andThen(transaction -> TransactionSigner.INSTANCE.sign(transaction, policy.getPolicyKeys().get(0)))
                 .andThen(transaction -> TransactionSigner.INSTANCE.sign(transaction, policy.getPolicyKeys().get(1)));
 

--- a/integration-test/src/it/java/com/bloxbean/cardano/client/function/TxBuilderContextIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/function/TxBuilderContextIT.java
@@ -25,6 +25,7 @@ import com.bloxbean.cardano.client.metadata.cbor.CBORMetadataList;
 import com.bloxbean.cardano.client.metadata.cbor.CBORMetadataMap;
 import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.util.JsonUtil;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,6 +52,29 @@ public class TxBuilderContextIT extends BaseITTest {
     UtxoSupplier utxoSupplier;
     ProtocolParams protocolParams;
 
+    static Account senderAccount1;
+    static String senderAddress1;
+
+    static Account senderAccount2;
+    static String senderAddress2;
+
+    @BeforeAll
+    public static void setupAll() {
+        //addr_test1qrynkm9vzsl7vrufzn6y4zvl2v55x0xwc02nwg00x59qlkxtsu6q93e6mrernam0k4vmkn3melezkvgtq84d608zqhnsn48axp
+        String senderMnemonic = "stone decade great marine meadow merge boss ahead again rapid detect cover vital estate web silly copper estate wisdom empty speed salute oak car";
+        senderAccount1 = new Account(Networks.testnet(), senderMnemonic);
+        senderAddress1 = senderAccount1.baseAddress();
+
+        String senderMnemonic2 = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
+        senderAccount2 = new Account(Networks.testnet(), senderMnemonic2);
+        senderAddress2 = senderAccount2.baseAddress();
+
+        if (backendType.equals(DEVKIT)) {
+            topUpFund(senderAddress1, 50000);
+            topUpFund(senderAddress2, 50000);
+        }
+    }
+
     @BeforeEach
     public void setup() throws ApiException {
         backendService = getBackendService();
@@ -60,6 +84,7 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     void testTransactionBuilding() throws CborSerializationException, ApiException {
+        if (backendType == DEVKIT) return; //skip
         //addr_test1qrynkm9vzsl7vrufzn6y4zvl2v55x0xwc02nwg00x59qlkxtsu6q93e6mrernam0k4vmkn3melezkvgtq84d608zqhnsn48axp
         String senderMnemonic = "stone decade great marine meadow merge boss ahead again rapid detect cover vital estate web silly copper estate wisdom empty speed salute oak car";
 
@@ -180,9 +205,6 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     void testMintingTwoNFTs_withSamePolicy() throws Exception {
-        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
-        Account sender = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddress = sender.baseAddress();
 
         String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
         String receiver2 = "addr_test1qq9f6hzuwmqpe3p9h90z2rtgs0v0lsq9ln5f79fjyec7eclg7v88q9als70uzkdh5k6hw20uuwqfz477znfp5v4rga2s3ysgxu";
@@ -255,14 +277,14 @@ public class TxBuilderContextIT extends BaseITTest {
                 createFromMintOutput(mintOutput1)
                         .and(createFromMintOutput(mintOutput2))
                         .and(createFromMintOutput(output3))
-                        .buildInputs(createFromSender(senderAddress, senderAddress))
+                        .buildInputs(createFromSender(senderAddress1, senderAddress1))
                         .andThen(mintCreator(policy.getPolicyScript(), mergeMultiAsset))
                         .andThen(metadataProvider(nftMetadata))
-                        .andThen(balanceTx(senderAddress, 2));
+                        .andThen(balanceTx(senderAddress1, 2));
 
         //Build and sign transaction
         Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
-                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+                .buildAndSign(txBuilder, signerFrom(senderAccount1).andThen(signerFrom(policy)));
 
         Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
         System.out.println(result);
@@ -277,9 +299,6 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     void testMintingTwoNFTs_withSamePolicyAndAssetName_differentReceivers() throws Exception {
-        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
-        Account sender = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddress = sender.baseAddress();
 
         String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
         String receiver2 = "addr_test1qq9f6hzuwmqpe3p9h90z2rtgs0v0lsq9ln5f79fjyec7eclg7v88q9als70uzkdh5k6hw20uuwqfz477znfp5v4rga2s3ysgxu";
@@ -352,14 +371,14 @@ public class TxBuilderContextIT extends BaseITTest {
                 createFromMintOutput(mintOutput1)
                         .and(createFromMintOutput(mintOutput2))
                         .and(createFromMintOutput(output3))
-                        .buildInputs(createFromSender(senderAddress, senderAddress))
+                        .buildInputs(createFromSender(senderAddress1, senderAddress1))
                         .andThen(mintCreator(policy.getPolicyScript(), mergeMultiAsset))
                         .andThen(metadataProvider(nftMetadata))
-                        .andThen(balanceTx(senderAddress, 2));
+                        .andThen(balanceTx(senderAddress1, 2));
 
         //Build and sign transaction
         Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
-                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+                .buildAndSign(txBuilder, signerFrom(senderAccount1).andThen(signerFrom(policy)));
 
         Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
         System.out.println(result);
@@ -374,9 +393,6 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     void testMintingTwoNFTs_withSamePolicyAndAssetName_differentReceivers_withOutputClass() throws Exception {
-        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
-        Account sender = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddress = sender.baseAddress();
 
         String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
         String receiver2 = "addr_test1qq9f6hzuwmqpe3p9h90z2rtgs0v0lsq9ln5f79fjyec7eclg7v88q9als70uzkdh5k6hw20uuwqfz477znfp5v4rga2s3ysgxu";
@@ -466,14 +482,14 @@ public class TxBuilderContextIT extends BaseITTest {
                         .and(output2.outputBuilder())
                         .and(output21.mintOutputBuilder())
                         .and(createFromMintOutput(output3)) //An alternate way
-                        .buildInputs(createFromSender(senderAddress, senderAddress))
+                        .buildInputs(createFromSender(senderAddress1, senderAddress1))
                         .andThen(mintCreator(policy.getPolicyScript(), mergeMultiAsset))
                         .andThen(metadataProvider(nftMetadata))
-                        .andThen(balanceTx(senderAddress, 2));
+                        .andThen(balanceTx(senderAddress1, 2));
 
         //Build and sign transaction
         Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
-                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+                .buildAndSign(txBuilder, signerFrom(senderAccount1).andThen(signerFrom(policy)));
 
         Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
         System.out.println(result);
@@ -488,10 +504,6 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     public void mintToken() throws CborSerializationException, ApiException, AddressExcepion {
-        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
-        Account sender = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddress = sender.baseAddress();
-        System.out.println("sender: " + senderAddress);
 
         String receiverAddress = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
 
@@ -525,13 +537,13 @@ public class TxBuilderContextIT extends BaseITTest {
                 .build();
 
         TxBuilder txBuilder = output.mintOutputBuilder()
-                .buildInputs(InputBuilders.createFromSender(senderAddress, senderAddress))
+                .buildInputs(InputBuilders.createFromSender(senderAddress1, senderAddress1))
                 .andThen(MintCreators.mintCreator(policy.getPolicyScript(), multiAsset))
                 .andThen(AuxDataProviders.metadataProvider(metadata))
-                .andThen(BalanceTxBuilders.balanceTx(senderAddress, 2));
+                .andThen(BalanceTxBuilders.balanceTx(senderAddress1, 2));
 
         Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
-                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+                .buildAndSign(txBuilder, signerFrom(senderAccount1).andThen(signerFrom(policy)));
 
         Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
         System.out.println(result);
@@ -547,10 +559,6 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     void testPayments_whenMergeOutputTrue() throws Exception {
-        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
-        Account sender = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddress = sender.baseAddress();
-
         String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
         String receiver2 = "addr_test1qq9f6hzuwmqpe3p9h90z2rtgs0v0lsq9ln5f79fjyec7eclg7v88q9als70uzkdh5k6hw20uuwqfz477znfp5v4rga2s3ysgxu";
         String receiver3 = "addr_test1qqqvjp4ffcdqg3fmx0k8rwamnn06wp8e575zcv8d0m3tjn2mmexsnkxp7az774522ce4h3qs4tjp9rxjjm46qf339d9sk33rqn";
@@ -639,14 +647,14 @@ public class TxBuilderContextIT extends BaseITTest {
                         .and(output2.outputBuilder())
                         .and(output21.mintOutputBuilder())
                         .and(createFromMintOutput(output3)) //An alternate way
-                        .buildInputs(createFromSender(senderAddress, senderAddress))
+                        .buildInputs(createFromSender(senderAddress1, senderAddress1))
                         .andThen(mintCreator(policy.getPolicyScript(), mergeMultiAsset))
                         .andThen(metadataProvider(nftMetadata))
-                        .andThen(balanceTx(senderAddress, 2));
+                        .andThen(balanceTx(senderAddress1, 2));
 
         //Build and sign transaction
         Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
-                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+                .buildAndSign(txBuilder, signerFrom(senderAccount1).andThen(signerFrom(policy)));
 
         assertThat(signedTransaction.getBody().getOutputs()).hasSize(4); //Total 4 outputs including change output
         assertThat(signedTransaction.getBody().getOutputs().get(0).getValue().getCoin()).isEqualTo(adaToLovelace(2.3));
@@ -669,10 +677,6 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     void testPayments_whenMergeOutputFalse() throws Exception {
-        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
-        Account sender = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddress = sender.baseAddress();
-
         String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
         String receiver2 = "addr_test1qq9f6hzuwmqpe3p9h90z2rtgs0v0lsq9ln5f79fjyec7eclg7v88q9als70uzkdh5k6hw20uuwqfz477znfp5v4rga2s3ysgxu";
         String receiver3 = "addr_test1qqqvjp4ffcdqg3fmx0k8rwamnn06wp8e575zcv8d0m3tjn2mmexsnkxp7az774522ce4h3qs4tjp9rxjjm46qf339d9sk33rqn";
@@ -761,15 +765,15 @@ public class TxBuilderContextIT extends BaseITTest {
                         .and(output2.outputBuilder())
                         .and(output21.mintOutputBuilder())
                         .and(createFromMintOutput(output3)) //An alternate way
-                        .buildInputs(createFromSender(senderAddress, senderAddress))
+                        .buildInputs(createFromSender(senderAddress2, senderAddress2))
                         .andThen(mintCreator(policy.getPolicyScript(), mergeMultiAsset))
                         .andThen(metadataProvider(nftMetadata))
-                        .andThen(balanceTx(senderAddress, 2));
+                        .andThen(balanceTx(senderAddress2, 2));
 
         //Build and sign transaction
         Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
                 .mergeOutputs(false)
-                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+                .buildAndSign(txBuilder, signerFrom(senderAccount2).andThen(signerFrom(policy)));
 
         assertThat(signedTransaction.getBody().getOutputs()).hasSize(6); //Total 4 outputs including change output
         assertThat(signedTransaction.getBody().getOutputs().get(0).getAddress()).isEqualTo(receiver1);
@@ -792,7 +796,7 @@ public class TxBuilderContextIT extends BaseITTest {
         assertThat(signedTransaction.getBody().getOutputs().get(4).getValue().getCoin()).isEqualTo(adaToLovelace(4));
         assertThat(signedTransaction.getBody().getOutputs().get(4).getValue().getMultiAssets()).isEmpty();
 
-        assertThat(signedTransaction.getBody().getOutputs().get(5).getAddress()).isEqualTo(senderAddress);
+        assertThat(signedTransaction.getBody().getOutputs().get(5).getAddress()).isEqualTo(senderAddress2);
 
         Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
         System.out.println(result);
@@ -807,10 +811,6 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     void testPayment_withMinUtxoValue_mergeOutputsIsTrue() throws Exception {
-        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
-        Account sender = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddress = sender.baseAddress();
-
         String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
 
         Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("policy-1", 1);
@@ -825,7 +825,7 @@ public class TxBuilderContextIT extends BaseITTest {
         //Define outputs
         //Output using Output class
         Output mintOutput = Output.builder()
-                .address(senderAddress)
+                .address(senderAddress2)
                 .policyId(policy.getPolicyId())
                 .assetName("TestNFT")
                 .qty(BigInteger.valueOf(100))
@@ -841,13 +841,13 @@ public class TxBuilderContextIT extends BaseITTest {
         TxBuilder txBuilder =
                 mintOutput.mintOutputBuilder()
                         .and(feeOutput.mintOutputBuilder())
-                        .buildInputs(createFromSender(senderAddress, senderAddress))
+                        .buildInputs(createFromSender(senderAddress2, senderAddress2))
                         .andThen(mintCreator(policy.getPolicyScript(), multiAsset1))
-                        .andThen(balanceTx(senderAddress, 2));
+                        .andThen(balanceTx(senderAddress2, 2));
 
         //Build and sign transaction
         Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
-                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+                .buildAndSign(txBuilder, signerFrom(senderAccount2).andThen(signerFrom(policy)));
 
         //asserts
         assertThat(signedTransaction.getBody().getOutputs()).hasSize(2);
@@ -855,7 +855,7 @@ public class TxBuilderContextIT extends BaseITTest {
         assertThat(signedTransaction.getBody().getOutputs().get(0).getValue().getCoin()).isEqualTo(adaToLovelace(1));
         assertThat(signedTransaction.getBody().getOutputs().get(0).getValue().getMultiAssets()).isEmpty();
 
-        assertThat(signedTransaction.getBody().getOutputs().get(1).getAddress()).isEqualTo(senderAddress);
+        assertThat(signedTransaction.getBody().getOutputs().get(1).getAddress()).isEqualTo(senderAddress2);
         assertThat(signedTransaction.getBody().getOutputs().get(1).getValue().getMultiAssets().size()).isGreaterThanOrEqualTo(1);
 
         Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
@@ -872,10 +872,6 @@ public class TxBuilderContextIT extends BaseITTest {
 
     @Test
     void testPayment_withCreateFromUtxos_withMinUtxoValue_mergeOutputsIsFalse() throws Exception {
-        String senderMnemonic = "kit color frog trick speak employ suit sort bomb goddess jewel primary spoil fade person useless measure manage warfare reduce few scrub beyond era";
-        Account sender = new Account(Networks.testnet(), senderMnemonic);
-        String senderAddress = sender.baseAddress();
-
         String receiver1 = "addr_test1qqwpl7h3g84mhr36wpetk904p7fchx2vst0z696lxk8ujsjyruqwmlsm344gfux3nsj6njyzj3ppvrqtt36cp9xyydzqzumz82";
 
         Policy policy = PolicyUtil.createMultiSigScriptAllPolicy("policy-1", 1);
@@ -890,7 +886,7 @@ public class TxBuilderContextIT extends BaseITTest {
         //Define outputs
         //Output using Output class
         Output mintOutput = Output.builder()
-                .address(senderAddress)
+                .address(senderAddress1)
                 .policyId(policy.getPolicyId())
                 .assetName("TestNFT")
                 .qty(BigInteger.valueOf(100))
@@ -902,7 +898,7 @@ public class TxBuilderContextIT extends BaseITTest {
                 .qty(adaToLovelace(1))
                 .build();
 
-        List<Utxo> utxos = backendService.getUtxoService().getUtxos(senderAddress, 10, 0).getValue();
+        List<Utxo> utxos = backendService.getUtxoService().getUtxos(senderAddress1, 10, 0).getValue();
         if (utxos == null)
             utxos = Collections.emptyList();
 
@@ -910,28 +906,28 @@ public class TxBuilderContextIT extends BaseITTest {
         TxBuilder txBuilder =
                 mintOutput.mintOutputBuilder()
                         .and(feeOutput.mintOutputBuilder())
-                        .buildInputs(createFromUtxos(utxos, senderAddress))
+                        .buildInputs(createFromUtxos(utxos, senderAddress1))
                         .andThen(mintCreator(policy.getPolicyScript(), multiAsset1))
-                        .andThen(balanceTx(senderAddress, 2));
+                        .andThen(balanceTx(senderAddress1, 2));
 
         //Build and sign transaction
         Transaction signedTransaction = TxBuilderContext.init(utxoSupplier, protocolParams)
                 .mergeOutputs(false)
-                .buildAndSign(txBuilder, signerFrom(sender).andThen(signerFrom(policy)));
+                .buildAndSign(txBuilder, signerFrom(senderAccount1).andThen(signerFrom(policy)));
 
         Result<String> result = backendService.getTransactionService().submitTransaction(signedTransaction.serialize());
         System.out.println(result);
 
         //asserts
         assertThat(signedTransaction.getBody().getOutputs()).hasSize(3);
-        assertThat(signedTransaction.getBody().getOutputs().get(0).getAddress()).isEqualTo(senderAddress);
+        assertThat(signedTransaction.getBody().getOutputs().get(0).getAddress()).isEqualTo(senderAddress1);
         assertThat(signedTransaction.getBody().getOutputs().get(0).getValue().getMultiAssets()).hasSize(1);
 
         assertThat(signedTransaction.getBody().getOutputs().get(1).getAddress()).isEqualTo(receiver1);
         assertThat(signedTransaction.getBody().getOutputs().get(1).getValue().getCoin()).isEqualTo(adaToLovelace(1));
         assertThat(signedTransaction.getBody().getOutputs().get(1).getValue().getMultiAssets()).isEmpty();
 
-        assertThat(signedTransaction.getBody().getOutputs().get(2).getAddress()).isEqualTo(senderAddress);
+        assertThat(signedTransaction.getBody().getOutputs().get(2).getAddress()).isEqualTo(senderAddress1);
 
         if (result.isSuccessful())
             System.out.println("Transaction Id: " + result.getValue());

--- a/plutus/src/main/java/com/bloxbean/cardano/client/plutus/util/ScriptDataHashGenerator.java
+++ b/plutus/src/main/java/com/bloxbean/cardano/client/plutus/util/ScriptDataHashGenerator.java
@@ -54,7 +54,7 @@ public class ScriptDataHashGenerator {
         if (redeemers != null && redeemers.size() > 0) {
 
             byte[] redeemerBytes;
-            if (era == Era.Conway) {
+            if (era.value >= Era.Conway.value) {
                 Map redeemerMap = new Map();
                 for(Redeemer redeemer: redeemers) {
                     var tuple = redeemer.serialize();
@@ -71,7 +71,7 @@ public class ScriptDataHashGenerator {
 
             encodedBytes = Bytes.concat(redeemerBytes, plutusDataBytes, costMdls.getLanguageViewEncoding());
         } else {
-            if (era == Era.Conway) {
+            if (era.value >= Era.Conway.value) {
                 encodedBytes = Bytes.concat(HexUtil.decodeHexString("0xA0"), plutusDataBytes, costMdls.getLanguageViewEncoding());
             } else { //Pre conway era
                 /**

--- a/plutus/src/main/java/com/bloxbean/cardano/client/plutus/util/ScriptDataHashGenerator.java
+++ b/plutus/src/main/java/com/bloxbean/cardano/client/plutus/util/ScriptDataHashGenerator.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
 import com.bloxbean.cardano.client.crypto.Blake2bUtil;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.plutus.spec.CostMdls;
+import com.bloxbean.cardano.client.plutus.spec.Language;
 import com.bloxbean.cardano.client.plutus.spec.PlutusData;
 import com.bloxbean.cardano.client.plutus.spec.Redeemer;
 import com.bloxbean.cardano.client.spec.Era;
@@ -25,8 +26,14 @@ public class ScriptDataHashGenerator {
     public static byte[] generate(Era era, List<Redeemer> redeemers, List<PlutusData> datums, CostMdls costMdls)
             throws CborSerializationException, CborException {
 
-        if (era == null)
+        //For workaround: https://github.com/bloxbean/cardano-client-lib/issues/426
+        boolean plutusV1Exists = costMdls.get(Language.PLUTUS_V1) != null;
+
+        if (era == null && plutusV1Exists){ //If era is not set and PlutusV1 exists, set era to Babbage
+            era = Era.Babbage;
+        } else if (era == null) {
             era = EraSerializationConfig.INSTANCE.getEra();
+        }
 
 
         /**

--- a/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/GovernanceScriptTxIT.java
+++ b/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/GovernanceScriptTxIT.java
@@ -41,7 +41,7 @@ public class GovernanceScriptTxIT extends QuickTxBaseIT {
 
     QuickTxBuilder quickTxBuilder;
 
-    static GovActionId lastGovActionId;
+    static GovActionId lastGovActionId = new GovActionId("1d9dce2addcf59a9b65d16c342368eb1e1d2b3ad2762e73c62f36380927cf898", 0);
 
     @Override
     public BackendService getBackendService() {
@@ -70,7 +70,7 @@ public class GovernanceScriptTxIT extends QuickTxBaseIT {
 
         PlutusV3Script plutusScript = PlutusV3Script.builder()
                 .type("PlutusScriptV3")
-                .cborHex("49480100002221200101")
+                .cborHex("46450101002499")
                 .build();
 
         var scriptHash = plutusScript.getScriptHash();
@@ -112,7 +112,7 @@ public class GovernanceScriptTxIT extends QuickTxBaseIT {
 
         PlutusV3Script plutusScript = PlutusV3Script.builder()
                 .type("PlutusScriptV3")
-                .cborHex("49480100002221200101")
+                .cborHex("46450101002499")
                 .build();
 
         var scriptHash = plutusScript.getScriptHash();
@@ -152,7 +152,7 @@ public class GovernanceScriptTxIT extends QuickTxBaseIT {
 
         PlutusV3Script plutusScript = PlutusV3Script.builder()
                 .type("PlutusScriptV3")
-                .cborHex("49480100002221200101")
+                .cborHex("46450101002499")
                 .build();
 
         var parameterChange = new ParameterChangeAction();
@@ -192,7 +192,7 @@ public class GovernanceScriptTxIT extends QuickTxBaseIT {
     void createVote() throws CborSerializationException {
         PlutusV3Script plutusScript = PlutusV3Script.builder()
                 .type("PlutusScriptV3")
-                .cborHex("49480100002221200101")
+                .cborHex("46450101002499")
                 .build();
 
         var scriptHash = plutusScript.getScriptHash();
@@ -232,7 +232,7 @@ public class GovernanceScriptTxIT extends QuickTxBaseIT {
         registerStakeKeys();
         PlutusV3Script drepPlutusScript = PlutusV3Script.builder()
                 .type("PlutusScriptV3")
-                .cborHex("49480100002221200101")
+                .cborHex("46450101002499")
                 .build();
 
         var drepScriptHash = drepPlutusScript.getScriptHash();
@@ -286,7 +286,7 @@ public class GovernanceScriptTxIT extends QuickTxBaseIT {
 
         PlutusV3Script plutusScript = PlutusV3Script.builder()
                 .type("PlutusScriptV3")
-                .cborHex("49480100002221200101")
+                .cborHex("46450101002499")
                 .build();
 
         var scriptHash = plutusScript.getScriptHash();

--- a/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/HelloContractOffchainIT.java
+++ b/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/HelloContractOffchainIT.java
@@ -1,0 +1,89 @@
+package com.bloxbean.cardano.client.quicktx;
+
+import com.bloxbean.cardano.client.address.AddressProvider;
+import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.backend.api.DefaultUtxoSupplier;
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.function.helper.ScriptUtxoFinders;
+import com.bloxbean.cardano.client.function.helper.SignerProviders;
+import com.bloxbean.cardano.client.plutus.blueprint.PlutusBlueprintUtil;
+import com.bloxbean.cardano.client.plutus.blueprint.model.PlutusVersion;
+import com.bloxbean.cardano.client.plutus.spec.*;
+import com.bloxbean.cardano.client.util.JsonUtil;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HelloContractOffchainIT extends TestDataBaseIT {
+    String compiledCode = "590169010100323232323232323225333002323232323253330073370e900118049baa0011323232533300a3370e900018061baa005132533300f00116132533333301300116161616132533301130130031533300d3370e900018079baa004132533300e3371e6eb8c04cc044dd5004a4410d48656c6c6f2c20576f726c642100100114a06644646600200200644a66602a00229404c94ccc048cdc79bae301700200414a2266006006002602e0026eb0c048c04cc04cc04cc04cc04cc04cc04cc04cc040dd50051bae301230103754602460206ea801054cc03924012465787065637420536f6d6528446174756d207b206f776e6572207d29203d20646174756d001616375c0026020002601a6ea801458c038c03c008c034004c028dd50008b1805980600118050009805001180400098029baa001149854cc00d2411856616c696461746f722072657475726e65642066616c736500136565734ae7155ceaab9e5573eae855d12ba401";
+
+    PlutusScript plutusScript = PlutusBlueprintUtil.getPlutusScriptFromCompiledCode(compiledCode, PlutusVersion.v3);
+    String scrtiptAddr = AddressProvider.getEntAddress(plutusScript, Networks.testnet()).toBech32();
+
+    public void lock() {
+        //create datum
+        PlutusData datum = ConstrPlutusData.of(0, BytesPlutusData.of(sender1.getBaseAddress().getPaymentCredentialHash().get()));
+
+        Tx tx = new Tx()
+                .payToContract(scrtiptAddr, Amount.ada(10), datum)
+                .payToContract(scrtiptAddr, Amount.ada(2), BytesPlutusData.of("Hello"))
+                .from(sender1.baseAddress());
+
+        QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
+        Result<String> result = quickTxBuilder.compose(tx)
+                .withSigner(SignerProviders.signerFrom(sender1))
+                .completeAndWait(System.out::println);
+
+        System.out.println(result);
+        assertThat(result.isSuccessful()).isTrue();
+        checkIfUtxoAvailable(result.getValue(), scrtiptAddr);
+    }
+
+    public void unlock() throws ApiException {
+        PlutusData datum = ConstrPlutusData.of(0, BytesPlutusData.of(sender1.getBaseAddress().getPaymentCredentialHash().get()));
+
+        UtxoSupplier utxoSupplier = new DefaultUtxoSupplier(backendService.getUtxoService());
+        Utxo scriptUtxo = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scrtiptAddr, datum).orElseThrow();
+
+        PlutusData redeemer = ConstrPlutusData.of(0, BytesPlutusData.of("Hello, World!"));
+
+        ScriptTx sctipTx = new ScriptTx()
+                .collectFrom(scriptUtxo, redeemer)
+                .payToAddress(receiver1, Amount.ada(10))
+                .attachSpendingValidator(plutusScript);
+
+        QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
+        Result<String> result = quickTxBuilder.compose(sctipTx)
+                .feePayer(receiver1)
+                .collateralPayer(sender1.baseAddress())
+                .withSigner(SignerProviders.signerFrom(sender1))
+                .withRequiredSigners(sender1.getBaseAddress())
+                .withTxInspector(tx -> {
+                    System.out.println("Tx: " + JsonUtil.getPrettyJson(tx));
+                })
+                .preBalanceTx((context, txn) -> {
+                    txn.getWitnessSet().getRedeemers().get(0)
+                            .setExUnits(ExUnits.builder()
+                                    .mem(BigInteger.valueOf(31507))
+                                    .steps(BigInteger.valueOf(9666253))
+                                    .build());
+                })
+                .completeAndWait(System.out::println);
+
+        System.out.println(result);
+        assertThat(result.isSuccessful()).isTrue();
+    }
+
+    @Test
+    public void lockAndUnlock() throws ApiException {
+        lock();
+        unlock();
+    }
+
+}

--- a/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/ScriptTxIT.java
+++ b/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/ScriptTxIT.java
@@ -82,7 +82,6 @@ public class ScriptTxIT extends TestDataBaseIT {
                 .feePayer(sender1Addr)
                 .withSigner(SignerProviders.signerFrom(sender1))
                 .withRequiredSigners(sender1.getBaseAddress())
-                .withSerializationEra(Era.Babbage)
                 .completeAndWait(System.out::println);
 
         System.out.println(result1.getResponse());

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
@@ -21,6 +21,7 @@ import com.bloxbean.cardano.client.function.helper.ReferenceScriptResolver;
 import com.bloxbean.cardano.client.function.helper.ScriptCostEvaluators;
 import com.bloxbean.cardano.client.function.helper.ScriptBalanceTxProviders;
 import com.bloxbean.cardano.client.plutus.spec.PlutusScript;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.Transaction;
 import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
 import com.bloxbean.cardano.client.util.JsonUtil;
@@ -158,6 +159,7 @@ public class QuickTxBuilder {
         private List<PlutusScript> referenceScripts;
 
         private boolean ignoreScriptCostEvaluationError = true;
+        private Era serializationEra;
 
         TxContext(AbstractTx... txs) {
             this.txList = txs;
@@ -277,6 +279,9 @@ public class QuickTxBuilder {
             //override default script supplier
             if (scriptSupplier != null)
                 txBuilderContext.setScriptSupplier(scriptSupplier);
+
+            if (serializationEra != null)
+                txBuilderContext.withSerializationEra(serializationEra);
 
             //If collateral inputs are set, exclude them from utxo selection
             if (collateralInputs != null && !collateralInputs.isEmpty()) {
@@ -729,6 +734,17 @@ public class QuickTxBuilder {
          */
         public TxContext ignoreScriptCostEvaluationError(boolean flag) {
             this.ignoreScriptCostEvaluationError = flag;
+            return this;
+        }
+
+        /**
+         * Set the serialization era for the transaction.
+         *
+         * @param era The serialization era to set. By default, Conway Era format is used for serialization.
+         * @return The TxContext object.
+         */
+        public TxContext withSerializationEra(Era era) {
+            this.serializationEra = era;
             return this;
         }
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/TransactionSigner.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/TransactionSigner.java
@@ -35,7 +35,9 @@ public enum TransactionSigner {
     public Transaction sign(@NonNull Transaction transaction, @NonNull HdKeyPair hdKeyPair) {
         try {
             byte[] signedTxBytes = sign(transaction.serialize(), hdKeyPair);
-            return Transaction.deserialize(signedTxBytes);
+            var signedTx = Transaction.deserialize(signedTxBytes);
+            signedTx.setEra(transaction.getEra());
+            return signedTx;
         } catch (CborSerializationException | CborDeserializationException e) {
             throw new CborRuntimeException(e);
         }
@@ -51,7 +53,9 @@ public enum TransactionSigner {
     public Transaction sign(Transaction transaction, SecretKey secretKey) {
         try {
             byte[] signedTxBytes = sign(transaction.serialize(), secretKey);
-            return Transaction.deserialize(signedTxBytes);
+            var signedTx = Transaction.deserialize(signedTxBytes);
+            signedTx.setEra(transaction.getEra());
+            return signedTx;
         } catch (CborSerializationException | CborDeserializationException e) {
             throw new CborRuntimeException(e);
         }

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/AuxiliaryData.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/AuxiliaryData.java
@@ -11,6 +11,8 @@ import com.bloxbean.cardano.client.metadata.exception.MetadataSerializationExcep
 import com.bloxbean.cardano.client.plutus.spec.PlutusV1Script;
 import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
 import com.bloxbean.cardano.client.plutus.spec.PlutusV3Script;
+import com.bloxbean.cardano.client.spec.Era;
+import com.bloxbean.cardano.client.spec.EraSerializationConfig;
 import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -43,7 +45,11 @@ public class AuxiliaryData {
     private List<PlutusV3Script> plutusV3Scripts = new ArrayList<>();
 
     public DataItem serialize() throws CborSerializationException {
-        return getAuxiliaryData();
+        return serialize(EraSerializationConfig.INSTANCE.getEra());
+    }
+
+    public DataItem serialize(Era era) throws CborSerializationException {
+        return getAuxiliaryData(era);
     }
 
     public static AuxiliaryData deserialize(Map map) throws CborDeserializationException {
@@ -110,8 +116,13 @@ public class AuxiliaryData {
 
     @JsonIgnore
     public byte[] getAuxiliaryDataHash() throws MetadataSerializationException {
+        return getAuxiliaryDataHash(EraSerializationConfig.INSTANCE.getEra());
+    }
+
+    @JsonIgnore
+    public byte[] getAuxiliaryDataHash(Era era) throws MetadataSerializationException {
         try {
-            Map map = getAuxiliaryData();
+            Map map = getAuxiliaryData(era);
             byte[] encodedBytes = CborSerializationUtil.serialize(map);
 
             return Blake2bUtil.blake2bHash256(encodedBytes);
@@ -120,7 +131,7 @@ public class AuxiliaryData {
         }
     }
 
-    private Map getAuxiliaryData() throws CborSerializationException {
+    private Map getAuxiliaryData(Era era) throws CborSerializationException {
         Map map = new Map();
 
         //Shelley-mary format

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/Transaction.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/Transaction.java
@@ -6,6 +6,8 @@ import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.metadata.Metadata;
+import com.bloxbean.cardano.client.spec.Era;
+import com.bloxbean.cardano.client.spec.EraSerializationConfig;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.util.JsonUtil;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -13,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
@@ -20,7 +23,10 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Slf4j
 public class Transaction {
+    private Era era;
+
     @Builder.Default
     private TransactionBody body = new TransactionBody();
 
@@ -66,19 +72,29 @@ public class Transaction {
     }
 
     public byte[] serialize() throws CborSerializationException {
+        if (era == null && this.getWitnessSet() != null
+                && this.getWitnessSet().getPlutusV1Scripts() != null && this.getWitnessSet().getPlutusV1Scripts().size() > 0) {
+            log.info("PlutusV1 scripts are used. Setting serialization era to Babbage");
+            this.setEra(Era.Babbage);
+        }
+
+        return serialize(era != null? era : EraSerializationConfig.INSTANCE.getEra());
+    }
+
+    private byte[] serialize(Era era) throws CborSerializationException {
         try {
             if (auxiliaryData != null && body.getAuxiliaryDataHash() == null) {
-                byte[] auxiliaryDataHash = auxiliaryData.getAuxiliaryDataHash();
+                byte[] auxiliaryDataHash = auxiliaryData.getAuxiliaryDataHash(era);
                 body.setAuxiliaryDataHash(auxiliaryDataHash);
             }
 
             Array array = new Array();
-            Map bodyMap = body.serialize();
+            Map bodyMap = body.serialize(era);
             array.add(bodyMap);
 
             //witness
             if (witnessSet != null) {
-                Map witnessMap = witnessSet.serialize();
+                Map witnessMap = witnessSet.serialize(era);
                 array.add(witnessMap);
             } else {
                 Map witnessMap = new Map();
@@ -92,7 +108,7 @@ public class Transaction {
 
             //Auxiliary Data
             if (auxiliaryData != null) {
-                DataItem auxDataMap = auxiliaryData.serialize();
+                DataItem auxDataMap = auxiliaryData.serialize(era);
                 array.add(auxDataMap);
             } else
                 array.add(SimpleValue.NULL);

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/TransactionBody.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/TransactionBody.java
@@ -5,6 +5,8 @@ import co.nstant.in.cbor.model.*;
 import com.bloxbean.cardano.client.exception.AddressExcepion;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
+import com.bloxbean.cardano.client.spec.EraSerializationConfig;
 import com.bloxbean.cardano.client.spec.NetworkId;
 import com.bloxbean.cardano.client.transaction.spec.cert.Certificate;
 import com.bloxbean.cardano.client.transaction.spec.governance.ProposalProcedure;
@@ -77,9 +79,13 @@ public class TransactionBody {
     private BigInteger donation; //22
 
     public Map serialize() throws CborSerializationException, AddressExcepion {
+        return serialize(EraSerializationConfig.INSTANCE.getEra());
+    }
+
+    public Map serialize(Era era) throws CborSerializationException, AddressExcepion {
         Map bodyMap = new Map();
 
-        Array inputsArray = createArray();
+        Array inputsArray = createArray(era);
         for (TransactionInput ti : inputs) {
             Array input = ti.serialize();
             inputsArray.add(input);
@@ -104,9 +110,9 @@ public class TransactionBody {
         }
 
         if (certs != null && certs.size() > 0) { //certs
-            Array certArray = createArray();
+            Array certArray = createArray(era);
             for (Certificate cert : certs) {
-                certArray.add(cert.serialize());
+                certArray.add(cert.serialize(era));
             }
 
             bodyMap.put(new UnsignedInteger(4), certArray);
@@ -146,7 +152,7 @@ public class TransactionBody {
 
         //collateral
         if (collateral != null && collateral.size() > 0) {
-            Array collateralArray = createArray();
+            Array collateralArray = createArray(era);
             for (TransactionInput ti : collateral) {
                 Array input = ti.serialize();
                 collateralArray.add(input);
@@ -156,7 +162,7 @@ public class TransactionBody {
 
         //required_signers
         if (requiredSigners != null && requiredSigners.size() > 0) {
-            Array requiredSignerArray = createArray();
+            Array requiredSignerArray = createArray(era);
             for (byte[] requiredSigner : requiredSigners) {
                 requiredSignerArray.add(new ByteString(requiredSigner));
             }
@@ -187,7 +193,7 @@ public class TransactionBody {
 
         //reference inputs
         if (referenceInputs != null && referenceInputs.size() > 0) {
-            Array referenceInputsArray = createArray();
+            Array referenceInputsArray = createArray(era);
             for (TransactionInput ti : referenceInputs) {
                 Array input = ti.serialize();
                 referenceInputsArray.add(input);
@@ -202,7 +208,7 @@ public class TransactionBody {
 
         //proposal procedures
         if (proposalProcedures != null && proposalProcedures.size() > 0) {
-            Array proposalProceduresArray = createArray();
+            Array proposalProceduresArray = createArray(era);
             for (var proposalProcedure : proposalProcedures) {
                 proposalProceduresArray.add(proposalProcedure.serialize());
             }

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/TransactionWitnessSet.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/TransactionWitnessSet.java
@@ -108,7 +108,7 @@ public class TransactionWitnessSet {
         }
 
         if(redeemers != null && redeemers.size() > 0) {
-            if (era == Era.Conway) { //Conway era and no plutus v1 scripts, use old array format
+            if (era == null || era.value >= Era.Conway.value) { //Conway era and no plutus v1 scripts, use old array format
                 Map redeemerMap = new Map();
                 for(Redeemer redeemer: redeemers) {
                     var tuple = redeemer.serialize();

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/TransactionWitnessSet.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/TransactionWitnessSet.java
@@ -49,12 +49,16 @@ public class TransactionWitnessSet {
     private List<PlutusV3Script> plutusV3Scripts = new UniqueList<>();
 
     public Map serialize() throws CborSerializationException {
+        return serialize(EraSerializationConfig.INSTANCE.getEra());
+    }
+
+    public Map serialize(Era era) throws CborSerializationException {
         //Array
         //1. native script [ script_pubkey]
         //script_pubkey = (0, addr_keyhash)
         Map witnessMap = new Map();
         if(vkeyWitnesses != null && vkeyWitnesses.size() > 0) {
-            Array vkeyWitnessArray = createArray();
+            Array vkeyWitnessArray = createArray(era);
 
             for (VkeyWitness vkeyWitness : vkeyWitnesses) {
                 vkeyWitnessArray.add(vkeyWitness.serialize());
@@ -64,7 +68,7 @@ public class TransactionWitnessSet {
         }
 
         if(nativeScripts != null && nativeScripts.size() > 0) {
-            Array nativeScriptArray = createArray();
+            Array nativeScriptArray = createArray(era);
 
             for (NativeScript nativeScript : nativeScripts) {
                 nativeScriptArray.add(nativeScript.serializeAsDataItem());
@@ -74,7 +78,7 @@ public class TransactionWitnessSet {
         }
 
         if(bootstrapWitnesses != null && bootstrapWitnesses.size() > 0) {
-            Array bootstrapWitnessArray = createArray();
+            Array bootstrapWitnessArray = createArray(era);
 
             for(BootstrapWitness bootstrapWitness: bootstrapWitnesses) {
                 bootstrapWitnessArray.add(bootstrapWitness.serialize());
@@ -84,7 +88,7 @@ public class TransactionWitnessSet {
         }
 
         if(plutusV1Scripts != null && plutusV1Scripts.size() > 0) {
-            Array plutusScriptArray = createArray();
+            Array plutusScriptArray = createArray(era);
 
             for(PlutusV1Script plutusScript: plutusV1Scripts) {
                 plutusScriptArray.add(plutusScript.serializeAsDataItem());
@@ -94,7 +98,7 @@ public class TransactionWitnessSet {
         }
 
         if(plutusDataList != null && plutusDataList.size() > 0) {
-            Array plutusdataArray = createArray();
+            Array plutusdataArray = createArray(era);
 
             for(PlutusData plutusData: plutusDataList) {
                 plutusdataArray.add(plutusData.serialize());
@@ -104,8 +108,7 @@ public class TransactionWitnessSet {
         }
 
         if(redeemers != null && redeemers.size() > 0) {
-            if (EraSerializationConfig.INSTANCE.getEra() == Era.Conway
-                    && (plutusV1Scripts == null || plutusV1Scripts.isEmpty())) { //Conway era and no plutus v1 scripts, use old array format
+            if (era == Era.Conway) { //Conway era and no plutus v1 scripts, use old array format
                 Map redeemerMap = new Map();
                 for(Redeemer redeemer: redeemers) {
                     var tuple = redeemer.serialize();
@@ -125,7 +128,7 @@ public class TransactionWitnessSet {
 
         //Plutus v2 script -- Babbage era
         if(plutusV2Scripts != null && plutusV2Scripts.size() > 0) {
-            Array plutusV2ScriptArray = createArray();
+            Array plutusV2ScriptArray = createArray(era);
 
             for(PlutusV2Script plutusV2Script: plutusV2Scripts) {
                 plutusV2ScriptArray.add(plutusV2Script.serializeAsDataItem());
@@ -136,7 +139,7 @@ public class TransactionWitnessSet {
 
         //Plutus v3 script -- Conway era
         if(plutusV3Scripts != null && plutusV3Scripts.size() > 0) {
-            Array plutusV3ScriptArray = createArray();
+            Array plutusV3ScriptArray = createArray(era);
 
             for(PlutusV3Script plutusV3Script: plutusV3Scripts) {
                 plutusV3ScriptArray.add(plutusV3Script.serializeAsDataItem());

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/AuthCommitteeHotCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/AuthCommitteeHotCert.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.address.Credential;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.util.CredentialSerializer;
 import lombok.*;
 
@@ -22,7 +23,7 @@ public class AuthCommitteeHotCert implements Certificate {
     private Credential committeeHotCredential;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(committeeColdCredential);
         Objects.requireNonNull(committeeHotCredential);
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/Certificate.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/Certificate.java
@@ -7,6 +7,8 @@ import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
+import com.bloxbean.cardano.client.spec.EraSerializationConfig;
 import com.bloxbean.cardano.client.util.HexUtil;
 
 import java.util.List;
@@ -92,7 +94,11 @@ public interface Certificate {
         return certificate;
     }
 
-    Array serialize() throws CborSerializationException;
+    default Array serialize() throws CborSerializationException {
+        return serialize(EraSerializationConfig.INSTANCE.getEra());
+    }
+
+    Array serialize(Era era) throws CborSerializationException;
 
     default String getCborHex() throws CborSerializationException {
         try {

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/GenesisKeyDelegation.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/GenesisKeyDelegation.java
@@ -6,6 +6,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.*;
 
 import java.util.List;
@@ -27,7 +28,7 @@ public class GenesisKeyDelegation implements Certificate {
     private byte[] vrfKeyHash;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Array array = new Array();
         array.add(new UnsignedInteger(5));
         array.add(new ByteString(genesisHash));

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/MoveInstataneous.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/MoveInstataneous.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.client.transaction.spec.cert;
 import co.nstant.in.cbor.model.*;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.*;
 
 import java.math.BigInteger;
@@ -32,7 +33,7 @@ public class MoveInstataneous implements Certificate {
     private java.util.Map<StakeCredential, BigInteger> stakeCredentialCoinMap; //funds are moved to stake credentials
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Array array = new Array();
         array.add(new UnsignedInteger(6));
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/PoolRegistration.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/PoolRegistration.java
@@ -6,6 +6,7 @@ import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborRuntimeException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.spec.UnitInterval;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -71,7 +72,7 @@ public class PoolRegistration implements Certificate {
     private String poolMetadataHash;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Array array = new Array();
         array.add(new UnsignedInteger(3));
         array.add(new ByteString(operator));
@@ -89,7 +90,7 @@ public class PoolRegistration implements Certificate {
         array.add(new ByteString(HexUtil.decodeHexString(rewardAccount)));
 
         //pool owners
-        Array poolOwnersArr = createArray();
+        Array poolOwnersArr = createArray(era);
         poolOwners.stream().forEach(poolOwner -> {
             poolOwnersArr.add(new ByteString(HexUtil.decodeHexString(poolOwner)));
         });

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/PoolRetirement.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/PoolRetirement.java
@@ -6,6 +6,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.*;
 
 import java.util.List;
@@ -26,7 +27,7 @@ public class PoolRetirement implements Certificate {
     private long epoch;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Array array = new Array();
         array.add(new UnsignedInteger(4));
         array.add(new ByteString(poolKeyHash));

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/RegCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/RegCert.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.*;
 
 import java.math.BigInteger;
@@ -22,7 +23,7 @@ public class RegCert implements Certificate {
     private BigInteger coin;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(stakeCredential);
         Objects.requireNonNull(coin);
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/RegDRepCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/RegDRepCert.java
@@ -6,6 +6,7 @@ import co.nstant.in.cbor.model.SimpleValue;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.address.Credential;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.governance.Anchor;
 import com.bloxbean.cardano.client.transaction.util.CredentialSerializer;
 import lombok.*;
@@ -30,7 +31,7 @@ public class RegDRepCert implements Certificate {
     private Anchor anchor;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(drepCredential);
         Objects.requireNonNull(coin);
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/ResignCommitteeColdCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/ResignCommitteeColdCert.java
@@ -6,6 +6,7 @@ import co.nstant.in.cbor.model.SimpleValue;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.address.Credential;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.governance.Anchor;
 import com.bloxbean.cardano.client.transaction.util.CredentialSerializer;
 import lombok.AllArgsConstructor;
@@ -27,7 +28,7 @@ public class ResignCommitteeColdCert implements Certificate {
     private Anchor anchor;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(committeeColdCredential);
 
         Array array = new Array();

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeDelegation.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeDelegation.java
@@ -6,6 +6,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.Getter;
 
 import java.util.List;
@@ -47,7 +48,7 @@ public class StakeDelegation implements Certificate {
     }
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         if (stakeCredential == null)
             throw new CborSerializationException("StakeDelegation serialization failed. StakeCredential is NULL");
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeDeregistration.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeDeregistration.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.Getter;
 
 import java.util.List;
@@ -42,7 +43,7 @@ public class StakeDeregistration implements Certificate {
     }
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         if (stakeCredential == null)
             throw new CborSerializationException("StakeDeregistration serialization failed. StakeCredential is NULL");
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeRegDelegCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeRegDelegCert.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.util.HexUtil;
 import lombok.*;
 
@@ -27,7 +28,7 @@ public class StakeRegDelegCert implements Certificate {
     private BigInteger coin;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(stakeCredential);
         Objects.requireNonNull(poolKeyHash);
         Objects.requireNonNull(coin);

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeRegistration.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeRegistration.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.Getter;
 
 import java.util.List;
@@ -42,7 +43,7 @@ public class StakeRegistration implements Certificate {
     }
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         if (stakeCredential == null)
             throw new CborSerializationException("StakeRegistration serialization failed. StakeCredential is NULL");
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeVoteDelegCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeVoteDelegCert.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.governance.DRep;
 import com.bloxbean.cardano.client.util.HexUtil;
 import lombok.*;
@@ -26,7 +27,7 @@ public class StakeVoteDelegCert implements Certificate {
     private DRep drep;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(stakeCredential);
         Objects.requireNonNull(poolKeyHash);
         Objects.requireNonNull(drep);

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeVoteRegDelegCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/StakeVoteRegDelegCert.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.governance.DRep;
 import com.bloxbean.cardano.client.util.HexUtil;
 import lombok.*;
@@ -29,7 +30,7 @@ public class StakeVoteRegDelegCert implements Certificate {
     private BigInteger coin;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(stakeCredential);
         Objects.requireNonNull(poolKeyHash);
         Objects.requireNonNull(drep);

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/UnregCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/UnregCert.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.*;
 
 import java.math.BigInteger;
@@ -22,7 +23,7 @@ public class UnregCert implements Certificate {
     private BigInteger coin;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(stakeCredential);
         Objects.requireNonNull(coin);
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/UnregDRepCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/UnregDRepCert.java
@@ -5,6 +5,7 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.address.Credential;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.util.CredentialSerializer;
 import lombok.*;
 
@@ -25,7 +26,7 @@ public class UnregDRepCert implements Certificate {
     private BigInteger coin;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(drepCredential);
         Objects.requireNonNull(coin);
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/UpdateDRepCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/UpdateDRepCert.java
@@ -6,6 +6,7 @@ import co.nstant.in.cbor.model.SimpleValue;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.address.Credential;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.governance.Anchor;
 import com.bloxbean.cardano.client.transaction.util.CredentialSerializer;
 import lombok.*;
@@ -24,7 +25,7 @@ public class UpdateDRepCert implements Certificate {
     private Anchor anchor;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(drepCredential);
 
         Array certArray = new Array();

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/VoteDelegCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/VoteDelegCert.java
@@ -4,6 +4,7 @@ import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.governance.DRep;
 import lombok.*;
 
@@ -22,7 +23,7 @@ public class VoteDelegCert implements Certificate {
     private DRep drep;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(stakeCredential);
         Objects.requireNonNull(drep);
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/VoteRegDelegCert.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/cert/VoteRegDelegCert.java
@@ -4,6 +4,7 @@ import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.governance.DRep;
 import lombok.*;
 
@@ -25,7 +26,7 @@ public class VoteRegDelegCert implements Certificate {
     private BigInteger coin;
 
     @Override
-    public Array serialize() throws CborSerializationException {
+    public Array serialize(Era era) throws CborSerializationException {
         Objects.requireNonNull(stakeCredential);
         Objects.requireNonNull(drep);
         Objects.requireNonNull(coin);

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/GovAction.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/GovAction.java
@@ -3,6 +3,8 @@ package com.bloxbean.cardano.client.transaction.spec.governance.actions;
 import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.SimpleValue;
+import com.bloxbean.cardano.client.spec.Era;
+import com.bloxbean.cardano.client.spec.EraSerializationConfig;
 
 import static com.bloxbean.cardano.client.common.cbor.CborSerializationUtil.toInt;
 
@@ -54,6 +56,10 @@ public interface GovAction {
         return govActionId;
     }
 
-    DataItem serialize();
+    default DataItem serialize() {
+        return serialize(EraSerializationConfig.INSTANCE.getEra());
+    }
+
+    DataItem serialize(Era era);
 
 }

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/HardForkInitiationAction.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/HardForkInitiationAction.java
@@ -4,6 +4,7 @@ import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.SimpleValue;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.ProtocolVersion;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,7 +28,7 @@ public class HardForkInitiationAction implements GovAction {
     private ProtocolVersion protocolVersion;
 
     @Override
-    public Array serialize() {
+    public Array serialize(Era era) {
         Objects.requireNonNull(protocolVersion);
 
         Array array = new Array();

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/InfoAction.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/InfoAction.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.client.transaction.spec.governance.actions;
 import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,7 +15,7 @@ public class InfoAction implements GovAction {
     private final GovActionType type = GovActionType.INFO_ACTION;
 
     @Override
-    public DataItem serialize() {
+    public DataItem serialize(Era era) {
         var array = new Array();
         array.add(new UnsignedInteger(6));
         return array;

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/NewConstitution.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/NewConstitution.java
@@ -4,6 +4,7 @@ import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.SimpleValue;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.governance.Constitution;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,7 +28,7 @@ public class NewConstitution implements GovAction {
     private Constitution constitution;
 
     @Override
-    public Array serialize() {
+    public Array serialize(Era era) {
         Objects.requireNonNull(constitution);
 
         Array array = new Array();

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/NoConfidence.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/NoConfidence.java
@@ -4,6 +4,7 @@ import co.nstant.in.cbor.model.Array;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.SimpleValue;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.client.spec.Era;
 import lombok.*;
 
 import java.util.List;
@@ -22,7 +23,7 @@ public class NoConfidence implements GovAction {
     private GovActionId prevGovActionId;
 
     @Override
-    public Array serialize() {
+    public Array serialize(Era era) {
         Array array = new Array();
         array.add(new UnsignedInteger(3));
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/ParameterChangeAction.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/ParameterChangeAction.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.client.transaction.spec.governance.actions;
 
 import co.nstant.in.cbor.model.*;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.ProtocolParamUpdate;
 import lombok.*;
 
@@ -24,7 +25,7 @@ public class ParameterChangeAction implements GovAction {
 
     @Override
     @SneakyThrows
-    public Array serialize() {
+    public Array serialize(Era era) {
         Objects.requireNonNull(protocolParamUpdate);
 
         Array array = new Array();

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/TreasuryWithdrawalsAction.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/TreasuryWithdrawalsAction.java
@@ -4,6 +4,7 @@ import co.nstant.in.cbor.model.*;
 import com.bloxbean.cardano.client.address.util.AddressUtil;
 import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
 import com.bloxbean.cardano.client.exception.CborRuntimeException;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.transaction.spec.Withdrawal;
 import lombok.*;
 
@@ -42,7 +43,7 @@ public class TreasuryWithdrawalsAction implements GovAction {
 
     @Override
     @SneakyThrows
-    public Array serialize() {
+    public Array serialize(Era era) {
         Objects.requireNonNull(withdrawals);
 
         Array array = new Array();

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/UpdateCommittee.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/actions/UpdateCommittee.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.client.transaction.spec.governance.actions;
 
 import co.nstant.in.cbor.model.*;
 import com.bloxbean.cardano.client.address.Credential;
+import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.spec.UnitInterval;
 import com.bloxbean.cardano.client.transaction.util.CredentialSerializer;
 import lombok.*;
@@ -37,7 +38,7 @@ public class UpdateCommittee implements GovAction {
 
     @Override
     @SneakyThrows
-    public Array serialize() {
+    public Array serialize(Era era) {
         Objects.requireNonNull(membersForRemoval);
         Objects.requireNonNull(newMembersAndTerms);
 
@@ -49,7 +50,7 @@ public class UpdateCommittee implements GovAction {
         else
             array.add(SimpleValue.NULL);
 
-        Array membersForRemovalArray = createArray();
+        Array membersForRemovalArray = createArray(era);
         for (Credential member: membersForRemoval) {
             membersForRemovalArray.add(CredentialSerializer.serialize(member));
         }

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/util/SerializationUtil.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/util/SerializationUtil.java
@@ -2,16 +2,16 @@ package com.bloxbean.cardano.client.transaction.util;
 
 import co.nstant.in.cbor.model.Array;
 import com.bloxbean.cardano.client.spec.Era;
-import com.bloxbean.cardano.client.spec.EraSerializationConfig;
 
 public final class SerializationUtil {
 
     //Create an array to represent set in Cardano
     //For Conway era or later, set the tag to 258
-    public static Array createArray() {
+    public static Array createArray(Era era) {
         Array array = new Array();
-        if (EraSerializationConfig.INSTANCE.getEra() == Era.Conway)
+        if (era == Era.Conway) {
             array.setTag(258);
+        }
         return array;
     }
 }

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/util/SerializationUtil.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/util/SerializationUtil.java
@@ -9,7 +9,8 @@ public final class SerializationUtil {
     //For Conway era or later, set the tag to 258
     public static Array createArray(Era era) {
         Array array = new Array();
-        if (era == Era.Conway) {
+
+        if (era == null || era.value >= Era.Conway.value) {
             array.setTag(258);
         }
         return array;

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/util/TransactionUtil.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/util/TransactionUtil.java
@@ -21,6 +21,7 @@ public class TransactionUtil {
     public static Transaction createCopy(Transaction transaction) {
         try {
             Transaction cloneTxn = Transaction.deserialize(transaction.serialize());
+            cloneTxn.setEra(transaction.getEra());
             return cloneTxn;
         } catch (CborDeserializationException e) {
             throw new CborRuntimeException(e);


### PR DESCRIPTION
Refactor transaction serialization logic to include era-specific (Babbage, Conway) behavior, ensuring compatibility with different Cardano eras. Update various test cases and integration tests to reflect these changes, and add logging for better traceability.