### PR TITLE
Update version to 0.6.0 in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group = com.bloxbean.cardano
 artifactId = cardano-client-lib
-version = 0.6.0-beta2-SNAPSHOT
+version = 0.6.0


### PR DESCRIPTION
Removing the beta label prepares the library for a stable release.