### PR TITLE
Wallet as fee payer / collateral payer in ScriptTx + UtxoSelectionStrategy interface change to handle multiple addresses

### DIFF
--- a/coinselection/src/main/java/com/bloxbean/cardano/client/coinselection/UtxoSelectionStrategy.java
+++ b/coinselection/src/main/java/com/bloxbean/cardano/client/coinselection/UtxoSelectionStrategy.java
@@ -105,6 +105,11 @@ public interface UtxoSelectionStrategy {
         return selected != null ? new ArrayList<>(selected) : Collections.emptyList();
     }
 
+    default List<Utxo> selectUtxos(AddressIterator addrIter, List<Amount> amounts, Set<Utxo> utxosToExclude) {
+        Set<Utxo> selected = select(addrIter, amounts, null, null, utxosToExclude, CoinselectionConfig.INSTANCE.getCoinSelectionLimit());
+        return selected != null ? new ArrayList<>(selected) : Collections.emptyList();
+    }
+
     Set<Utxo> select(AddressIterator addressIterator, List<Amount> outputAmounts, String datumHash, PlutusData inlineDatum, Set<Utxo> utxosToExclude, int maxUtxoSelectionLimit);
 
     UtxoSelectionStrategy fallback();

--- a/coinselection/src/main/java/com/bloxbean/cardano/client/coinselection/UtxoSelector.java
+++ b/coinselection/src/main/java/com/bloxbean/cardano/client/coinselection/UtxoSelector.java
@@ -50,4 +50,13 @@ public interface UtxoSelector {
      * @throws ApiException if error
      */
     List<Utxo> findAll(String address, Predicate<Utxo> predicate, Set<Utxo> excludeUtxos) throws ApiException;
+
+    /**
+     * Enables UTXO search by address verification hash (addr_vkh).
+     *
+     * By default, searching by address verification hash is disabled.
+     *
+     * @param flag a boolean indicating whether to enable or disable searching UTXOs by address vkh.
+     */
+    default void setSearchByAddressVkh(boolean flag) {}
 }

--- a/coinselection/src/main/java/com/bloxbean/cardano/client/coinselection/impl/DefaultUtxoSelector.java
+++ b/coinselection/src/main/java/com/bloxbean/cardano/client/coinselection/impl/DefaultUtxoSelector.java
@@ -83,4 +83,10 @@ public class DefaultUtxoSelector implements UtxoSelector {
     protected int getUtxoFetchSize() {
         return 100;
     }
+
+    @Override
+    public void setSearchByAddressVkh(boolean flag) {
+        utxoSupplier.setSearchByAddressVkh(flag);
+    }
+
 }

--- a/core-api/src/main/java/com/bloxbean/cardano/client/api/AddressIterator.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/client/api/AddressIterator.java
@@ -9,9 +9,25 @@ import java.util.Iterator;
  * UtxoSelectionStrategy implementation.
  */
 public interface AddressIterator extends Iterator<Address> {
+
+    /**
+     * Retrieves the first address in the iterator's list of addresses without moving the cursor.
+     *
+     * @return the first {@link Address} in the list, or null if the list is empty.
+     */
+    Address getFirst();
+
     /**
      * Reset the pointer to the beginning
      */
     void reset();
+
+    /**
+     * Creates and returns a copy of this AddressIterator.
+     * The cloned instance is independent of the original and can be used separately.
+     *
+     * @return a new AddressIterator instance that is a copy of the current iterator.
+     */
+    AddressIterator clone();
 
 }

--- a/core-api/src/main/java/com/bloxbean/cardano/client/api/UtxoSupplier.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/client/api/UtxoSupplier.java
@@ -64,4 +64,15 @@ public interface UtxoSupplier {
     default boolean isUsedAddress(Address address) {
         return true;
     }
+
+    /**
+     * Enables UTXO search by address verification hash (addr_vkh).
+     * Configures this {@link UtxoSupplier} to search UTXO using the address verification hash.
+     *
+     * By default, searching by address verification hash is disabled.
+     *
+     * @param flag a boolean indicating whether to enable or disable searching UTXOs by address vkh.
+     */
+    default void setSearchByAddressVkh(boolean flag) {
+    }
 }

--- a/core-api/src/main/java/com/bloxbean/cardano/client/api/common/AddressIterators.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/client/api/common/AddressIterators.java
@@ -12,6 +12,10 @@ public class AddressIterators {
         return new SingleAddressIterator(address);
     }
 
+    public static AddressIterator of(String address) {
+        return new SingleAddressIterator(new Address(address));
+    }
+
     static class SingleAddressIterator implements AddressIterator {
         private Address address;
         private Iterator<Address> iterator;
@@ -32,8 +36,18 @@ public class AddressIterators {
         }
 
         @Override
+        public Address getFirst() {
+            return address;
+        }
+
+        @Override
         public void reset() {
             this.iterator = List.of(address).iterator();
+        }
+
+        @Override
+        public AddressIterator clone() {
+            return new SingleAddressIterator(address);
         }
     }
 }

