### PR TITLE
Support BigInteger for "required" in ScriptAtLeast and change slot from long to BigInteger

### DIFF
--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/script/RequireTimeAfter.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/script/RequireTimeAfter.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigInteger;
+
 /**
  * This script class is for "RequireTimeAfter" expression
  */
@@ -16,9 +18,13 @@ import lombok.NoArgsConstructor;
 public class RequireTimeAfter implements NativeScript {
 
     private final ScriptType type = ScriptType.after;
-    private long slot;
+    private BigInteger slot;
 
     public RequireTimeAfter(long slot) {
+        this.slot = BigInteger.valueOf(slot);
+    }
+
+    public RequireTimeAfter(BigInteger slot) {
         this.slot = slot;
     }
 

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/script/RequireTimeBefore.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/script/RequireTimeBefore.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigInteger;
+
 /**
  * This script class is for "RequireTimeBefore" expression
  */
@@ -16,9 +18,13 @@ import lombok.NoArgsConstructor;
 public class RequireTimeBefore implements NativeScript {
 
     private final ScriptType type = ScriptType.before;
-    private long slot;
+    private BigInteger slot;
 
     public RequireTimeBefore(long slot) {
+        this.slot = BigInteger.valueOf(slot);
+    }
+
+    public RequireTimeBefore(BigInteger slot) {
         this.slot = slot;
     }
 

--- a/transaction-spec/src/test/java/com/bloxbean/cardano/client/transaction/spec/script/ScriptTest.java
+++ b/transaction-spec/src/test/java/com/bloxbean/cardano/client/transaction/spec/script/ScriptTest.java
@@ -370,7 +370,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testScriptAtLeastWithMaxLongRequires() throws Exception {
+    void testScriptAtLeastWithMaxLongRequires() throws Exception {
         ScriptAtLeast scriptAtLeast = new ScriptAtLeast(9223372036854775807L);
         ScriptPubkey scriptPubkey = new ScriptPubkey("ad7a7b87959173fc9eac9a85891cc93892f800dd45c0544128228884");
         scriptAtLeast.addScript(scriptPubkey);

--- a/transaction-spec/src/test/java/com/bloxbean/cardano/client/transaction/spec/script/ScriptTest.java
+++ b/transaction-spec/src/test/java/com/bloxbean/cardano/client/transaction/spec/script/ScriptTest.java
@@ -27,7 +27,7 @@ class ScriptTest {
     ObjectMapper mapper = new ObjectMapper();
 
     @Test
-    public void testGetPolicyId() throws CborSerializationException {
+    void testGetPolicyId() throws CborSerializationException {
         ScriptPubkey scriptPubkey = new ScriptPubkey("ad7a7b87959173fc9eac9a85891cc93892f800dd45c0544128228884");
         String policyId = scriptPubkey.getPolicyId();
 
@@ -37,7 +37,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testSciptAllPolicyId() throws CborSerializationException {
+    void testSciptAllPolicyId() throws CborSerializationException {
         ScriptPubkey scriptPubkey1 = new ScriptPubkey("ad7a7b87959173fc9eac9a85891cc93892f800dd45c0544128228884");
         ScriptPubkey scriptPubkey2 = new ScriptPubkey("ee7a7b87959173fc9eac9a85891cc93892f800dd45c0544128228884");
         ScriptPubkey scriptPubkey3 = new ScriptPubkey("ff7a7b87959173fc9eac9a85891cc93892f800dd45c0544128228884");
@@ -56,7 +56,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testSciptAnyPolicyId() throws CborSerializationException {
+    void testSciptAnyPolicyId() throws CborSerializationException {
         ScriptPubkey scriptPubkey1 = new ScriptPubkey("ad7a7b87959173fc9eac9a85891cc93892f800dd45c0544128228884");
         ScriptPubkey scriptPubkey2 = new ScriptPubkey("ef7a7b87959173fc9eac9a85891cc93892f800dd45c0544128228884");
         ScriptPubkey scriptPubkey3 = new ScriptPubkey("ff7a7b87959173fc9eac9a85891cc93892f800dd45c0544128228884");
@@ -75,7 +75,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testSciptAtLeastPolicyId() throws CborSerializationException {
+    void testSciptAtLeastPolicyId() throws CborSerializationException {
         ScriptPubkey scriptPubkey1 = new ScriptPubkey("2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413");
         ScriptPubkey scriptPubkey2 = new ScriptPubkey("f856c0c5839bab22673747d53f1ae9eed84afafb085f086e8e988614");
         ScriptPubkey scriptPubkey3 = new ScriptPubkey("b275b08c999097247f7c17e77007c7010cd19f20cc086ad99d398538");
@@ -93,7 +93,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testRequiredAfterPolicyId() throws CborSerializationException {
+    void testRequiredAfterPolicyId() throws CborSerializationException {
         RequireTimeAfter requiredAfter = new RequireTimeAfter(1000);
         ScriptPubkey scriptPubkey = new ScriptPubkey("966e394a544f242081e41d1965137b1bb412ac230d40ed5407821c37");
 
@@ -109,7 +109,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testRequiredBeforePolicyId() throws CborSerializationException {
+    void testRequiredBeforePolicyId() throws CborSerializationException {
         RequireTimeBefore requireTimeBefore = new RequireTimeBefore(2000);
         ScriptPubkey scriptPubkey = new ScriptPubkey("966e394a544f242081e41d1965137b1bb412ac230d40ed5407821c37");
 
@@ -125,7 +125,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testScriptAnyScriptPubRequiredBeforePolicyId() throws CborSerializationException {
+    void testScriptAnyScriptPubRequiredBeforePolicyId() throws CborSerializationException {
 
         ScriptAny scriptAny = new ScriptAny()
                 .addScript(new ScriptPubkey("b275b08c999097247f7c17e77007c7010cd19f20cc086ad99d398538"))
@@ -141,7 +141,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeser_whenScriptPubKey() throws JsonProcessingException, CborDeserializationException {
+    void testJsonSerDeser_whenScriptPubKey() throws JsonProcessingException, CborDeserializationException {
         ScriptPubkey key = new ScriptPubkey("74cfebcf5e97474d7b89c862d7ee7cff22efbb032d4133a1b84cbdcd");
 
         String jsonStr = mapper.writeValueAsString(key);
@@ -153,7 +153,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeser_whenScriptPubKeyJackson() throws JsonProcessingException {
+    void testJsonSerDeser_whenScriptPubKeyJackson() throws JsonProcessingException {
         ScriptPubkey scriptPubkey1 = new ScriptPubkey("74cfebcf5e97474d7b89c862d7ee7cff22efbb032d4133a1b84cbdcd");
 
         String jsonStr = mapper.writeValueAsString(scriptPubkey1);
@@ -165,7 +165,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeser_whenScriptAll() throws IOException, CborDeserializationException {
+    void testJsonSerDeser_whenScriptAll() throws IOException, CborDeserializationException {
         ScriptPubkey key1 = new ScriptPubkey("74cfebcf5e97474d7b89c862d7ee7cff22efbb032d4133a1b84cbdcd");
         ScriptPubkey key2 = new ScriptPubkey("710ee487dbbcdb59b5841a00d1029a56a407c722b3081c02470b516d");
         ScriptPubkey key3 = new ScriptPubkey("beed26382ec96254a6714928c3c5bb8227abecbbb095cfeab9fb2dd1");
@@ -185,7 +185,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeser_whenScriptAllJackson() throws IOException {
+    void testJsonSerDeser_whenScriptAllJackson() throws IOException {
         ScriptPubkey key1 = new ScriptPubkey("74cfebcf5e97474d7b89c862d7ee7cff22efbb032d4133a1b84cbdcd");
         ScriptPubkey key2 = new ScriptPubkey("710ee487dbbcdb59b5841a00d1029a56a407c722b3081c02470b516d");
         ScriptPubkey key3 = new ScriptPubkey("beed26382ec96254a6714928c3c5bb8227abecbbb095cfeab9fb2dd1");
@@ -204,7 +204,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeser_whenScriptAny() throws IOException, CborDeserializationException {
+    void testJsonSerDeser_whenScriptAny() throws IOException, CborDeserializationException {
         ScriptPubkey key1 = new ScriptPubkey("74cfebcf5e97474d7b89c862d7ee7cff22efbb032d4133a1b84cbdcd");
         ScriptPubkey key2 = new ScriptPubkey("710ee487dbbcdb59b5841a00d1029a56a407c722b3081c02470b516d");
         ScriptPubkey key3 = new ScriptPubkey("beed26382ec96254a6714928c3c5bb8227abecbbb095cfeab9fb2dd1");
@@ -224,7 +224,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeser_whenScriptAnyJackson() throws IOException {
+    void testJsonSerDeser_whenScriptAnyJackson() throws IOException {
         ScriptPubkey key1 = new ScriptPubkey("74cfebcf5e97474d7b89c862d7ee7cff22efbb032d4133a1b84cbdcd");
         ScriptPubkey key2 = new ScriptPubkey("710ee487dbbcdb59b5841a00d1029a56a407c722b3081c02470b516d");
         ScriptPubkey key3 = new ScriptPubkey("beed26382ec96254a6714928c3c5bb8227abecbbb095cfeab9fb2dd1");
@@ -242,7 +242,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeser_whenScriptAtLeast() throws IOException, CborDeserializationException {
+    void testJsonSerDeser_whenScriptAtLeast() throws IOException, CborDeserializationException {
         ScriptPubkey key1 = new ScriptPubkey("74cfebcf5e97474d7b89c862d7ee7cff22efbb032d4133a1b84cbdcd");
         ScriptPubkey key2 = new ScriptPubkey("710ee487dbbcdb59b5841a00d1029a56a407c722b3081c02470b516d");
         ScriptPubkey key3 = new ScriptPubkey("beed26382ec96254a6714928c3c5bb8227abecbbb095cfeab9fb2dd1");
@@ -262,7 +262,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeser_whenScriptAtLeastJackson() throws IOException {
+    void testJsonSerDeser_whenScriptAtLeastJackson() throws IOException {
         ScriptPubkey key1 = new ScriptPubkey("74cfebcf5e97474d7b89c862d7ee7cff22efbb032d4133a1b84cbdcd");
         ScriptPubkey key2 = new ScriptPubkey("710ee487dbbcdb59b5841a00d1029a56a407c722b3081c02470b516d");
         ScriptPubkey key3 = new ScriptPubkey("beed26382ec96254a6714928c3c5bb8227abecbbb095cfeab9fb2dd1");
@@ -281,7 +281,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeSer_whenRequireTimeBefore() throws JsonProcessingException, CborDeserializationException {
+    void testJsonSerDeSer_whenRequireTimeBefore() throws JsonProcessingException, CborDeserializationException {
         RequireTimeBefore requireTimeBefore = new RequireTimeBefore(30003);
 
         String jsonStr = mapper.writeValueAsString(requireTimeBefore);
@@ -294,7 +294,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeSer_whenRequireTimeBeforeJackson() throws JsonProcessingException {
+    void testJsonSerDeSer_whenRequireTimeBeforeJackson() throws JsonProcessingException {
         RequireTimeBefore requireTimeBefore1 = new RequireTimeBefore(30003);
 
         String jsonStr = mapper.writeValueAsString(requireTimeBefore1);
@@ -306,7 +306,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeSer_whenRequireTimeAfter() throws JsonProcessingException, CborDeserializationException {
+    void testJsonSerDeSer_whenRequireTimeAfter() throws JsonProcessingException, CborDeserializationException {
         RequireTimeAfter requireTimeAfter = new RequireTimeAfter(20003);
 
         String jsonStr = mapper.writeValueAsString(requireTimeAfter);
@@ -319,7 +319,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testJsonSerDeSer_whenRequireTimeAfterJackson() throws JsonProcessingException {
+    void testJsonSerDeSer_whenRequireTimeAfterJackson() throws JsonProcessingException {
         RequireTimeAfter requireTimeAfter1 = new RequireTimeAfter(20003);
 
         String jsonStr = mapper.writeValueAsString(requireTimeAfter1);
@@ -331,7 +331,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testGetScriptPubkey() throws CborSerializationException {
+    void testGetScriptPubkey() throws CborSerializationException {
         String cborText = "582037abc7f86d3f53cbedd38835cd4dbcf0ff7d2bf5a5c12ec77c6851bf5295ae63";
         VerificationKey vkey = KeyGenUtil.getPublicKeyFromPrivateKey(new SecretKey(cborText));
 
@@ -343,7 +343,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testKeysSerializationDeserialization() throws CborSerializationException, JsonProcessingException {
+    void testKeysSerializationDeserialization() throws CborSerializationException, JsonProcessingException {
         Tuple<ScriptPubkey, Keys> tuple = ScriptPubkey.createWithNewKey();
         Keys keys1 = tuple._2;
 
@@ -356,7 +356,7 @@ class ScriptTest {
     }
 
     @Test
-    public void testScriptAtLeastWithNegativeRequires() throws Exception {
+    void testScriptAtLeastWithNegativeRequires() throws Exception {
         String cborHex = "820083031affffb5ff858202828200581c1c12f03c1ef2e935acc35ec2e6f96c650fd3bfba3e96550504d5336183031afff6b79a8182051a0005561382051a0003dd4683031a000491b58182041a0004dc05820180820180";
         NativeScript scriptAtLeast = NativeScript.deserializeScriptRef(HexUtil.decodeHexString(cborHex));
 


### PR DESCRIPTION
Enhanced RequireTimeBefore, RequireTimeAfter, and ScriptAtLeast to handle BigInteger values, allowing support for larger numeric ranges. Updated deserialization and serialization methods accordingly.

To fix #461 