### PR TITLE
Utility methods to convert CIP129 DRepId, cc ids + Fix Ogmios Tx Evaluator and Epoch Params

### DIFF
--- a/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/OgmiosTxResponseParser.java
+++ b/backend-modules/blockfrost/src/main/java/com/bloxbean/cardano/client/backend/blockfrost/service/OgmiosTxResponseParser.java
@@ -71,9 +71,9 @@ class OgmiosTxResponseParser {
                             redeemerTag = RedeemerTag.Cert;
                         else if ("reward".equals(splits[0]) || "withdrawal".equals(splits[0]) || "withdraw".equals(splits[0]))
                             redeemerTag = RedeemerTag.Reward;
-                        else if ("vote".equals(splits[0]))
+                        else if ("vote".equals(splits[0]) || "voting".equals(splits[0]))
                             redeemerTag = RedeemerTag.Voting;
-                        else if ("propose".equals(splits[0]))
+                        else if ("propose".equals(splits[0]) || "proposing".equals(splits[0]))
                             redeemerTag = RedeemerTag.Proposing;
                         else
                             throw new RuntimeException("Invalid RedeemerTag in evaluateTx reponse: " + splits[0]);

--- a/backend-modules/ogmios/src/it/java/com/bloxbean/cardano/client/backend/ogmios/OgmiosBaseTest.java
+++ b/backend-modules/ogmios/src/it/java/com/bloxbean/cardano/client/backend/ogmios/OgmiosBaseTest.java
@@ -9,8 +9,8 @@ public class OgmiosBaseTest {
     protected KupoUtxoService kupoUtxoService;
     protected KupmiosBackendService kupmiosBackendService;
 
-    private String OGMIOS_HTTP_URL = "http://ogmios-preprod:1337/";
-    private String KUPO_HTTP_URL = "http://kupo-preprod:1442/";
+    private String OGMIOS_HTTP_URL = "http://localhost:1337/";
+    private String KUPO_HTTP_URL = "http://localhost:1442/";
 
     public OgmiosBaseTest() {
         this.ogmiosBackendService = new OgmiosBackendService(OGMIOS_HTTP_URL);

--- a/backend-modules/ogmios/src/it/java/com/bloxbean/cardano/client/backend/ogmios/OgmiosEpochServiceIT.java
+++ b/backend-modules/ogmios/src/it/java/com/bloxbean/cardano/client/backend/ogmios/OgmiosEpochServiceIT.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,6 +32,8 @@ public class OgmiosEpochServiceIT extends OgmiosBaseTest {
         assertEquals(protocolParams.getCollateralPercent().intValue(), 150);
         assertThat(protocolParams.getEMax()).isNotNull();
         assertThat(protocolParams.getNOpt()).isNotNull();
+        assertThat(protocolParams.getDrepDeposit()).isGreaterThan(BigInteger.ZERO);
+        assertThat(protocolParams.getGovActionDeposit()).isGreaterThan(BigInteger.ZERO);
         assertThat(protocolParams.getMinFeeRefScriptCostPerByte()).isEqualTo(BigDecimal.valueOf(15.0));
     }
 }

--- a/governance/src/main/java/com/bloxbean/cardano/client/governance/GovId.java
+++ b/governance/src/main/java/com/bloxbean/cardano/client/governance/GovId.java
@@ -1,8 +1,11 @@
 package com.bloxbean.cardano.client.governance;
 
+import com.bloxbean.cardano.client.address.Credential;
 import com.bloxbean.cardano.client.address.CredentialType;
 import com.bloxbean.cardano.client.crypto.Bech32;
+import com.bloxbean.cardano.client.transaction.spec.governance.DRep;
 import com.bloxbean.cardano.client.util.HexUtil;
+import lombok.NonNull;
 
 /**
  * The GovId class provides methods for generating governance related ids.
@@ -94,6 +97,72 @@ public class GovId {
 
         byte[] mergedBytes = HexUtil.decodeHexString(txHash + indexHex);
         return Bech32.encode(mergedBytes, GOV_ACTION_PREFIX);
+    }
+
+    public static DRep toDrep(@NonNull String drepId) {
+        if (!drepId.startsWith(DREP_PREFIX))
+            throw new IllegalArgumentException("Invalid drep id prefix");
+
+        byte[] idBytes = Bech32.decode(drepId).data;
+        byte[] keyBytes = new byte[idBytes.length - 1];
+
+        if (keyBytes.length != 28)
+            throw new IllegalArgumentException("Key bytes length should be 28, but found " + keyBytes.length);
+
+        System.arraycopy(idBytes, 1, keyBytes, 0, idBytes.length - 1);
+
+        var credType = credTypeFromIdBytes(idBytes);
+
+        if (credType == CredentialType.Key)
+            return DRep.addrKeyHash(keyBytes);
+        else if (credType == CredentialType.Script)
+            return DRep.scriptHash(keyBytes);
+        else
+            throw new IllegalArgumentException("Invalid credential type");
+    }
+
+    public static Credential ccHotToCredential(@NonNull String ccHotId) {
+        if (!ccHotId.startsWith(CC_HOT_PREFIX))
+            throw new IllegalArgumentException("Invalid cc hot id prefix");
+
+        byte[] idBytes = Bech32.decode(ccHotId).data;
+        byte[] keyBytes = new byte[idBytes.length - 1];
+
+        if (keyBytes.length != 28)
+            throw new IllegalArgumentException("Key bytes length should be 28, but found " + keyBytes.length);
+
+        System.arraycopy(idBytes, 1, keyBytes, 0, idBytes.length - 1);
+
+        var credType = credTypeFromIdBytes(idBytes);
+
+        if (credType == CredentialType.Key)
+            return Credential.fromKey(keyBytes);
+        else if (credType == CredentialType.Script)
+            return Credential.fromScript(keyBytes);
+        else
+            throw new IllegalArgumentException("Invalid credential type");
+    }
+
+    public static Credential ccColdToCredential(@NonNull String ccColdId) {
+        if (!ccColdId.startsWith(CC_COLD_PREFIX))
+            throw new IllegalArgumentException("Invalid cc cold id prefix");
+
+        byte[] idBytes = Bech32.decode(ccColdId).data;
+        byte[] keyBytes = new byte[idBytes.length - 1];
+
+        if (keyBytes.length != 28)
+            throw new IllegalArgumentException("Key bytes length should be 28, but found " + keyBytes.length);
+
+        System.arraycopy(idBytes, 1, keyBytes, 0, idBytes.length - 1);
+
+        var credType = credTypeFromIdBytes(idBytes);
+
+        if (credType == CredentialType.Key)
+            return Credential.fromKey(keyBytes);
+        else if (credType == CredentialType.Script)
+            return Credential.fromScript(keyBytes);
+        else
+            throw new IllegalArgumentException("Invalid credential type");
     }
 
     private static byte[] getIdentifierBytes(byte keyType, byte credType, byte[] keyHash) {

--- a/governance/src/main/java/com/bloxbean/cardano/client/governance/LegacyDRepId.java
+++ b/governance/src/main/java/com/bloxbean/cardano/client/governance/LegacyDRepId.java
@@ -47,6 +47,9 @@ public class LegacyDRepId {
     public static DRep toDrep(String drepId, DRepType drepType) {
         byte[] bytes = Bech32.decode(drepId).data;
 
+        if (bytes.length != 28)
+            throw new IllegalArgumentException("DRep key bytes length should be 28, but found " + bytes.length);
+
         if (drepType == DRepType.ADDR_KEYHASH) {
             return DRep.addrKeyHash(HexUtil.encodeHexString(bytes));
         } else if (drepType == DRepType.SCRIPTHASH) {

--- a/governance/src/test/java/com/bloxbean/cardano/client/governance/GovIdTest.java
+++ b/governance/src/test/java/com/bloxbean/cardano/client/governance/GovIdTest.java
@@ -1,10 +1,14 @@
 package com.bloxbean.cardano.client.governance;
 
+import com.bloxbean.cardano.client.address.Credential;
 import com.bloxbean.cardano.client.address.CredentialType;
+import com.bloxbean.cardano.client.transaction.spec.governance.DRep;
+import com.bloxbean.cardano.client.transaction.spec.governance.DRepType;
 import com.bloxbean.cardano.client.util.HexUtil;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class GovIdTest {
 
@@ -78,6 +82,82 @@ class GovIdTest {
 
         String govActionId = GovId.govAction(txHash, index);
         assertThat(govActionId).isEqualTo("gov_action1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsq6dmejn");
+    }
+
+    @Test
+    void drepFromDrepId() {
+        String drepId = "drep1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7vlc9n";
+        DRep dRep = GovId.toDrep(drepId);
+
+        assertThat(dRep.getHash()).isEqualTo("00000000000000000000000000000000000000000000000000000000");
+        assertThat(dRep.getType()).isEqualTo(DRepType.ADDR_KEYHASH);
+    }
+
+    @Test
+    void drepFromDrepId_1() {
+        String drepId = "drep1y2jmg4g450lced7q9n34rq6d5vjwkm0ugx6h0894u6ur92s9txn3a";
+        DRep dRep = GovId.toDrep(drepId);
+
+        assertThat(dRep.getHash()).isEqualTo("a5b45515a3ff8cb7c02ce351834da324eb6dfc41b5779cb5e6b832aa");
+        assertThat(dRep.getType()).isEqualTo(DRepType.ADDR_KEYHASH);
+    }
+
+    @Test
+    void drepFromDrepId_invlid_keylength() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            String drepId = "drep15k6929drl7xt0spvudgcxndryn4kmlzpk4meed0xhqe25nle07s";
+            GovId.toDrep(drepId);
+        });
+    }
+
+    @Test
+    void drepFromDrepId_invlid_drepid() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            String drepId = "cc_hot1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvcdjk7";
+            GovId.toDrep(drepId);
+        });
+    }
+
+    @Test
+    void ccHotToCredential() {
+        String drepId = "cc_hot1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvcdjk7";
+        Credential credential = GovId.ccHotToCredential(drepId);
+
+        assertThat(credential.getBytes()).isEqualTo(HexUtil.decodeHexString("00000000000000000000000000000000000000000000000000000000"));
+        assertThat(credential.getType()).isEqualTo(CredentialType.Key);
+    }
+
+    @Test
+    void ccHotToCredential_invalid_prefix() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            String drepId = "cc_cold1zvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6kflvs";
+            GovId.ccHotToCredential(drepId);
+        });
+    }
+
+    @Test
+    void ccColdToCredential() {
+        String drepId = "cc_cold1zvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6kflvs";
+        Credential credential = GovId.ccColdToCredential(drepId);
+
+        assertThat(credential.getBytes()).isEqualTo(HexUtil.decodeHexString("00000000000000000000000000000000000000000000000000000000"));
+        assertThat(credential.getType()).isEqualTo(CredentialType.Script);
+    }
+
+    @Test
+    void ccColdToCredential_invalid_prefix() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            String drepId = "cc_hot1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvcdjk7";
+            GovId.ccColdToCredential(drepId);
+        });
+    }
+
+    @Test
+    void ccColdToCredential_invlid_keylength() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            String drepId = "cc_cold1lmaet9hdvu9d9jvh34u0un4ndw3yewaq5ch6fnwsctw02xxwylj";
+            GovId.ccColdToCredential(drepId);
+        });
     }
 
     /**. TODO : Add tests for commented test cases

--- a/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/GovernanceTxIT.java
+++ b/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/GovernanceTxIT.java
@@ -7,8 +7,11 @@ import com.bloxbean.cardano.client.backend.blockfrost.common.Constants;
 import com.bloxbean.cardano.client.backend.blockfrost.service.BFBackendService;
 import com.bloxbean.cardano.client.common.model.Networks;
 import com.bloxbean.cardano.client.crypto.cip1852.DerivationPath;
+import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.function.helper.SignerProviders;
-import com.bloxbean.cardano.client.governance.LegacyDRepId;
+import com.bloxbean.cardano.client.governance.GovId;
+import com.bloxbean.cardano.client.plutus.spec.PlutusData;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV3Script;
 import com.bloxbean.cardano.client.spec.UnitInterval;
 import com.bloxbean.cardano.client.transaction.spec.ProtocolParamUpdate;
 import com.bloxbean.cardano.client.transaction.spec.ProtocolVersion;
@@ -16,15 +19,14 @@ import com.bloxbean.cardano.client.transaction.spec.Withdrawal;
 import com.bloxbean.cardano.client.transaction.spec.governance.*;
 import com.bloxbean.cardano.client.transaction.spec.governance.actions.*;
 import com.bloxbean.cardano.client.util.HexUtil;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.math.BigInteger;
 
 import static com.bloxbean.cardano.client.common.ADAConversionUtil.adaToLovelace;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-//TODO -- Update tests to use Yaci DevKit Sanchonet
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class GovernanceTxIT extends TestDataBaseIT {
     BackendService backendService;
     Account sender1;
@@ -35,6 +37,12 @@ public class GovernanceTxIT extends TestDataBaseIT {
 
     QuickTxBuilder quickTxBuilder;
 
+    //For devkit default guardrails script
+    PlutusV3Script alwaysTrueScript = PlutusV3Script.builder()
+            .type("PlutusScriptV3")
+            .cborHex("46450101002499")
+            .build();
+
     @Override
     public BackendService getBackendService() {
         if (BLOCKFROST.equals(backendType)) {
@@ -42,8 +50,8 @@ public class GovernanceTxIT extends TestDataBaseIT {
             if (bfProjectId == null || bfProjectId.isEmpty()) {
                 bfProjectId = System.getenv("BF_PROJECT_ID");
             }
-
-            return new BFBackendService(Constants.BLOCKFROST_SANCHONET_URL, bfProjectId);
+            bfProjectId = "preprodJ9lqAJFlWztmUtNfbwx2FOKmPmnQE5La";
+            return new BFBackendService(Constants.BLOCKFROST_PREPROD_URL, bfProjectId);
         } else
             return super.getBackendService();
     }
@@ -59,9 +67,12 @@ public class GovernanceTxIT extends TestDataBaseIT {
 
         sender2 = new Account(Networks.testnet(), senderMnemonic, DerivationPath.createExternalAddressDerivationPathForAccount(1));
         sender2Addr = sender2.baseAddress();
+
+        topUpFund(sender1Addr, 300000L);
     }
 
     @Test
+    @Order(1)
     void registerDrep() {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
@@ -88,6 +99,7 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(2)
     void deRegisterDrep() {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
         Tx tx = new Tx()
@@ -107,6 +119,71 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(3)
+    void registerDrep_again() {
+        QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
+
+        var anchor = new Anchor("https://pages.bloxbean.com/cardano-stake/bloxbean-pool.json",
+                HexUtil.decodeHexString("bafef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937"));
+
+        Tx drepRegTx = new Tx()
+                .registerDRep(sender1, anchor)
+                .from(sender1Addr);
+
+        Result<String> result = quickTxBuilder.compose(drepRegTx)
+                .withSigner(SignerProviders.signerFrom(sender1))
+                .withSigner(SignerProviders.signerFrom(sender1.drepHdKeyPair()))
+                .complete();
+
+        System.out.println("DRepId : " + sender1.drepId());
+
+
+        System.out.println(result);
+        assertTrue(result.isSuccessful());
+        waitForTransaction(result);
+
+        checkIfUtxoAvailable(result.getValue(), sender1Addr);
+    }
+
+    @Test
+    @Order(4)
+    void voteDelegation() {
+        try {
+            stakeAddressRegistration(sender2Addr);
+        } catch (Exception e) {
+            e.printStackTrace();
+            //Incase it's already registered
+        }
+
+        QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
+
+        //CIP 105
+        DRep drep = GovId.toDrep(sender1.drepId());
+        System.out.println("Drep : " + sender1.drepId());
+
+        //For Legacy DRep id (CIP 105)
+//      DRep drep = GovId.toDrep(sender1.legacyDRepId());
+
+        Tx tx = new Tx()
+                .delegateVotingPowerTo(sender2Addr, drep)
+                .from(sender1Addr);
+
+        Result<String> result = quickTxBuilder.compose(tx)
+                .withSigner(SignerProviders.stakeKeySignerFrom(sender2))
+                .withSigner(SignerProviders.signerFrom(sender1))
+                .withTxInspector(transaction -> {
+                    System.out.println(transaction);
+                })
+                .completeAndWait(s -> System.out.println(s));
+
+        System.out.println(result);
+        assertTrue(result.isSuccessful());
+        checkIfUtxoAvailable(result.getValue(), sender1Addr);
+    }
+
+
+    @Test
+    @Order(5)
     void updateDrep() {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
@@ -129,6 +206,7 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(6)
     void updateDrep_nullAnchor() {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
@@ -148,7 +226,15 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(15)
     void createProposal_infoAction() {
+        try {
+            stakeAddressRegistration(sender1Addr);
+        } catch (Exception e) {
+            e.printStackTrace();
+            //Incase already registered
+        }
+
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var govAction = new InfoAction();
@@ -170,13 +256,14 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(16)
     void createProposal_newConstitutionAction() {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var anchor = new Anchor("https://bit.ly/2kBHHHL",
                 HexUtil.decodeHexString("cdfef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937"));
         var govAction = new NewConstitution();
-        govAction.setPrevGovActionId(new GovActionId("bd5d786d745ec7c1994f8cff341afee513c7cdad73e8883d540ff71c41763fd1", 0));
+        //govAction.setPrevGovActionId(new GovActionId("bd5d786d745ec7c1994f8cff341afee513c7cdad73e8883d540ff71c41763fd1", 0));
         govAction.setConstitution(Constitution.builder()
                 .anchor(anchor)
                 .build());
@@ -195,12 +282,13 @@ public class GovernanceTxIT extends TestDataBaseIT {
         checkIfUtxoAvailable(result.getValue(), sender1Addr);
     }
 
+    String prevGovId;
     @Test
-    void createProposal_noConfidence() {
+    @Order(17)
+    void createProposal_noConfidence_withPrevGovAction() {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var noConfidence = new NoConfidence();
-        noConfidence.setPrevGovActionId(new GovActionId("e86050ac376fc4df7c76635f648c963f44702e13beb81a5c9971a418013c74dc", 0));
         var anchor = new Anchor("https://xyz.com",
                 HexUtil.decodeHexString("cafef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937"));
 
@@ -213,30 +301,62 @@ public class GovernanceTxIT extends TestDataBaseIT {
                 .withSigner(SignerProviders.signerFrom(sender1))
                 .completeAndWait(s -> System.out.println(s));
 
+        prevGovId = result.getValue();
         System.out.println(result);
         assertTrue(result.isSuccessful());
         checkIfUtxoAvailable(result.getValue(), sender1Addr);
+
+        //Another noConfidence proposal with prevGovAction id
+
+        var noConfidence2 = new NoConfidence();
+        System.out.println("Prev Gov id: " + prevGovId);
+        noConfidence2.setPrevGovActionId(new GovActionId(prevGovId, 0));
+        var anchor2 = new Anchor("https://abc.com",
+                HexUtil.decodeHexString("cafef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937"));
+
+        Tx tx2 = new Tx()
+                .createProposal(noConfidence2, sender1.stakeAddress(), anchor2)
+                .from(sender1Addr);
+
+        Result<String> result2 = quickTxBuilder.compose(tx2)
+                .withSigner(SignerProviders.drepKeySignerFrom(sender1))
+                .withSigner(SignerProviders.signerFrom(sender1))
+                .completeAndWait(s -> System.out.println(s));
+
+        System.out.println(result2);
+        assertTrue(result2.isSuccessful());
+        checkIfUtxoAvailable(result2.getValue(), sender1Addr);
     }
 
     @Test
-    void createProposal_parameterChangeAction() {
+    @Order(18)
+    void createProposal_parameterChangeAction() throws CborSerializationException {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var parameterChange = new ParameterChangeAction();
-        parameterChange.setPrevGovActionId(new GovActionId("529736be1fac33431667f2b66231b7b66d4c7a3975319ddac7cfb17dcb5c4145", 0));
+//        parameterChange.setPrevGovActionId(new GovActionId("529736be1fac33431667f2b66231b7b66d4c7a3975319ddac7cfb17dcb5c4145", 0));
         parameterChange.setProtocolParamUpdate(ProtocolParamUpdate.builder()
                 .minPoolCost(adaToLovelace(100))
                 .build()
         );
+
+        //For devkit default guardrails script
+        PlutusV3Script alwaysTrueScript = PlutusV3Script.builder()
+                .type("PlutusScriptV3")
+                .cborHex("46450101002499")
+                .build();
+
+        parameterChange.setPolicyHash(alwaysTrueScript.getScriptHash());
+
         var anchor = new Anchor("https://xyz.com",
                 HexUtil.decodeHexString("cafef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937"));
 
-        Tx tx = new Tx()
-                .createProposal(parameterChange, sender1.stakeAddress(), anchor)
-                .from(sender1Addr);
+        ScriptTx tx = new ScriptTx()
+                .createProposal(parameterChange, sender1.stakeAddress(), anchor, PlutusData.unit())
+                .attachProposingValidator(alwaysTrueScript);
 
         Result<String> result = quickTxBuilder.compose(tx)
-                .withSigner(SignerProviders.drepKeySignerFrom(sender1))
+                .feePayer(sender1Addr)
                 .withSigner(SignerProviders.signerFrom(sender1))
                 .completeAndWait(s -> System.out.println(s));
 
@@ -246,21 +366,38 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
-    void createProposal_treasuryWithdrawalAction() {
+    @Order(19)
+    void createProposal_treasuryWithdrawalAction() throws CborSerializationException {
+        String rewardAddress = "stake_test1ur6l9f5l9jw44kl2nf6nm5kca3nwqqkccwynnjm0h2cv60ccngdwa";
+        try {
+            stakeAddressRegistration(rewardAddress);
+        } catch (Exception e) {
+            e.printStackTrace();
+            //If already registered
+        }
+
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var treasuryWithdrawalsAction = new TreasuryWithdrawalsAction();
-        treasuryWithdrawalsAction.addWithdrawal(new Withdrawal("stake_test1ur6l9f5l9jw44kl2nf6nm5kca3nwqqkccwynnjm0h2cv60ccngdwa", adaToLovelace(20)));
+        treasuryWithdrawalsAction.addWithdrawal(new Withdrawal(rewardAddress, adaToLovelace(20)));
+
+        //For devkit default guardrails script
+        treasuryWithdrawalsAction.setPolicyHash(alwaysTrueScript.getScriptHash());
+
         var anchor = new Anchor("https://xyz.com",
                 HexUtil.decodeHexString("daeef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937"));
 
-        Tx tx = new Tx()
-                .createProposal(treasuryWithdrawalsAction, sender1.stakeAddress(), anchor)
-                .from(sender1Addr);
+        ScriptTx tx = new ScriptTx()
+                .createProposal(treasuryWithdrawalsAction, sender1.stakeAddress(), anchor, PlutusData.unit())
+                .attachProposingValidator(alwaysTrueScript);
 
         Result<String> result = quickTxBuilder.compose(tx)
+                .feePayer(sender1Addr)
                 .withSigner(SignerProviders.drepKeySignerFrom(sender1))
                 .withSigner(SignerProviders.signerFrom(sender1))
+                .withTxInspector(transaction -> {
+                    System.out.println(transaction);
+                })
                 .completeAndWait(s -> System.out.println(s));
 
         System.out.println(result);
@@ -269,11 +406,12 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(20)
     void createProposal_updateCommittee() {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var updateCommittee = new UpdateCommittee();
-        updateCommittee.setPrevGovActionId(new GovActionId("b3ce0371310a07a797657d19453d953bb352b6841c2f5c5e0bd2557189ef5c3a", 0));
+//        updateCommittee.setPrevGovActionId(new GovActionId("b3ce0371310a07a797657d19453d953bb352b6841c2f5c5e0bd2557189ef5c3a", 0));
         updateCommittee.setQuorumThreshold(new UnitInterval(BigInteger.valueOf(1), BigInteger.valueOf(3)));
 
         var anchor = new Anchor("https://xyz.com",
@@ -294,12 +432,13 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(21)
     void createProposal_hardforkInitiation() {
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var hardforkInitiation = new HardForkInitiationAction();
-        hardforkInitiation.setPrevGovActionId(new GovActionId("416f7f01c548a85546aa5bbd155b34bb2802df68e08db4e843ef6da764cd8f7e", 0));
-        hardforkInitiation.setProtocolVersion(new ProtocolVersion(9, 3));
+//        hardforkInitiation.setPrevGovActionId(new GovActionId("416f7f01c548a85546aa5bbd155b34bb2802df68e08db4e843ef6da764cd8f7e", 0));
+        hardforkInitiation.setProtocolVersion(new ProtocolVersion(11, 0));
 
         var anchor = new Anchor("https://xyz.com",
                 HexUtil.decodeHexString("daeef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937"));
@@ -319,7 +458,26 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(30)
     void createVote() {
+        //Create an info proposal and then vote
+        var govAction = new InfoAction();
+
+        Tx infoPropTx = new Tx()
+                .createProposal(govAction, sender1.stakeAddress(), new Anchor("https://xyz.com",
+                        HexUtil.decodeHexString("daeef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937")))
+                .from(sender1Addr);
+
+        Result<String> infoPropResult = quickTxBuilder.compose(infoPropTx)
+                .withSigner(SignerProviders.drepKeySignerFrom(sender1))
+                .withSigner(SignerProviders.signerFrom(sender1))
+                .completeAndWait(s -> System.out.println(s));
+
+        System.out.println(infoPropResult);
+        assertTrue(infoPropResult.isSuccessful());
+        checkIfUtxoAvailable(infoPropResult.getValue(), sender1Addr);
+
+        //Create vote and submit
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var anchor = new Anchor("https://xyz.com",
@@ -327,7 +485,7 @@ public class GovernanceTxIT extends TestDataBaseIT {
 
         var voter = new Voter(VoterType.DREP_KEY_HASH, sender1.drepCredential());
         Tx tx = new Tx()
-                .createVote(voter, new GovActionId("5655fbb4ceafd34296fe58f6e3d28b8ff663a89e84aa0edd77bd02fe379cef4c", 0),
+                .createVote(voter, new GovActionId(infoPropResult.getValue(), 0),
                         Vote.NO, anchor)
                 .from(sender1Addr);
 
@@ -342,12 +500,32 @@ public class GovernanceTxIT extends TestDataBaseIT {
     }
 
     @Test
+    @Order(31)
     void createVote_noAnchor() {
+        //Create an info proposal and then vote
+        var govAction = new InfoAction();
+
+        Tx infoPropTx = new Tx()
+                .createProposal(govAction, sender1.stakeAddress(), new Anchor("https://xyz.com",
+                        HexUtil.decodeHexString("daeef700c0039a2efb056a665b3a8bcd94f8670b88d659f7f3db68340f6f0937")))
+                .registerDRep(sender2)
+                .from(sender1Addr);
+
+        Result<String> infoPropResult = quickTxBuilder.compose(infoPropTx)
+                .withSigner(SignerProviders.signerFrom(sender1))
+                .withSigner(SignerProviders.drepKeySignerFrom(sender2))
+                .completeAndWait(s -> System.out.println(s));
+
+        System.out.println(infoPropResult);
+        assertTrue(infoPropResult.isSuccessful());
+        checkIfUtxoAvailable(infoPropResult.getValue(), sender1Addr);
+
+        //Vote
         QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
 
         var voter = new Voter(VoterType.DREP_KEY_HASH, sender2.drepCredential());
         Tx tx = new Tx()
-                .createVote(voter, new GovActionId("5655fbb4ceafd34296fe58f6e3d28b8ff663a89e84aa0edd77bd02fe379cef4c", 0),
+                .createVote(voter, new GovActionId(infoPropResult.getValue(), 0),
                         Vote.YES)
                 .from(sender1Addr);
 
@@ -360,32 +538,6 @@ public class GovernanceTxIT extends TestDataBaseIT {
         assertTrue(result.isSuccessful());
         checkIfUtxoAvailable(result.getValue(), sender1Addr);
     }
-
-    @Test
-    void voteDelegation() {
-//        stakeAddressRegistration(sender2Addr);
-        QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
-
-        DRep drep = LegacyDRepId.toDrep(sender1.drepId(), DRepType.ADDR_KEYHASH);
-        System.out.println("Drep : " + sender1.drepId());
-
-        Tx tx = new Tx()
-                .delegateVotingPowerTo(sender2Addr, drep)
-                .from(sender1Addr);
-
-        Result<String> result = quickTxBuilder.compose(tx)
-                .withSigner(SignerProviders.stakeKeySignerFrom(sender2))
-                .withSigner(SignerProviders.signerFrom(sender1))
-                .withTxInspector(transaction -> {
-                    System.out.println(transaction);
-                })
-                .completeAndWait(s -> System.out.println(s));
-
-        System.out.println(result);
-        assertTrue(result.isSuccessful());
-        checkIfUtxoAvailable(result.getValue(), sender1Addr);
-    }
-
 
     //stake address registration
     void stakeAddressRegistration(String addressToRegister) {

--- a/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/DRep.java
+++ b/transaction-spec/src/main/java/com/bloxbean/cardano/client/transaction/spec/governance/DRep.java
@@ -23,6 +23,10 @@ public class DRep {
     private DRepType type;
     private String hash; //key hash or script hash
 
+    public static DRep addrKeyHash(byte[] bytes) {
+        return addrKeyHash(HexUtil.encodeHexString(bytes));
+    }
+
     public static DRep addrKeyHash(String addrKeyHash) {
         DRep drep = new DRep();
         drep.type = DRepType.ADDR_KEYHASH;


### PR DESCRIPTION
- New static methods in `GovId` to get DRep from drepId, Credential from ccHotId and ccColdId
- Fixed BFBackend's tx evaluator endpoint to parse & map `proposing` redeemer tag
- `OgmiosEpochService` :  Added required values like govActionDeposit, drepDeposit to the response.