--- a/function/src/main/java/com/bloxbean/cardano/client/function/TxBuilderContext.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/TxBuilderContext.java
@@ -47,6 +47,7 @@ public class TxBuilderContext {
     //Stores utxos used in the transaction.
     //This list is cleared after each build() call.
     private Set<Utxo> utxos = new HashSet<>();
+    private Set<Utxo> collateralUtxos = new HashSet<>();
 
     @Setter(AccessLevel.NONE)
     private Map<String, Tuple<PlutusScript, byte[]>> refScripts = new HashMap<>();
@@ -205,6 +206,24 @@ public class TxBuilderContext {
         utxos.clear();
     }
 
+    public void addCollateralUtxo(Utxo utxo) {
+        collateralUtxos.add(utxo);
+    }
+
+    public Set<Utxo> getCollateralUtxos() {
+        return collateralUtxos;
+    }
+
+    public void clearCollateralUtxos() {
+        collateralUtxos.clear();
+    }
+
+    public Set<Utxo> getAllUtxos() {
+        Set<Utxo> allUtxos = new HashSet<>(utxos);
+        allUtxos.addAll(collateralUtxos);
+        return allUtxos;
+    }
+
     @SneakyThrows
     public void addRefScripts(PlutusScript plutusScript) {
         refScripts.put(HexUtil.encodeHexString(plutusScript.getScriptHash()), new Tuple<>(plutusScript, plutusScript.scriptRefBytes()));
@@ -307,6 +326,7 @@ public class TxBuilderContext {
     private void clearTempStates() {
         clearMintMultiAssets();
         clearUtxos();
+        clearCollateralUtxos();
         clearRefScripts();
     }
 }

--- a/function/src/main/java/com/bloxbean/cardano/client/function/TxBuilderContext.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/TxBuilderContext.java
@@ -167,6 +167,19 @@ public class TxBuilderContext {
     }
 
     /**
+     * Configures the context to enable or disable UTXO search by address verification hash (addr_vkh).
+     * This setting will propagate the configuration to both the {@link UtxoSupplier} and the {@link UtxoSelector} within the context.
+     *
+     * @param flag a boolean value indicating whether to enable (true) or disable (false) searching UTXOs by address verification hash.
+     * @return the current instance of {@code TxBuilderContext}
+     */
+    public TxBuilderContext withSearchUtxoByAddressVkh(boolean flag) {
+        this.utxoSupplier.setSearchByAddressVkh(flag);
+        this.utxoSelector.setSearchByAddressVkh(flag);
+        return this;
+    }
+
+    /**
      * Set the serialization era for the transaction
      * @param era
      * @return TxBuilderContext

--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/BalanceTxBuilders.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/BalanceTxBuilders.java
@@ -1,5 +1,7 @@
 package com.bloxbean.cardano.client.function.helper;
 
+import com.bloxbean.cardano.client.api.AddressIterator;
+import com.bloxbean.cardano.client.api.common.AddressIterators;
 import com.bloxbean.cardano.client.function.TxBuilder;
 import com.bloxbean.cardano.client.api.util.UtxoUtil;
 import lombok.extern.slf4j.Slf4j;
@@ -20,11 +22,31 @@ public class BalanceTxBuilders {
      * @return TxBuilder
      */
     public static TxBuilder balanceTx(String changeAddress, int nSigners) {
+        return balanceTx(AddressIterators.of(changeAddress), nSigners);
+    }
+
+    /**
+     * Function to balance an unbalanced transaction.
+     * This is a wrapper function which invokes the following functions to create a balanced transaction
+     * <ul>
+     *  <li>{@link FeeCalculators#feeCalculator(String, int)} </li>
+     *  <li>{@link ChangeOutputAdjustments#adjustChangeOutput(String, int)} </li>
+     *  <li>{@link CollateralBuilders#balanceCollateralOutputs()} (For transaction with collateral return)</li>
+     * </ul>
+     *
+     * @param changeAddressIter An iterator for change addresses to be used for adjusting outputs.
+     *                          The first address from the iterator is used as the change address
+     * @param nSigners          No of signers. This is required for accurate fee calculation.
+     * @return A {@link TxBuilder} instance that balances the transaction during its building phase.
+     */
+    public static TxBuilder balanceTx(AddressIterator changeAddressIter, int nSigners) {
         return (context, txn) -> {
+            String changeAddress = changeAddressIter.getFirst().getAddress();
+
             FeeCalculators.feeCalculator(changeAddress, nSigners).apply(context, txn);
 
             //Incase change output goes below min ada after fee deduction
-            ChangeOutputAdjustments.adjustChangeOutput(changeAddress, nSigners).apply(context, txn);
+            ChangeOutputAdjustments.adjustChangeOutput(changeAddressIter.clone(), changeAddress, nSigners).apply(context, txn);
 
             //If collateral return found, balance collateral outputs
             if (txn.getBody().getCollateralReturn() != null)
@@ -55,16 +77,40 @@ public class BalanceTxBuilders {
      *  <li>{@link ChangeOutputAdjustments#adjustChangeOutput(String, int)} </li>
      *  <li>{@link CollateralBuilders#balanceCollateralOutputs()} (For transaction with collateral return)</li>
      * </ul>
+     *
      * @param changeAddress Change output address
      * @param additionalSigners No of Additional signers. This is required for accurate fee calculation.
      * @return TxBuilder
      */
     public static TxBuilder balanceTxWithAdditionalSigners(String changeAddress, int additionalSigners) {
+        return balanceTxWithAdditionalSigners(AddressIterators.of(changeAddress), additionalSigners);
+    }
+
+    /**
+     * Function to balance an unbalanced transaction using Automatic Utxo Discovery with Additional Signers.
+     * This is a wrapper function which invokes the following functions to create a balanced transaction
+     * <ul>
+     *  <li>{@link FeeCalculators#feeCalculator(String, int)} </li>
+     *  <li>{@link ChangeOutputAdjustments#adjustChangeOutput(String, int)} </li>
+     *  <li>{@link CollateralBuilders#balanceCollateralOutputs()} (For transaction with collateral return)</li>
+     * </ul>
+     *
+     * @param changeAddressIter An iterator to provide addresses for any change output.
+     *                          The first address from the iterator is used as the change address
+     * @param additionalSigners The number of additional required signers to include in the
+     *                          transaction balancing process.
+     * @return A {@link TxBuilder} function that applies the necessary adjustments to balance
+     *         the transaction, including fee calculation, change output adjustments, and
+     *         collateral balancing if applicable.
+     */
+    public static TxBuilder balanceTxWithAdditionalSigners(AddressIterator changeAddressIter, int additionalSigners) {
         return (context, txn) -> {
-            FeeCalculators.feeCalculator(changeAddress, UtxoUtil.getNoOfRequiredSigners(context.getUtxos()) + additionalSigners).apply(context, txn);
+            String changeAddress = changeAddressIter.getFirst().getAddress();
+
+            FeeCalculators.feeCalculator(changeAddress, UtxoUtil.getNoOfRequiredSigners(context.getAllUtxos()) + additionalSigners).apply(context, txn);
 
             //Incase change output goes below min ada after fee deduction
-            ChangeOutputAdjustments.adjustChangeOutput(changeAddress, UtxoUtil.getNoOfRequiredSigners(context.getUtxos()) + additionalSigners).apply(context, txn);
+            ChangeOutputAdjustments.adjustChangeOutput(changeAddressIter.clone(), UtxoUtil.getNoOfRequiredSigners(context.getAllUtxos()) + additionalSigners).apply(context, txn);
 
             //If collateral return found, balance collateral outputs
             if (txn.getBody().getCollateralReturn() != null)

--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/ChangeOutputAdjustments.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/ChangeOutputAdjustments.java
@@ -84,6 +84,25 @@ public class ChangeOutputAdjustments {
      * Function to adjust change output in a <code>Transaction</code> to meet min ada requirement.
      * Finds a change output specific to given change address.
      * If multiple change outputs with less than min required ada are found for the change address, it throws <code>{@link TxBuildException}</code>
+     * Get additional utxos from sender address and update the change output.
+     * Re-calculates fee and checks min ada in change output.
+     * Retry if required, upto 3 times
+     *
+     * @param senderAddress Address to select additional utxos
+     * @param changeAddress Address for change output selection
+     * @param noOfSigners   No of required signers. Required for fee calculation after adjustment
+     * @return <code>TxBuilder</code> function
+     * @throws TxBuildException If multiple change outputs with less than min required ada are found for the change address.
+     * @throws ApiRuntimeException If api call error
+     */
+    public static TxBuilder adjustChangeOutput(String senderAddress, String changeAddress, int noOfSigners) {
+        return adjustChangeOutput(AddressIterators.of(senderAddress), changeAddress, noOfSigners);
+    }
+
+    /**
+     * Function to adjust change output in a <code>Transaction</code> to meet min ada requirement.
+     * Finds a change output specific to given change address.
+     * If multiple change outputs with less than min required ada are found for the change address, it throws <code>{@link TxBuildException}</code>
      * Get additional utxos from change address and update the change output.
      * Re-calculates fee and checks min ada in change output.
      * Retry if required, upto 3 times.

--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/CollateralBuilders.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/CollateralBuilders.java
@@ -34,6 +34,8 @@ public class CollateralBuilders {
                         .index(utxo.getOutputIndex())
                         .build();
                 transaction.getBody().getCollateral().add(input);
+
+                context.addCollateralUtxo(utxo);
             });
         };
     }
@@ -54,6 +56,8 @@ public class CollateralBuilders {
                         .index(utxo.getOutputIndex())
                         .build();
                 transaction.getBody().getCollateral().add(input);
+
+                context.addCollateralUtxo(utxo);
             });
         };
     }
@@ -102,6 +106,8 @@ public class CollateralBuilders {
 
                 //Create collateral output
                 UtxoUtil.copyUtxoValuesToOutput(collateralOutput, utxo);
+
+                context.addCollateralUtxo(utxo);
             });
 
             transaction.getBody().setCollateralReturn(collateralOutput);

--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/SignerProviders.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/SignerProviders.java
@@ -42,7 +42,7 @@ public class SignerProviders {
      */
     public static TxSigner signerFrom(Wallet wallet) {
         return (context, transaction) -> {
-            var utxos = context.getUtxos()
+            var utxos = context.getAllUtxos()
                     .stream().filter(utxo -> utxo instanceof WalletUtxo)
                     .map(utxo -> (WalletUtxo) utxo)
                     .collect(Collectors.toSet());

--- a/function/src/test/java/com/bloxbean/cardano/client/function/helper/ChangeOutputAdjustmentsTest.java
+++ b/function/src/test/java/com/bloxbean/cardano/client/function/helper/ChangeOutputAdjustmentsTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.client.function.helper;
 
+import com.bloxbean.cardano.client.api.AddressIterator;
 import com.bloxbean.cardano.client.api.UtxoSupplier;
 import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.client.api.helper.FeeCalculationService;
@@ -157,7 +158,9 @@ class ChangeOutputAdjustmentsTest extends BaseTest {
         );
 
         given(utxoSelector.findFirst(eq(changeAddress), any(), any())).willReturn(Optional.empty());
-        given(utxoSelectionStrategy.selectUtxos(eq(changeAddress), eq(LOVELACE), any(), anySet())).willReturn(additionalUtxos);
+        given(utxoSelectionStrategy.selectUtxos((AddressIterator) argThat(arg -> arg instanceof AddressIterator),
+                eq(LOVELACE), any(), anySet()))
+                .willReturn(additionalUtxos);
 
         Transaction transaction = new Transaction();
         //Just adding a random input/output
@@ -287,7 +290,10 @@ class ChangeOutputAdjustmentsTest extends BaseTest {
         );
 
         given(utxoSelector.findFirst(eq(changeAddress), any(), any())).willReturn(Optional.empty());
-        given(utxoSelectionStrategy.selectUtxos(eq(changeAddress), eq(LOVELACE), any(), anySet())).willReturn(additionalUtxos);
+        given(utxoSelectionStrategy.selectUtxos(
+                (AddressIterator) argThat(arg -> arg instanceof AddressIterator),
+                eq(LOVELACE), any(), anySet()))
+                .willReturn(additionalUtxos);
 
         Transaction transaction = new Transaction();
         //Just adding a random input/output

--- a/hd-wallet/src/it/java/com/bloxbean/cardano/hdwallet/QuickTxBaseIT.java
+++ b/hd-wallet/src/it/java/com/bloxbean/cardano/hdwallet/QuickTxBaseIT.java
@@ -79,6 +79,31 @@ public class QuickTxBaseIT {
         }
     }
 
+    protected static void resetNetwork() {
+        try {
+            // URL to reset the network
+            String url = DEVKIT_ADMIN_BASE_URL + "local-cluster/api/admin/devnet/reset";
+            URL obj = new URL(url);
+            HttpURLConnection connection = (HttpURLConnection) obj.openConnection();
+
+            // Set request method to POST
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/json; utf-8");
+            connection.setRequestProperty("Accept", "application/json");
+            connection.setDoOutput(true);
+
+            // Check the response code
+            int responseCode = connection.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                System.out.println("Funds topped up successfully.");
+            } else {
+                System.out.println("Failed to top up funds. Response code: " + responseCode);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     public void waitForTransaction(Result<String> result) {
         try {
             if (result.isSuccessful()) { //Wait for transaction to be mined

--- a/hd-wallet/src/it/java/com/bloxbean/cardano/hdwallet/ScriptTxIT.java
+++ b/hd-wallet/src/it/java/com/bloxbean/cardano/hdwallet/ScriptTxIT.java
@@ -1,0 +1,243 @@
+package com.bloxbean.cardano.hdwallet;
+
+import com.bloxbean.cardano.client.account.Account;
+import com.bloxbean.cardano.client.address.AddressProvider;
+import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.backend.api.BackendService;
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.function.helper.ScriptUtxoFinders;
+import com.bloxbean.cardano.client.function.helper.SignerProviders;
+import com.bloxbean.cardano.client.plutus.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV3Script;
+import com.bloxbean.cardano.client.quicktx.QuickTxBuilder;
+import com.bloxbean.cardano.client.quicktx.ScriptTx;
+import com.bloxbean.cardano.client.quicktx.Tx;
+import com.bloxbean.cardano.client.quicktx.TxStatus;
+import com.bloxbean.cardano.client.quicktx.verifiers.TxVerifiers;
+import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import static com.bloxbean.cardano.client.common.CardanoConstants.LOVELACE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ScriptTxIT extends QuickTxBaseIT {
+
+    BackendService backendService;
+    UtxoSupplier utxoSupplier;
+
+    String receiver1 = "addr_test1qz3s0c370u8zzqn302nppuxl840gm6qdmjwqnxmqxme657ze964mar2m3r5jjv4qrsf62yduqns0tsw0hvzwar07qasqeamp0c";
+
+    static Account topupAccount;
+
+    @BeforeAll
+    static void beforeAll() {
+        String topupAccountMnemonic = "weapon news intact viable rigid hope ginger defy remove enemy dog volume belt clay shuffle angle crunch eye end asthma arctic sphere arm limit";
+        topupAccount = new Account(Networks.testnet(), topupAccountMnemonic);
+
+        topUpFund(topupAccount.baseAddress(), 100000);
+    }
+
+    @BeforeEach
+    void setup() {
+        backendService = getBackendService();
+        utxoSupplier = getUTXOSupplier();
+    }
+
+    @Test
+    void alwaysTrueScript() throws ApiException {
+        Wallet walletA = new Wallet(Networks.testnet());
+        Wallet walletB = new Wallet(Networks.testnet());
+
+        splitPaymentBetweenAddress(topupAccount, walletA, 20, Double.valueOf(3000), false);
+        payToAddressAt(topupAccount, walletB, 13, Double.valueOf(5));
+
+        PlutusV3Script plutusScript = PlutusV3Script.builder()
+                .type("PlutusScriptV3")
+                .cborHex("46450101002499")
+                .build();
+
+        String scriptAddress = AddressProvider.getEntAddress(plutusScript, Networks.testnet()).toBech32();
+        BigInteger scriptAmt = new BigInteger("2479280");
+
+        long randInt = System.currentTimeMillis();
+        BigIntPlutusData plutusData = new BigIntPlutusData(BigInteger.valueOf(randInt));
+
+        Tx tx = new Tx();
+        tx.payToContract(scriptAddress, Amount.lovelace(scriptAmt), plutusData)
+                .from(walletA);
+
+        QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
+        var result = quickTxBuilder.compose(tx)
+                .withSigner(SignerProviders.signerFrom(walletA))
+                .complete();
+
+        assertThat(result.getTxStatus()).isEqualTo(TxStatus.SUBMITTED);
+
+        System.out.println(result.getResponse());
+        checkIfUtxoAvailable(result.getValue(), scriptAddress);
+
+        Optional<Utxo> optionalUtxo = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scriptAddress, plutusData);
+        ScriptTx scriptTx = new ScriptTx()
+                .collectFrom(optionalUtxo.get(), plutusData)
+                .payToAddress(receiver1, Amount.lovelace(scriptAmt))
+                .attachSpendingValidator(plutusScript)
+                .withChangeAddress(scriptAddress, plutusData);
+
+        Result<String> result1 = quickTxBuilder.compose(scriptTx)
+                .feePayer(walletB)
+                .withSigner(SignerProviders.signerFrom(walletB))
+                .withVerifier(TxVerifiers.outputAmountVerifier(walletB.getBaseAddressString(0),
+                        LOVELACE,
+                        amt -> (Amount.ada(5).getQuantity().compareTo(amt.getQuantity()) > 0)))
+                .withTxInspector(txn -> {
+                    assertThat(txn.getBody().getOutputs()).hasSize(2);
+                    assertThat(txn.getBody().getInputs()).hasSize(2);
+                })
+                .completeAndWait(System.out::println);
+
+        System.out.println(result1);
+        assertTrue(result1.isSuccessful());
+
+        checkIfUtxoAvailable(result1.getValue(), receiver1);
+    }
+
+    @Test
+    void alwaysTrueScript_separateCollateralPayer() throws ApiException {
+        Wallet walletA = new Wallet(Networks.testnet());
+        Wallet walletB = new Wallet(Networks.testnet());
+        Wallet collaterWallet = new Wallet(Networks.testnet());
+
+        splitPaymentBetweenAddress(topupAccount, walletA, 20, Double.valueOf(3000), false);
+        payToAddressAt(topupAccount, walletB, 13, Double.valueOf(5));
+        payToAddressAt(topupAccount, collaterWallet, 2, Double.valueOf(7));
+
+        PlutusV3Script plutusScript = PlutusV3Script.builder()
+                .type("PlutusScriptV3")
+                .cborHex("46450101002499")
+                .build();
+
+        String scriptAddress = AddressProvider.getEntAddress(plutusScript, Networks.testnet()).toBech32();
+        BigInteger scriptAmt = new BigInteger("2479280");
+
+        long randInt = System.currentTimeMillis();
+        BigIntPlutusData plutusData = new BigIntPlutusData(BigInteger.valueOf(randInt));
+
+        Tx tx = new Tx();
+        tx.payToContract(scriptAddress, Amount.lovelace(scriptAmt), plutusData)
+                .from(walletA);
+
+        QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
+        var result = quickTxBuilder.compose(tx)
+                .withSigner(SignerProviders.signerFrom(walletA))
+                .complete();
+
+        assertThat(result.getTxStatus()).isEqualTo(TxStatus.SUBMITTED);
+
+        System.out.println(result.getResponse());
+        checkIfUtxoAvailable(result.getValue(), scriptAddress);
+
+        Optional<Utxo> optionalUtxo = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scriptAddress, plutusData);
+        ScriptTx scriptTx = new ScriptTx()
+                .collectFrom(optionalUtxo.get(), plutusData)
+                .payToAddress(receiver1, Amount.lovelace(scriptAmt))
+                .attachSpendingValidator(plutusScript)
+                .withChangeAddress(scriptAddress, plutusData);
+
+        Result<String> result1 = quickTxBuilder.compose(scriptTx)
+                .feePayer(walletB)
+                .collateralPayer(collaterWallet)
+                .withSigner(SignerProviders.signerFrom(walletB))
+                .withSigner(SignerProviders.signerFrom(collaterWallet))
+                .withVerifier(TxVerifiers.outputAmountVerifier(walletB.getBaseAddressString(0),
+                        LOVELACE,
+                        amt -> (Amount.ada(5).getQuantity().compareTo(amt.getQuantity()) > 0)))
+                .withTxInspector(txn -> {
+                    assertThat(txn.getBody().getOutputs()).hasSize(2);
+                    assertThat(txn.getBody().getInputs()).hasSize(2);
+
+                    //check if the correct collateral is selected
+                    List<Utxo> collWalletUtxos = utxoSupplier.getAll(collaterWallet.getBaseAddressString(2));
+                    var collWalletUtxoTIs = collWalletUtxos.stream().map(utxo -> new TransactionInput(utxo.getTxHash(), utxo.getOutputIndex()))
+                                    .collect(Collectors.toList());
+                    assertThat(collWalletUtxoTIs).contains(txn.getBody().getCollateral().get(0));
+                })
+                .completeAndWait(System.out::println);
+
+        System.out.println(result1);
+        assertTrue(result1.isSuccessful());
+
+        checkIfUtxoAvailable(result1.getValue(), receiver1);
+    }
+
+    void splitPaymentBetweenAddress(Account topupAccount, Wallet receiverWallet, int totalAddresses, Double adaAmount, boolean enableEntAddrPayment) {
+        // Create an amount array with no of totalAddresses with random distribution of split amounts
+        Double[] amounts = new Double[totalAddresses];
+        Double remainingAmount = adaAmount;
+        Random rand = new Random();
+
+        for (int i = 0; i < totalAddresses - 1; i++) {
+            Double randomAmount = Double.valueOf(rand.nextInt(remainingAmount.intValue()));
+            amounts[i] = randomAmount;
+            remainingAmount = remainingAmount - randomAmount;
+        }
+        amounts[totalAddresses - 1] = remainingAmount;
+
+        String[] addresses = new String[totalAddresses];
+        Random random = new Random();
+        int currentIndex = 0;
+
+        for (int i = 0; i < totalAddresses; i++) {
+            if (enableEntAddrPayment) {
+                if (i % 2 == 0)
+                    addresses[i] = receiverWallet.getBaseAddressString(currentIndex);
+                else
+                    addresses[i] = receiverWallet.getEntAddress(currentIndex).toBech32();
+            } else {
+                addresses[i] = receiverWallet.getBaseAddressString(currentIndex);
+            }
+
+            currentIndex += random.nextInt(20) + 1;
+        }
+
+        Tx tx = new Tx();
+        for (int i = 0; i < addresses.length; i++) {
+            tx.payToAddress(addresses[i], Amount.ada(amounts[i]));
+        }
+
+        tx.from(topupAccount.baseAddress());
+
+        var result = new QuickTxBuilder(backendService)
+                .compose(tx)
+                .withSigner(SignerProviders.signerFrom(topupAccount))
+                .completeAndWait();
+
+        System.out.println(result);
+    }
+
+    void payToAddressAt(Account topupAccount, Wallet receiverWallet, int index, Double adaAmount) {
+        Tx tx = new Tx()
+                .payToAddress(receiverWallet.getBaseAddressString(index), Amount.ada(adaAmount))
+                .from(topupAccount.baseAddress());
+
+        var result = new QuickTxBuilder(backendService)
+                .compose(tx)
+                .withSigner(SignerProviders.signerFrom(topupAccount))
+                .completeAndWait();
+
+        System.out.println(result);
+    }
+
+}

--- a/hd-wallet/src/it/java/com/bloxbean/cardano/hdwallet/ScriptTxIT.java
+++ b/hd-wallet/src/it/java/com/bloxbean/cardano/hdwallet/ScriptTxIT.java
@@ -58,8 +58,8 @@ public class ScriptTxIT extends QuickTxBaseIT {
 
     @Test
     void alwaysTrueScript() throws ApiException {
-        Wallet walletA = new Wallet(Networks.testnet());
-        Wallet walletB = new Wallet(Networks.testnet());
+        Wallet walletA = Wallet.create(Networks.testnet());
+        Wallet walletB = Wallet.create(Networks.testnet());
 
         splitPaymentBetweenAddress(topupAccount, walletA, 20, Double.valueOf(3000), false);
         payToAddressAt(topupAccount, walletB, 13, Double.valueOf(5));
@@ -116,9 +116,9 @@ public class ScriptTxIT extends QuickTxBaseIT {
 
     @Test
     void alwaysTrueScript_separateCollateralPayer() throws ApiException {
-        Wallet walletA = new Wallet(Networks.testnet());
-        Wallet walletB = new Wallet(Networks.testnet());
-        Wallet collaterWallet = new Wallet(Networks.testnet());
+        Wallet walletA = Wallet.create(Networks.testnet());
+        Wallet walletB = Wallet.create(Networks.testnet());
+        Wallet collaterWallet = Wallet.create(Networks.testnet());
 
         splitPaymentBetweenAddress(topupAccount, walletA, 20, Double.valueOf(3000), false);
         payToAddressAt(topupAccount, walletB, 13, Double.valueOf(5));

--- a/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/DefaultWallet.java
+++ b/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/DefaultWallet.java
@@ -1,0 +1,380 @@
+package com.bloxbean.cardano.hdwallet;
+
+import com.bloxbean.cardano.client.account.Account;
+import com.bloxbean.cardano.client.address.Address;
+import com.bloxbean.cardano.client.address.AddressProvider;
+import com.bloxbean.cardano.client.common.model.Network;
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.crypto.MnemonicUtil;
+import com.bloxbean.cardano.client.crypto.bip32.HdKeyGenerator;
+import com.bloxbean.cardano.client.crypto.bip32.HdKeyPair;
+import com.bloxbean.cardano.client.crypto.bip39.MnemonicCode;
+import com.bloxbean.cardano.client.crypto.bip39.MnemonicException;
+import com.bloxbean.cardano.client.crypto.bip39.Words;
+import com.bloxbean.cardano.client.crypto.cip1852.CIP1852;
+import com.bloxbean.cardano.client.crypto.cip1852.DerivationPath;
+import com.bloxbean.cardano.client.transaction.TransactionSigner;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.api.model.WalletUtxo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * The Wallet class represents wallet with functionalities to manage accounts, addresses.
+ */
+public class DefaultWallet implements Wallet {
+
+    @Getter
+    private int accountNo = 0;
+    @Getter
+    private final Network network;
+
+    @Getter
+    @JsonIgnore
+    private String mnemonic;
+
+    @JsonIgnore
+    private byte[] rootKey; //Pvt key at root level m/
+
+    @JsonIgnore
+    private byte[] accountKey; //Pvt key at account level m/1852'/1815'/x
+
+    private String stakeAddress;
+    private Map<Integer, Account> cache;
+    private HdKeyPair rootKeyPair;
+    private HdKeyPair stakeKeys;
+
+    @Getter
+    @Setter
+    private boolean searchUtxoByAddrVkh;
+
+    @Getter
+    @Setter
+    private int[] indexesToScan; //If set, only scan these indexes and avoid gap limit during address scanning
+
+    @Getter
+    @Setter
+    private int gapLimit = 20; //No of unused addresses to scan.
+
+    public DefaultWallet() {
+        this(Networks.mainnet());
+    }
+
+    public DefaultWallet(Network network) {
+        this(network, Words.TWENTY_FOUR);
+    }
+
+    public DefaultWallet(Network network, Words noOfWords) {
+        this(network, noOfWords, 0);
+    }
+
+    public DefaultWallet(Network network, Words noOfWords, int account) {
+        this.network = network;
+        this.mnemonic = MnemonicUtil.generateNew(noOfWords);
+        this.accountNo = account;
+        cache = new HashMap<>();
+    }
+
+    /**
+     * Create a Wallet object from given mnemonic or rootKey or accountKey
+     * Only one of these value should be set : mnemonic or rootKey or accountKey
+     * @param network network
+     * @param mnemonic mnemonic
+     * @param rootKey root key
+     * @param accountKey account level key
+     * @param account account number
+     */
+    protected DefaultWallet(Network network, String mnemonic, byte[] rootKey, byte[] accountKey, int account) {
+        //check if more than one value set and throw exception
+        if ((mnemonic != null && !mnemonic.isEmpty() ? 1 : 0) +
+                (rootKey != null && rootKey.length > 0 ? 1 : 0) +
+                (accountKey != null && accountKey.length > 0 ? 1 : 0) > 1) {
+            throw new WalletException("Only one of mnemonic, rootKey, or accountKey should be set.");
+        }
+
+        this.network = network;
+        this.cache = new HashMap<>();
+
+        if (mnemonic != null && !mnemonic.isEmpty()) {
+            this.mnemonic = mnemonic;
+            this.accountNo = account;
+            MnemonicUtil.validateMnemonic(this.mnemonic);
+        } else if (rootKey != null && rootKey.length > 0) {
+            this.accountNo = account;
+
+            if (rootKey.length == 96)
+                this.rootKey = rootKey;
+            else
+                throw new WalletException("Invalid length (Root Key): " + rootKey.length);
+        } else if (accountKey != null && accountKey.length > 0) {
+            this.accountNo = account;
+
+            if (accountKey.length == 96)
+                this.accountKey = accountKey;
+            else
+                throw new WalletException("Invalid length (Account Private Key): " + accountKey.length);
+        }
+
+    }
+
+    /**
+     * Get Enterprise address for current account. Account can be changed via the setter.
+     * @param index address index
+     * @return Address object with enterprise address
+     */
+    @Override
+    public Address getEntAddress(int index) {
+        return getEntAddress(this.accountNo, index);
+    }
+
+    /**
+     * Get Enterprise address for derivation path m/1852'/1815'/{account}'/0/{index}
+     * @param account account no
+     * @param index address index
+     * @return Address object with Enterprise address
+     */
+    private Address getEntAddress(int account, int index) {
+        return getAccount(account, index).getEnterpriseAddress();
+    }
+
+    /**
+     * Get Baseaddress for current account. Account can be changed via the setter.
+     * @param index address index
+     * @return Address object for Base address
+     */
+    @Override
+    public Address getBaseAddress(int index) {
+        return getBaseAddress(this.accountNo, index);
+    }
+
+    /**
+     * Get Baseaddress for current account as String. Account can be changed via the setter.
+     * @param index address index
+     * @return Base address as string
+     */
+    @Override
+    public String getBaseAddressString(int index) {
+        return getBaseAddress(index).getAddress();
+    }
+
+    /**
+     * Get Baseaddress for derivationpath m/1852'/1815'/{account}'/0/{index}
+     * @param account account number
+     * @param index address index
+     * @return Address object for Base address
+     */
+    @Override
+    public Address getBaseAddress(int account, int index) {
+        return getAccount(account,index).getBaseAddress();
+    }
+
+    /**
+     * Returns the Account object for the index and current account. Account can be changed via the setter.
+     * @param index address index
+     * @return Account object
+     */
+    @Override
+    public Account getAccountAtIndex(int index) {
+        return getAccount(this.accountNo, index);
+    }
+
+    /**
+     * Returns the Account object for the index and account.
+     * @param account account number
+     * @param index address index
+     * @return Account object
+     */
+    @Override
+    public Account getAccount(int account, int index) {
+        if(account != this.accountNo) {
+            return deriveAccount(account, index);
+        } else {
+            if(cache.containsKey(index)) {
+                return cache.get(index);
+            } else {
+                Account acc = deriveAccount(account, index);
+                if (acc != null)
+                    cache.put(index, acc);
+
+                return acc;
+            }
+        }
+    }
+
+    private Account deriveAccount(int account, int index) {
+        DerivationPath derivationPath = DerivationPath.createExternalAddressDerivationPathForAccount(account);
+        derivationPath.getIndex().setValue(index);
+
+        if (mnemonic != null && !mnemonic.isEmpty()) {
+            return Account.createFromMnemonic(this.network, this.mnemonic, derivationPath);
+        } else if (rootKey != null && rootKey.length > 0) {
+            return Account.createFromRootKey(this.network, this.rootKey, derivationPath);
+        } else if (accountKey != null && accountKey.length > 0) {
+            return Account.createFromAccountKey(this.network, this.accountKey, derivationPath);
+        }else {
+            throw new WalletException("Can't create Account. At least one of 'mnemonic', 'accountKey', or 'rootKey' must be set.");
+        }
+    }
+
+    /**
+     * Setting the current account for derivation path.
+     * Setting the account will reset the cache.
+     * @param account account number which will be set in the wallet
+     */
+    @Override
+    public void setAccountNo(int account) {
+        this.accountNo = account;
+        // invalidating cache since it is only held for one account
+        cache = new HashMap<>();
+    }
+
+    @Override
+    public int getAccountNo() {
+        return this.accountNo;
+    }
+
+    /**
+     * Returns the RootkeyPair
+     * @return Root key as HdKeyPair if non-empty else empty optional
+     */
+    @JsonIgnore
+    @Override
+    public Optional<HdKeyPair> getRootKeyPair() {
+        if(rootKeyPair == null) {
+            if (mnemonic != null && !mnemonic.isEmpty()) {
+                HdKeyGenerator hdKeyGenerator = new HdKeyGenerator();
+                try {
+                    byte[] entropy = MnemonicCode.INSTANCE.toEntropy(this.mnemonic);
+                    rootKeyPair = hdKeyGenerator.getRootKeyPairFromEntropy(entropy);
+                } catch (MnemonicException.MnemonicLengthException | MnemonicException.MnemonicWordException |
+                         MnemonicException.MnemonicChecksumException e) {
+                    throw new WalletException("Unable to derive root key pair", e);
+                }
+            } else if (rootKey != null && rootKey.length > 0) {
+                HdKeyGenerator hdKeyGenerator = new HdKeyGenerator();
+                rootKeyPair = hdKeyGenerator.getKeyPairFromSecretKey(rootKey, HdKeyGenerator.MASTER_PATH);
+            }
+        }
+
+        return Optional.ofNullable(rootKeyPair);
+    }
+
+    @Override
+    public Optional<byte[]> getRootPvtKey() {
+        return getRootKeyPair()
+                .map(rkp -> rkp.getPrivateKey().getBytes());
+    }
+
+    /**
+     * Finds needed signers within wallet and signs the transaction with each one
+     * @param txToSign transaction
+     * @return signed Transaction
+     */
+    @Override
+    public Transaction sign(Transaction txToSign, Set<WalletUtxo> utxos) {
+        Map<String, Account> accountMap = utxos.stream()
+                .map(WalletUtxo::getDerivationPath)
+                .filter(Objects::nonNull)
+                .map(derivationPath -> getAccount(
+                        derivationPath.getAccount().getValue(),
+                        derivationPath.getIndex().getValue()))
+                .collect(Collectors.toMap(
+                        Account::baseAddress,
+                        Function.identity(),
+                        (existing, replacement) -> existing)); // Handle duplicates if necessary
+
+        var accounts = accountMap.values();
+
+        if(accounts.isEmpty())
+            throw new WalletException("No signers found!");
+
+        for (Account signerAcc : accounts)
+            txToSign = signerAcc.sign(txToSign);
+
+        return txToSign;
+    }
+
+//
+//    /**
+//     * Returns a list with signers needed for this transaction
+//     *
+//     * @param tx
+//     * @param utxoSupplier
+//     * @return
+//     */
+//    public List<Account> getSignersForTransaction(Transaction tx, WalletUtxoSupplier utxoSupplier) {
+//        return getSignersForInputs(tx.getBody().getInputs(), utxoSupplier);
+//    }
+//
+//    private List<Account> getSignersForInputs(List<TransactionInput> inputs, WalletUtxoSupplier utxoSupplier) {
+//        // searching for address to sign
+//        List<Account> signers = new ArrayList<>();
+//        List<TransactionInput> remaining = new ArrayList<>(inputs);
+//
+//        int index = 0;
+//        int emptyCounter = 0;
+//        while (!remaining.isEmpty() || emptyCounter >= INDEX_SEARCH_RANGE) {
+//            List<WalletUtxo> utxos = utxoSupplier.getUtxosForAccountAndIndex(this.account, index);
+//            emptyCounter = utxos.isEmpty() ? emptyCounter + 1 : 0;
+//
+//            for (Utxo utxo : utxos) {
+//                if(matchUtxoWithInputs(inputs, utxo, signers, index, remaining))
+//                    break;
+//            }
+//            index++;
+//        }
+//        return signers;
+//    }
+//
+//    private boolean matchUtxoWithInputs(List<TransactionInput> inputs, Utxo utxo, List<Account> signers, int index, List<TransactionInput> remaining) {
+//        for (TransactionInput input : inputs) {
+//            if(utxo.getTxHash().equals(input.getTransactionId()) && utxo.getOutputIndex() == input.getIndex()) {
+//                var account = getAccountObject(index);
+//                var accNotFound = signers.stream()
+//                        .noneMatch(acc -> account.baseAddress().equals(acc.baseAddress()));
+//                if (accNotFound)
+//                    signers.add(getAccountObject(index));
+//                remaining.remove(input);
+//            }
+//        }
+//        return remaining.isEmpty();
+//    }
+
+    /**
+     * Returns the stake address of the wallet.
+     * @return Stake address as string
+     */
+    @Override
+    public String getStakeAddress() {
+        if (stakeAddress == null || stakeAddress.isEmpty()) {
+            HdKeyPair stakeKeyPair = getStakeKeyPair();
+            Address address = AddressProvider.getRewardAddress(stakeKeyPair.getPublicKey(), network);
+            stakeAddress = address.toBech32();
+        }
+        return stakeAddress;
+    }
+
+    /**
+     * Signs the transaction with stake key from wallet.
+     * @param transaction transaction object to sign
+     * @return Signed transaction object
+     */
+    @Override
+    public Transaction signWithStakeKey(Transaction transaction) {
+        return TransactionSigner.INSTANCE.sign(transaction, getStakeKeyPair());
+    }
+
+    private HdKeyPair getStakeKeyPair() {
+        if(stakeKeys == null) {
+            DerivationPath stakeDerivationPath = DerivationPath.createStakeAddressDerivationPathForAccount(this.accountNo);
+            stakeKeys = new CIP1852().getKeyPairFromMnemonic(mnemonic, stakeDerivationPath);
+        }
+        return stakeKeys;
+    }
+
+}

--- a/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/DefaultWallet.java
+++ b/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/DefaultWallet.java
@@ -51,10 +51,6 @@ public class DefaultWallet implements Wallet {
 
     @Getter
     @Setter
-    private boolean searchUtxoByAddrVkh;
-
-    @Getter
-    @Setter
     private int[] indexesToScan; //If set, only scan these indexes and avoid gap limit during address scanning
 
     @Getter

--- a/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/Wallet.java
+++ b/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/Wallet.java
@@ -138,24 +138,6 @@ public interface Wallet {
     Network getNetwork();
 
     /**
-     * Checks if the wallet is configured to search unspent transaction outputs (UTXOs)
-     * using an address VKH (verification key hash).
-     *
-     * @return {@code true} if search by address VKH is enabled; {@code false} otherwise
-     */
-    boolean isSearchUtxoByAddrVkh();
-
-    /**
-     * Configures whether the wallet should search for unspent transaction outputs (UTXOs)
-     * using an address verification key hash (VKH).
-     *
-     * @param searchUtxoByAddrVkh a boolean value indicating whether to enable or disable
-     *                            the search for UTXOs by address VKH. Set to {@code true}
-     *                            to enable the search, or {@code false} to disable it.
-     */
-    void setSearchUtxoByAddrVkh(boolean searchUtxoByAddrVkh);
-
-    /**
      * Retrieves the array of indexes to be scanned by the wallet.
      *
      * @return an integer array containing the indexes to scan

--- a/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/Wallet.java
+++ b/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/Wallet.java
@@ -2,82 +2,233 @@ package com.bloxbean.cardano.hdwallet;
 
 import com.bloxbean.cardano.client.account.Account;
 import com.bloxbean.cardano.client.address.Address;
-import com.bloxbean.cardano.client.address.AddressProvider;
+import com.bloxbean.cardano.client.api.model.WalletUtxo;
 import com.bloxbean.cardano.client.common.model.Network;
 import com.bloxbean.cardano.client.common.model.Networks;
-import com.bloxbean.cardano.client.crypto.MnemonicUtil;
-import com.bloxbean.cardano.client.crypto.bip32.HdKeyGenerator;
 import com.bloxbean.cardano.client.crypto.bip32.HdKeyPair;
-import com.bloxbean.cardano.client.crypto.bip39.MnemonicCode;
-import com.bloxbean.cardano.client.crypto.bip39.MnemonicException;
 import com.bloxbean.cardano.client.crypto.bip39.Words;
-import com.bloxbean.cardano.client.crypto.cip1852.CIP1852;
-import com.bloxbean.cardano.client.crypto.cip1852.DerivationPath;
-import com.bloxbean.cardano.client.transaction.TransactionSigner;
 import com.bloxbean.cardano.client.transaction.spec.Transaction;
-import com.bloxbean.cardano.client.api.model.WalletUtxo;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.Getter;
-import lombok.Setter;
 
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.Optional;
+import java.util.Set;
 
 /**
- * The Wallet class represents wallet with functionalities to manage accounts, addresses.
+ * An interface representing a Wallet for managing addresses, accounts,
+ * keys, and transactions. It provides methods to retrieve addresses, manage accounts,
+ * sign transactions, and configure wallet settings.
  */
-public class Wallet {
+public interface Wallet {
 
-    @Getter
-    private int accountNo = 0;
-    @Getter
-    private final Network network;
+    /**
+     * Retrieves the enterprise address associated with the specified index.
+     *
+     * @param index the index of the enterprise address to be retrieved
+     * @return the enterprise address corresponding to the given index
+     */
+    Address getEntAddress(int index);
 
-    @Getter
-    @JsonIgnore
-    private String mnemonic;
+    /**
+     * Retrieves the base address associated with the specified index.
+     *
+     * @param index the index of the base address to be retrieved
+     * @return the base address corresponding to the given index
+     */
+    Address getBaseAddress(int index);
 
-    @JsonIgnore
-    private byte[] rootKey; //Pvt key at root level m/
+    /**
+     * Retrieves the base address as string associated with the specified index.
+     *
+     * @param index the index of the base address string to be retrieved
+     * @return the base address string corresponding to the given index
+     */
+    String getBaseAddressString(int index);
 
-    @JsonIgnore
-    private byte[] accountKey; //Pvt key at account level m/1852'/1815'/x
+    /**
+     * Retrieves the base address associated with the specified account and index.
+     *
+     * @param account the account number for which the base address is to be retrieved
+     * @param index the index of the base address to be retrieved
+     * @return the base address corresponding to the specified account and index
+     */
+    Address getBaseAddress(int account, int index);
 
-    private String stakeAddress;
-    private Map<Integer, Account> cache;
-    private HdKeyPair rootKeyPair;
-    private HdKeyPair stakeKeys;
+    /**
+     * Retrieves the stake address associated with the Wallet instance.
+     *
+     * @return the stake address as a String
+     */
+    String getStakeAddress();
 
-    @Getter
-    @Setter
-    private boolean searchUtxoByAddrVkh;
+    /**
+     * Returns the Account object for the index and current account. Account can be changed via the setter.
+     *
+     * @param index the address index of the account to be retrieved
+     * @return the account corresponding to the given index
+     */
+    Account getAccountAtIndex(int index);
 
-    @Getter
-    @Setter
-    private int[] indexesToScan; //If set, only scan these indexes and avoid gap limit during address scanning
+    /**
+     * Returns the Account object for the index and account.
+     *
+     * @param account the account number for which the account is to be retrieved
+     * @param index the index of the account to be retrieved
+     * @return the account corresponding to the specified account number and index
+     */
+    Account getAccount(int account, int index);
 
-    @Getter
-    @Setter
-    private int gapLimit = 20; //No of unused addresses to scan.
+    /**
+     * Sets the account number for this Wallet instance.
+     *
+     * @param account the account number to be set
+     */
+    void setAccountNo(int account);
 
-    public Wallet() {
-        this(Networks.mainnet());
+    /**
+     * Retrieves the account number associated with this Wallet instance.
+     *
+     * @return the account number as an integer
+     */
+    int getAccountNo();
+
+    /**
+     * Retrieves the root HD key pair associated with this Wallet instance.
+     *
+     * @return an {@code Optional} containing the root HD key pair if available, or an empty {@code Optional} if not set
+     */
+    Optional<HdKeyPair> getRootKeyPair();
+
+    /**
+     * Retrieves the root private key associated with this Wallet instance.
+     *
+     * @return an {@code Optional} containing the root private key as a byte array if available,
+     *         or an empty {@code Optional} if the root private key is not set.
+     */
+    Optional<byte[]> getRootPvtKey();
+
+    /**
+     * Retrieves the mnemonic phrase associated with the Wallet instance.
+     *
+     * @return the mnemonic phrase as a String
+     */
+    String getMnemonic();
+
+    /**
+     * Signs a transaction using the wallet's private keys and the provided set of unspent transaction outputs (UTXOs).
+     * This method generates the necessary signatures to authorize the transaction.
+     *
+     * @param txToSign the transaction object to be signed
+     * @param utxos the set of UTXOs used in the transaction
+     * @return the signed transaction object
+     */
+    Transaction sign(Transaction txToSign, Set<WalletUtxo> utxos);
+
+    /**
+     * Signs the provided transaction using the wallet's stake key.
+     *
+     * @param transaction the transaction to be signed
+     * @return the transaction signed with the wallet's stake key
+     */
+    Transaction signWithStakeKey(Transaction transaction);
+
+    /**
+     * Retrieves the network associated with this Wallet instance.
+     *
+     * @return the {@code Network} object representing the network configuration for the Wallet
+     */
+    Network getNetwork();
+
+    /**
+     * Checks if the wallet is configured to search unspent transaction outputs (UTXOs)
+     * using an address VKH (verification key hash).
+     *
+     * @return {@code true} if search by address VKH is enabled; {@code false} otherwise
+     */
+    boolean isSearchUtxoByAddrVkh();
+
+    /**
+     * Configures whether the wallet should search for unspent transaction outputs (UTXOs)
+     * using an address verification key hash (VKH).
+     *
+     * @param searchUtxoByAddrVkh a boolean value indicating whether to enable or disable
+     *                            the search for UTXOs by address VKH. Set to {@code true}
+     *                            to enable the search, or {@code false} to disable it.
+     */
+    void setSearchUtxoByAddrVkh(boolean searchUtxoByAddrVkh);
+
+    /**
+     * Retrieves the array of indexes to be scanned by the wallet.
+     *
+     * @return an integer array containing the indexes to scan
+     */
+    int[] getIndexesToScan();
+
+    /**
+     * Configures the indexes that need to be scanned.
+     *
+     * @param indexesToScan an array of integers representing the specific indexes to scan
+     */
+    void setIndexesToScan(int[] indexesToScan);
+
+    /**
+     * Retrieves the gap limit value.
+     *
+     * @return An integer representing the gap limit.
+     */
+    int getGapLimit();
+
+    /**
+     * Sets the gap limit value used for generating or validating keychains.
+     * The gap limit defines the maximum number of unused keys or addresses
+     * that can be scanned or generated ahead without invalidating the current state.
+     *
+     * @param gapLimit the maximum number of unused keys or addresses allowed.
+     */
+    void setGapLimit(int gapLimit);
+
+    //-- static methods to create DefaultWallet
+
+    /**
+     * Creates a new instance of the {@link DefaultWallet}.
+     *
+     * @return a new Wallet instance of type DefaultWallet
+     */
+    static Wallet create() {
+        return new DefaultWallet();
     }
 
-    public Wallet(Network network) {
-        this(network, Words.TWENTY_FOUR);
+    /**
+     * Creates a new Wallet instance for the specified network.
+     *
+     * @param network the network to be used for the Wallet, e.g., a mainnet or testnet instance
+     * @return a new Wallet instance of type DefaultWallet configured for the specified network
+     */
+    static Wallet create(Network network) {
+        return new DefaultWallet(network);
     }
 
-    public Wallet(Network network, Words noOfWords) {
-        this(network, noOfWords, 0);
+    /**
+     * Creates a new Wallet instance using the specified network and mnemonic length.
+     *
+     * @param network the network to be used, e.g., mainnet or testnet
+     * @param noOfWords the number of words representing the wallet's mnemonic strength,
+     *                  defined by the Words enum (e.g., TWELVE, FIFTEEN, TWENTY_FOUR)
+     * @return a new Wallet instance of type DefaultWallet configured with the specified network and mnemonic strength
+     */
+    static Wallet create(Network network, Words noOfWords) {
+        return new DefaultWallet(network, noOfWords, 0);
     }
 
-    public Wallet(Network network, Words noOfWords, int account) {
-        this.network = network;
-        this.mnemonic = MnemonicUtil.generateNew(noOfWords);
-        this.accountNo = account;
-        cache = new HashMap<>();
+    /**
+     * Creates a new Wallet instance for the specified network, mnemonic strength, and account number.
+     *
+     * @param network the network to be used for the Wallet, e.g., mainnet or testnet
+     * @param noOfWords the number of words representing the wallet's mnemonic strength,
+     *                  defined by the Words enum (e.g., TWELVE, FIFTEEN, TWENTY_FOUR)
+     * @param account the account number to be used for wallet derivation
+     * @return a new Wallet instance of type DefaultWallet configured for the specified network, mnemonic strength, and account number
+     */
+    static Wallet create(Network network, Words noOfWords, int account) {
+        return new DefaultWallet(network, noOfWords, account);
     }
 
     /**
@@ -85,9 +236,9 @@ public class Wallet {
      * The account is set to zero.
      *
      * @param mnemonic the mnemonic phrase
-     * @return a Wallet instance created from the provided mnemonic
+     * @return a new Wallet instance of type DefaultWallet created from the provided mnemonic
      */
-    public static Wallet createFromMnemonic(String mnemonic) {
+    static Wallet createFromMnemonic(String mnemonic) {
         return createFromMnemonic(Networks.mainnet(), mnemonic, 0);
     }
 
@@ -97,9 +248,9 @@ public class Wallet {
      *
      * @param network the network to be used, e.g., Networks.mainnet(), Networks.testnet()
      * @param mnemonic the mnemonic phrase
-     * @return a Wallet instance created from the provided mnemonic
+     * @return a new Wallet instance of type DefaultWallet created from the provided mnemonic
      */
-    public static Wallet createFromMnemonic(Network network, String mnemonic) {
+    static Wallet createFromMnemonic(Network network, String mnemonic) {
         return createFromMnemonic(network, mnemonic, 0);
     }
 
@@ -109,10 +260,10 @@ public class Wallet {
      * @param network the network to be used, e.g., Networks.mainnet(), Networks.testnet()
      * @param mnemonic the mnemonic phrase
      * @param account the account no to be used for wallet derivation
-     * @return a Wallet instance created from the provided mnemonic
+     * @return a new Wallet instance of type DefaultWallet created from the provided mnemonic
      */
-    public static Wallet createFromMnemonic(Network network, String mnemonic, int account) {
-        return new Wallet(network, mnemonic, null, null, account);
+    static Wallet createFromMnemonic(Network network, String mnemonic, int account) {
+        return new DefaultWallet(network, mnemonic, null, null, account);
     }
 
     /**
@@ -121,9 +272,9 @@ public class Wallet {
      *
      * @param network the network to be used, e.g., Networks.mainnet(), Networks.testnet()
      * @param rootKey the root key used for wallet initialization
-     * @return a Wallet instance created from the provided root key
+     * @return a new Wallet instance of type DefaultWallet created from the provided root key
      */
-    public static Wallet createFromRootKey(Network network, byte[] rootKey) {
+    static Wallet createFromRootKey(Network network, byte[] rootKey) {
         return createFromRootKey(network, rootKey, 0);
     }
 
@@ -133,10 +284,10 @@ public class Wallet {
      * @param network the network to be used, e.g., Networks.mainnet(), Networks.testnet()
      * @param rootKey the root key used for wallet initialization
      * @param account the account number to be used for wallet derivation
-     * @return a Wallet instance created from the provided root key
+     * @return a new Wallet instance of type DefaultWallet created from the provided root key
      */
-    public static Wallet createFromRootKey(Network network, byte[] rootKey, int account) {
-        return new Wallet(network, null, rootKey, null, account);
+    static Wallet createFromRootKey(Network network, byte[] rootKey, int account) {
+        return new DefaultWallet(network, null, rootKey, null, account);
     }
 
     /**
@@ -144,290 +295,9 @@ public class Wallet {
      *
      * @param network the network to be used, e.g., Networks.mainnet(), Networks.testnet()
      * @param accountKey the account key used for wallet initialization
-     * @return a Wallet instance created from the provided account key
+     * @return a new Wallet instance of type DefaultWallet created from the provided account key
      */
-    public static Wallet createFromAccountKey(Network network, byte[] accountKey) {
-        return new Wallet(network, null, null, accountKey, 0);
+    static Wallet createFromAccountKey(Network network, byte[] accountKey) {
+        return new DefaultWallet(network, null, null, accountKey, 0);
     }
-
-    /**
-     * Create a Wallet object from given mnemonic or rootKey or accountKey
-     * Only one of these value should be set : mnemonic or rootKey or accountKey
-     * @param network network
-     * @param mnemonic mnemonic
-     * @param rootKey root key
-     * @param accountKey account level key
-     * @param account account number
-     */
-    private Wallet(Network network, String mnemonic, byte[] rootKey, byte[] accountKey, int account) {
-        //check if more than one value set and throw exception
-        if ((mnemonic != null && !mnemonic.isEmpty() ? 1 : 0) +
-                (rootKey != null && rootKey.length > 0 ? 1 : 0) +
-                (accountKey != null && accountKey.length > 0 ? 1 : 0) > 1) {
-            throw new WalletException("Only one of mnemonic, rootKey, or accountKey should be set.");
-        }
-
-        this.network = network;
-        this.cache = new HashMap<>();
-
-        if (mnemonic != null && !mnemonic.isEmpty()) {
-            this.mnemonic = mnemonic;
-            this.accountNo = account;
-            MnemonicUtil.validateMnemonic(this.mnemonic);
-        } else if (rootKey != null && rootKey.length > 0) {
-            this.accountNo = account;
-
-            if (rootKey.length == 96)
-                this.rootKey = rootKey;
-            else
-                throw new WalletException("Invalid length (Root Key): " + rootKey.length);
-        } else if (accountKey != null && accountKey.length > 0) {
-            this.accountNo = account;
-
-            if (accountKey.length == 96)
-                this.accountKey = accountKey;
-            else
-                throw new WalletException("Invalid length (Account Private Key): " + accountKey.length);
-        }
-
-    }
-
-    /**
-     * Get Enterprise address for current account. Account can be changed via the setter.
-     * @param index address index
-     * @return Address object with enterprise address
-     */
-    public Address getEntAddress(int index) {
-        return getEntAddress(this.accountNo, index);
-    }
-
-    /**
-     * Get Enterprise address for derivation path m/1852'/1815'/{account}'/0/{index}
-     * @param account account no
-     * @param index address index
-     * @return Address object with Enterprise address
-     */
-    private Address getEntAddress(int account, int index) {
-        return getAccountNo(account, index).getEnterpriseAddress();
-    }
-
-    /**
-     * Get Baseaddress for current account. Account can be changed via the setter.
-     * @param index address index
-     * @return Address object for Base address
-     */
-    public Address getBaseAddress(int index) {
-        return getBaseAddress(this.accountNo, index);
-    }
-
-    /**
-     * Get Baseaddress for current account as String. Account can be changed via the setter.
-     * @param index address index
-     * @return Base address as string
-     */
-    public String getBaseAddressString(int index) {
-        return getBaseAddress(index).getAddress();
-    }
-
-    /**
-     * Get Baseaddress for derivationpath m/1852'/1815'/{account}'/0/{index}
-     * @param account account number
-     * @param index address index
-     * @return Address object for Base address
-     */
-    public Address getBaseAddress(int account, int index) {
-        return getAccountNo(account,index).getBaseAddress();
-    }
-
-    /**
-     * Returns the Account object for the index and current account. Account can be changed via the setter.
-     * @param index address index
-     * @return Account object
-     */
-    public Account getAccountAtIndex(int index) {
-        return getAccountNo(this.accountNo, index);
-    }
-
-    /**
-     * Returns the Account object for the index and account.
-     * @param account account number
-     * @param index address index
-     * @return Account object
-     */
-    public Account getAccountNo(int account, int index) {
-        if(account != this.accountNo) {
-            return deriveAccount(account, index);
-        } else {
-            if(cache.containsKey(index)) {
-                return cache.get(index);
-            } else {
-                Account acc = deriveAccount(account, index);
-                if (acc != null)
-                    cache.put(index, acc);
-
-                return acc;
-            }
-        }
-    }
-
-    private Account deriveAccount(int account, int index) {
-        DerivationPath derivationPath = DerivationPath.createExternalAddressDerivationPathForAccount(account);
-        derivationPath.getIndex().setValue(index);
-
-        if (mnemonic != null && !mnemonic.isEmpty()) {
-            return Account.createFromMnemonic(this.network, this.mnemonic, derivationPath);
-        } else if (rootKey != null && rootKey.length > 0) {
-            return Account.createFromRootKey(this.network, this.rootKey, derivationPath);
-        } else if (accountKey != null && accountKey.length > 0) {
-            return Account.createFromAccountKey(this.network, this.accountKey, derivationPath);
-        }else {
-            throw new WalletException("Can't create Account. At least one of 'mnemonic', 'accountKey', or 'rootKey' must be set.");
-        }
-    }
-
-    /**
-     * Setting the current account for derivation path.
-     * Setting the account will reset the cache.
-     * @param account account number which will be set in the wallet
-     */
-    public void setAccountNo(int account) {
-        this.accountNo = account;
-        // invalidating cache since it is only held for one account
-        cache = new HashMap<>();
-    }
-
-    /**
-     * Returns the RootkeyPair
-     * @return Root key as HdKeyPair if non-empty else empty optional
-     */
-    @JsonIgnore
-    public Optional<HdKeyPair> getRootKeyPair() {
-        if(rootKeyPair == null) {
-            if (mnemonic != null && !mnemonic.isEmpty()) {
-                HdKeyGenerator hdKeyGenerator = new HdKeyGenerator();
-                try {
-                    byte[] entropy = MnemonicCode.INSTANCE.toEntropy(this.mnemonic);
-                    rootKeyPair = hdKeyGenerator.getRootKeyPairFromEntropy(entropy);
-                } catch (MnemonicException.MnemonicLengthException | MnemonicException.MnemonicWordException |
-                         MnemonicException.MnemonicChecksumException e) {
-                    throw new WalletException("Unable to derive root key pair", e);
-                }
-            } else if (rootKey != null && rootKey.length > 0) {
-                HdKeyGenerator hdKeyGenerator = new HdKeyGenerator();
-                rootKeyPair = hdKeyGenerator.getKeyPairFromSecretKey(rootKey, HdKeyGenerator.MASTER_PATH);
-            }
-        }
-
-        return Optional.ofNullable(rootKeyPair);
-    }
-
-    public Optional<byte[]> getRootPvtKey() {
-        return getRootKeyPair()
-                .map(rkp -> rkp.getPrivateKey().getBytes());
-    }
-
-    /**
-     * Finds needed signers within wallet and signs the transaction with each one
-     * @param txToSign transaction
-     * @return signed Transaction
-     */
-    public Transaction sign(Transaction txToSign, Set<WalletUtxo> utxos) {
-        Map<String, Account> accountMap = utxos.stream()
-                .map(WalletUtxo::getDerivationPath)
-                .filter(Objects::nonNull)
-                .map(derivationPath -> getAccountNo(
-                        derivationPath.getAccount().getValue(),
-                        derivationPath.getIndex().getValue()))
-                .collect(Collectors.toMap(
-                        Account::baseAddress,
-                        Function.identity(),
-                        (existing, replacement) -> existing)); // Handle duplicates if necessary
-
-        var accounts = accountMap.values();
-
-        if(accounts.isEmpty())
-            throw new WalletException("No signers found!");
-
-        for (Account signerAcc : accounts)
-            txToSign = signerAcc.sign(txToSign);
-
-        return txToSign;
-    }
-
-//
-//    /**
-//     * Returns a list with signers needed for this transaction
-//     *
-//     * @param tx
-//     * @param utxoSupplier
-//     * @return
-//     */
-//    public List<Account> getSignersForTransaction(Transaction tx, WalletUtxoSupplier utxoSupplier) {
-//        return getSignersForInputs(tx.getBody().getInputs(), utxoSupplier);
-//    }
-//
-//    private List<Account> getSignersForInputs(List<TransactionInput> inputs, WalletUtxoSupplier utxoSupplier) {
-//        // searching for address to sign
-//        List<Account> signers = new ArrayList<>();
-//        List<TransactionInput> remaining = new ArrayList<>(inputs);
-//
-//        int index = 0;
-//        int emptyCounter = 0;
-//        while (!remaining.isEmpty() || emptyCounter >= INDEX_SEARCH_RANGE) {
-//            List<WalletUtxo> utxos = utxoSupplier.getUtxosForAccountAndIndex(this.account, index);
-//            emptyCounter = utxos.isEmpty() ? emptyCounter + 1 : 0;
-//
-//            for (Utxo utxo : utxos) {
-//                if(matchUtxoWithInputs(inputs, utxo, signers, index, remaining))
-//                    break;
-//            }
-//            index++;
-//        }
-//        return signers;
-//    }
-//
-//    private boolean matchUtxoWithInputs(List<TransactionInput> inputs, Utxo utxo, List<Account> signers, int index, List<TransactionInput> remaining) {
-//        for (TransactionInput input : inputs) {
-//            if(utxo.getTxHash().equals(input.getTransactionId()) && utxo.getOutputIndex() == input.getIndex()) {
-//                var account = getAccountObject(index);
-//                var accNotFound = signers.stream()
-//                        .noneMatch(acc -> account.baseAddress().equals(acc.baseAddress()));
-//                if (accNotFound)
-//                    signers.add(getAccountObject(index));
-//                remaining.remove(input);
-//            }
-//        }
-//        return remaining.isEmpty();
-//    }
-
-    /**
-     * Returns the stake address of the wallet.
-     * @return Stake address as string
-     */
-    public String getStakeAddress() {
-        if (stakeAddress == null || stakeAddress.isEmpty()) {
-            HdKeyPair stakeKeyPair = getStakeKeyPair();
-            Address address = AddressProvider.getRewardAddress(stakeKeyPair.getPublicKey(), network);
-            stakeAddress = address.toBech32();
-        }
-        return stakeAddress;
-    }
-
-    /**
-     * Signs the transaction with stake key from wallet.
-     * @param transaction transaction object to sign
-     * @return Signed transaction object
-     */
-    public Transaction signWithStakeKey(Transaction transaction) {
-        return TransactionSigner.INSTANCE.sign(transaction, getStakeKeyPair());
-    }
-
-    private HdKeyPair getStakeKeyPair() {
-        if(stakeKeys == null) {
-            DerivationPath stakeDerivationPath = DerivationPath.createStakeAddressDerivationPathForAccount(this.accountNo);
-            stakeKeys = new CIP1852().getKeyPairFromMnemonic(mnemonic, stakeDerivationPath);
-        }
-        return stakeKeys;
-    }
-
 }

--- a/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/util/HDWalletAddressIterator.java
+++ b/hd-wallet/src/main/java/com/bloxbean/cardano/hdwallet/util/HDWalletAddressIterator.java
@@ -74,11 +74,20 @@ public class HDWalletAddressIterator implements AddressIterator {
     }
 
     @Override
+    public Address getFirst() {
+        return wallet.getBaseAddress(0);
+    }
+
+    @Override
     public void reset() {
         index = 0;
         gapCount = 0;
 
         this.indexesToScan = wallet.getIndexesToScan() != null && wallet.getIndexesToScan().length > 0 ?
                 Arrays.stream(wallet.getIndexesToScan()).iterator() : null;
+    }
+
+    public AddressIterator clone() {
+        return new HDWalletAddressIterator(wallet, utxoSupplier);
     }
 }

--- a/hd-wallet/src/test/java/com/bloxbean/cardano/hdwallet/WalletTest.java
+++ b/hd-wallet/src/test/java/com/bloxbean/cardano/hdwallet/WalletTest.java
@@ -36,21 +36,21 @@ public class WalletTest {
 
     @Test
     void generateMnemonic24w() {
-        Wallet hdWallet = new Wallet(Networks.testnet());
+        Wallet hdWallet = Wallet.create(Networks.testnet());
         String mnemonic = hdWallet.getMnemonic();
         assertEquals(24, mnemonic.split(" ").length);
     }
 
     @Test
     void generateMnemonic15w() {
-        Wallet hdWallet = new Wallet(Networks.testnet(), Words.FIFTEEN);
+        DefaultWallet hdWallet = new DefaultWallet(Networks.testnet(), Words.FIFTEEN);
         String mnemonic = hdWallet.getMnemonic();
         assertEquals(15, mnemonic.split(" ").length);
     }
 
     @Test
     void WalletAddressToAccountAddressTest() {
-        Wallet hdWallet = new Wallet(Networks.testnet());
+        DefaultWallet hdWallet = new DefaultWallet(Networks.testnet());
         Address address = hdWallet.getBaseAddress(0);
         Account a = new Account(hdWallet.getNetwork(), hdWallet.getMnemonic(), 0);
         assertEquals(address.getAddress(), a.getBaseAddress().getAddress());

--- a/hd-wallet/src/test/java/com/bloxbean/cardano/hdwallet/util/HDWalletAddressIteratorTest.java
+++ b/hd-wallet/src/test/java/com/bloxbean/cardano/hdwallet/util/HDWalletAddressIteratorTest.java
@@ -33,7 +33,7 @@ class HDWalletAddressIteratorTest {
 
     @Test
     void next() throws Exception{
-        Wallet wallet = new Wallet();
+        Wallet wallet = Wallet.create();
         var addr1 = wallet.getAccountAtIndex(3).baseAddress();
         var addr2 = wallet.getAccountAtIndex(7).baseAddress();
         var addr3 = wallet.getAccountAtIndex(24).baseAddress();
@@ -66,7 +66,7 @@ class HDWalletAddressIteratorTest {
 
     @Test
     void next_noTx() throws Exception{
-        Wallet wallet = new Wallet();
+        Wallet wallet = Wallet.create();
         wallet.setGapLimit(5);
 
         var addr1 = wallet.getAccountAtIndex(5).baseAddress();

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/AbstractTx.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/AbstractTx.java
@@ -18,9 +18,9 @@ import com.bloxbean.cardano.client.spec.Script;
 import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.util.Tuple;
+import com.bloxbean.cardano.hdwallet.Wallet;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import com.bloxbean.cardano.hdwallet.Wallet;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
@@ -191,7 +191,7 @@ public class QuickTxBuilder {
          * @throws TxBuildException if the fee payer has already been set
          */
         public TxContext feePayer(String address) {
-            if (feePayerWallet != null || feePayer != null)
+            if (this.feePayerWallet != null || this.feePayer != null)
                 throw new TxBuildException("The fee payer has already been set. It can only be set once.");
 
             this.feePayer = address;
@@ -207,7 +207,7 @@ public class QuickTxBuilder {
          * @throws TxBuildException if the fee payer has already been set
          */
         public TxContext feePayer(Wallet feePayerWallet) {
-            if (feePayerWallet != null || feePayer != null)
+            if (this.feePayerWallet != null || this.feePayer != null)
                 throw new TxBuildException("The fee payer has already been set. It can only be set once.");
 
             this.feePayerWallet = feePayerWallet;

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
@@ -225,7 +225,7 @@ public class QuickTxBuilder {
          * @throws TxBuildException if the collateral payer has already been set
          */
         public TxContext collateralPayer(String address) {
-            if (collateralPayerWallet != null || collateralPayer != null)
+            if (this.collateralPayerWallet != null || this.collateralPayer != null)
                 throw new TxBuildException("The collateral payer has already been set. It can only be set once.");
 
             this.collateralPayer = address;
@@ -241,7 +241,7 @@ public class QuickTxBuilder {
          * @throws TxBuildException if the collateral payer has already been set
          */
         public TxContext collateralPayer(Wallet wallet) {
-            if (collateralPayerWallet != null || collateralPayer != null)
+            if (this.collateralPayerWallet != null || this.collateralPayer != null)
                 throw new TxBuildException("The collateral payer has already been set. It can only be set once.");
 
             this.collateralPayerWallet = wallet;

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
@@ -177,6 +177,7 @@ public class QuickTxBuilder {
         private boolean ignoreScriptCostEvaluationError = true;
         private Era serializationEra;
         private boolean removeDuplicateScriptWitnesses = false;
+        private boolean searchUtxoByAddressVkh = false;
 
         TxContext(AbstractTx... txs) {
             this.txList = txs;
@@ -359,6 +360,9 @@ public class QuickTxBuilder {
 
             //Set merge outputs flag
             txBuilderContext.mergeOutputs(mergeOutputs);
+
+            //Enable/Disable search by address vkh
+            txBuilderContext.withSearchUtxoByAddressVkh(searchUtxoByAddressVkh);
 
             //Set tx evaluator for script cost calculation
             if (txnEvaluator != null)
@@ -997,6 +1001,25 @@ public class QuickTxBuilder {
          */
         public TxContext removeDuplicateScriptWitnesses(boolean remove) {
             this.removeDuplicateScriptWitnesses = remove;
+            return this;
+        }
+
+        /**
+         * Enables UTXO search by address verification hash (addr_vkh).
+         * Configures the internal {@link UtxoSupplier} to search using the address verification hash.
+         *
+         * By default, searching by address verification hash is disabled.
+         * <p></p>
+         * If the {@link UtxoSupplier} relies on {@link UtxoService} to provide UTXOs
+         * and the {@link UtxoService} does not support searching by address verification hash,
+         * the search will fail.
+         *
+         * @param flag a boolean indicating whether to enable or disable searching UTXOs by address vkh.
+         *
+         * @return TxContext the current TxContext instance
+         */
+        public TxContext withSearchUtxoByAddressVkh(boolean flag) {
+            this.searchUtxoByAddressVkh = flag;
             return this;
         }
 

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/ScriptTx.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/ScriptTx.java
@@ -46,6 +46,7 @@ public class ScriptTx extends AbstractTx<ScriptTx> {
     protected List<TransactionInput> referenceInputs;
 
     protected String fromAddress;
+    protected Wallet fromWallet;
     private StakeTx stakeTx;
     private GovTx govTx;
 
@@ -641,11 +642,17 @@ public class ScriptTx extends AbstractTx<ScriptTx> {
 
     @Override
     protected Wallet getFromWallet() {
-        return null;
+        return fromWallet;
     }
 
     void from(String address) {
         this.fromAddress = address;
+    }
+
+    void from(Wallet wallet) {
+        this.fromWallet = wallet;
+        // TODO fromAddress is not used in this scenarios, but it must be set to avoid breaking other things.
+        this.fromAddress = this.fromWallet.getBaseAddressString(0);
     }
 
     @Override

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/verifiers/OutputAmountVerifier.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/verifiers/OutputAmountVerifier.java
@@ -8,6 +8,7 @@ import com.bloxbean.cardano.client.transaction.spec.Transaction;
 import com.bloxbean.cardano.client.util.Tuple;
 
 import java.math.BigInteger;
+import java.util.function.Predicate;
 
 import static com.bloxbean.cardano.client.common.CardanoConstants.LOVELACE;
 
@@ -18,6 +19,8 @@ public class OutputAmountVerifier implements Verifier {
 
     private final String address;
     private final Amount amount;
+    private final Predicate<Amount> predicate;
+    private final String unit;
     private final String customMsg;
 
     /**
@@ -29,19 +32,43 @@ public class OutputAmountVerifier implements Verifier {
     public OutputAmountVerifier(String address, Amount amount, String customMsg) {
         this.address = address;
         this.amount = amount;
+        this.unit = amount.getUnit();
+        this.predicate = null;
+        this.customMsg = customMsg;
+    }
+
+    /**
+     * Constructor to create an OutputAmountVerifier instance with a specific unit and predicate for validation.
+     * This verifier is used to verify the output amount for a given address.
+     *
+     * @param address the address for which the output amount is to be verified
+     * @param unit the unit of the amount to be verified
+     * @param predicate a predicate to define the condition for amount verification
+     * @param customMsg a custom message to throw in case of verification failure
+     */
+    public OutputAmountVerifier(String address, String unit, Predicate<Amount> predicate, String customMsg) {
+        this.address = address;
+        this.amount = null;
+        this.unit = unit;
+        this.predicate = predicate;
         this.customMsg = customMsg;
     }
 
     @Override
     public void verify(Transaction txn) throws VerifierException {
-        if (LOVELACE.equals(amount.getUnit())) {
+        if (LOVELACE.equals(unit)) {
             BigInteger lovelaceAmt = txn.getBody()
                     .getOutputs().stream()
                     .filter(o -> o.getAddress().equals(address))
                     .map(o -> o.getValue().getCoin())
                     .reduce(BigInteger.ZERO, (amount1, amount2) -> amount1.add(amount2));
 
-            if (lovelaceAmt.compareTo(amount.getQuantity()) != 0) {
+            if (predicate != null) {
+                if (!predicate.test(Amount.lovelace(lovelaceAmt))) {
+                    String expectedMsg = formatExceptionMessage(customMsg, address, unit, lovelaceAmt);
+                    throw new VerifierException(expectedMsg);
+                }
+            } else if (lovelaceAmt.compareTo(amount.getQuantity()) != 0) {
                 String expectedMsg = formatExceptionMessage(customMsg, address, amount, lovelaceAmt);
                 throw new VerifierException(expectedMsg);
             }
@@ -57,8 +84,13 @@ public class OutputAmountVerifier implements Verifier {
                     }).map(assetTuple -> assetTuple._2.getValue())
                     .reduce(BigInteger.ZERO, (amount1, amount2) -> amount1.add(amount2));
 
-            String expectedMsg = formatExceptionMessage(customMsg, address, amount, assetAmount);
-            if (assetAmount.compareTo(amount.getQuantity()) != 0) {
+            if (predicate != null) {
+                if (!predicate.test(Amount.asset(amount.getUnit(), assetAmount))) {
+                    String expectedMsg = formatExceptionMessage(customMsg, address, unit, assetAmount);
+                    throw new VerifierException(expectedMsg);
+                }
+            } else if (assetAmount.compareTo(amount.getQuantity()) != 0) {
+                String expectedMsg = formatExceptionMessage(customMsg, address, amount, assetAmount);
                 throw new VerifierException(expectedMsg);
             }
         }
@@ -67,6 +99,15 @@ public class OutputAmountVerifier implements Verifier {
     private String formatExceptionMessage(String customMsg, String address, Amount expectedAmount, BigInteger actualAmount) {
         String expectedMsg = String.format("Expected amount %s(%s) for address %s, \nbut got %s",
                 expectedAmount.getQuantity(), expectedAmount.getUnit(), address, actualAmount);
+        if(customMsg != null)
+            expectedMsg = customMsg + ".\n" + expectedMsg;
+
+        return expectedMsg;
+    }
+
+    private String formatExceptionMessage(String customMsg, String address, String unit, BigInteger actualAmount) {
+        String expectedMsg = String.format("Amount for  address %s and unit %s doesn't match the condition. Actual amount: %s",
+                 address, unit, actualAmount);
         if(customMsg != null)
             expectedMsg = customMsg + ".\n" + expectedMsg;
 

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/verifiers/TxVerifiers.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/verifiers/TxVerifiers.java
@@ -3,6 +3,8 @@ package com.bloxbean.cardano.client.quicktx.verifiers;
 import com.bloxbean.cardano.client.api.model.Amount;
 import com.bloxbean.cardano.client.quicktx.Verifier;
 
+import java.util.function.Predicate;
+
 /**
  * Helper class to create verifiers
  */
@@ -27,5 +29,17 @@ public class TxVerifiers {
      */
     public static Verifier outputAmountVerifier(String address, Amount amount, String customMsg) {
         return new OutputAmountVerifier(address, amount, customMsg);
+    }
+
+    /**
+     * Creates a verifier to validate the output amount for a specific address and unit with the given condition.
+     *
+     * @param address the address for which the output amount is to be verified
+     * @param unit the unit of the output amount to be verified (e.g., lovelace, asset unit)
+     * @param condition a predicate defining the condition that the amount must satisfy
+     * @return an instance of Verifier to validate the output amount based on the provided parameters
+     */
+    public static Verifier outputAmountVerifier(String address, String unit, Predicate<Amount> condition) {
+        return new OutputAmountVerifier(address, unit, condition, null);
     }
 }


### PR DESCRIPTION
#490 

- The `UtxoSelectionStrategy` interface has been updated to accept an `AddressIterator` instead of a single address. This is required for HDWallet implementations, where the wallet needs to scan multiple addresses for UTXOs. For the existing single address mode, the `AddressIterator` only contains one address.

- An interface for the wallet and a default wallet implementation have been created. This will enable us to introduce new wallet implementations, such as `LedgerHWWallet` in the future without changing the core transaction builder APIs.

- A new method in `UtxoSupplier` and `UtxoSelector` to enable/disable utxo search by address vkh.
