### PR TITLE
Update edsa lib dependency to bloxbean fork

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ slf4j-reload4j = "org.slf4j:slf4j-reload4j:2.0.11"
 bouncycastle-bcprov = "org.bouncycastle:bcprov-jdk18on:1.78"
 guava = "com.google.guava:guava:33.0.0-jre"
 co-nstant-in-cbor = "co.nstant.in:cbor:0.9"
-i2p-crypto-eddsa = "net.i2p.crypto:eddsa:0.3.0"
+i2p-crypto-eddsa = "com.bloxbean.cardano:net-i2p-crypto-eddsa:0.3.1"
 
 jackson-databind = "com.fasterxml.jackson.core:jackson-databind:2.16.0"
 retrofit2 = "com.squareup.retrofit2:retrofit:2.9.0"


### PR DESCRIPTION
- Fork https://github.com/bloxbean/ed25519-java/

Fixes:
- CVE-2020-36843 fix (https://github.com/str4d/ed25519-java/issues/82#issuecomment-2751279758)