### PR TITLE
Update intro.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A client library for Cardano in Java. This library simplifies the interaction with Cardano blockchain from a Java application.
 
-### **Latest Stable Version**: [0.6.2](https://github.com/bloxbean/cardano-client-lib/releases/tag/v0.6.2)
+### **Latest Stable Version**: [0.6.3](https://github.com/bloxbean/cardano-client-lib/releases/tag/v0.6.3)
 
 ### More details --> [Documentation](https://cardano-client.dev/)
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -8,7 +8,7 @@ A client library for Cardano in Java. This library simplifies the interaction wi
 
 :::info
 
-**Latest Stable Version**: [0.5.1](https://github.com/bloxbean/cardano-client-lib/releases/tag/v0.5.1)
+**Latest Stable Version**: [0.6.3](https://github.com/bloxbean/cardano-client-lib/releases/tag/v0.6.3)
 
 :::
 
@@ -30,7 +30,7 @@ A client library for Cardano in Java. This library simplifies the interaction wi
 
 [JavaDoc](https://javadoc.io/doc/com.bloxbean.cardano/cardano-client-core/latest/index.html)
 
-[Documentation](https://cardano-client.bloxbean.com/)
+[Documentation](https://cardano-client.dev/)
 
 ### Features
 


### PR DESCRIPTION
Fixes the -- apparently -- outdated link to the docs page. I've also bumped the latest stable version to what is given in the Releases section of Github in both the docs intro page and README file. 