### PR TITLE
 Fix: Add support for inline datum in change outputs when using ScriptTx.withChangeAddress(address, datum)

### DIFF
--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/InputBuilders.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/InputBuilders.java
@@ -41,7 +41,7 @@ public class InputBuilders {
 
         return ((context, outputs) -> {
             HDWalletAddressIterator addressIterator = new HDWalletAddressIterator(senderWallet, context.getUtxoSupplier());
-           return buildInputs(addressIterator, changeAddress, context, outputs);
+            return buildInputs(addressIterator, changeAddress, context, outputs);
         });
 
     }
@@ -253,8 +253,8 @@ public class InputBuilders {
         if (datum == null) {
             return createFromUtxos(utxos, changeAddress, null);
         } else {
-            String datumHash = Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(datum).getDatumHash();
-            return createFromUtxos(utxos, changeAddress, datumHash);
+            var plutusDataDatum = Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(datum);
+            return createFromUtxos(() -> utxos, changeAddress, plutusDataDatum, null);
         }
     }
 
@@ -267,7 +267,7 @@ public class InputBuilders {
      * @return <code>{@link TxInputBuilder}</code> function
      */
     public static TxInputBuilder createFromUtxos(List<Utxo> utxos, String changeAddress, String datumHash) {
-        return createFromUtxos(() -> utxos, changeAddress, datumHash);
+        return createFromUtxos(() -> utxos, changeAddress, null, datumHash);
     }
 
     /**
@@ -275,10 +275,11 @@ public class InputBuilders {
      *
      * @param supplier      Supplier function to provide a list of <code>{@link Utxo}</code>
      * @param changeAddress change address
-     * @param datumHash     datum hash to add to change output
+     * @param changeOutputDatum change output datum (inline datum)
+     * @param changeOutputDatumHash     datum hash to add to change output if changeOutputDatum is null
      * @return <code>{@link TxInputBuilder}</code> function
      */
-    public static TxInputBuilder createFromUtxos(Supplier<List<Utxo>> supplier, String changeAddress, String datumHash) {
+    public static TxInputBuilder createFromUtxos(Supplier<List<Utxo>> supplier, String changeAddress, PlutusData changeOutputDatum, String changeOutputDatumHash) {
         Objects.requireNonNull(changeAddress, "Change address cannot be null");
 
         return (context, outputs) -> {
@@ -322,8 +323,10 @@ public class InputBuilders {
                 Value changedValue = changeOutput.getValue().subtract(value);
                 changeOutput.setValue(changedValue);
 
-                if (datumHash != null && !datumHash.isEmpty())
-                    changeOutput.setDatumHash(HexUtil.decodeHexString(datumHash));
+                if (changeOutputDatum != null)
+                    changeOutput.setInlineDatum(changeOutputDatum);
+                else if (changeOutputDatumHash != null && !changeOutputDatumHash.isEmpty())
+                    changeOutput.setDatumHash(HexUtil.decodeHexString(changeOutputDatumHash));
 
                 if (!changeOutput.getValue().getCoin().equals(BigInteger.ZERO) ||
                         (changeOutput.getValue().getMultiAssets() != null && !changeOutput.getValue().getMultiAssets().isEmpty())) {

--- a/function/src/test/java/com/bloxbean/cardano/client/function/helper/InputBuildersTest.java
+++ b/function/src/test/java/com/bloxbean/cardano/client/function/helper/InputBuildersTest.java
@@ -17,6 +17,7 @@ import com.bloxbean.cardano.client.function.TxBuilderContext;
 import com.bloxbean.cardano.client.function.TxInputBuilder;
 import com.bloxbean.cardano.client.plutus.annotation.Constr;
 import com.bloxbean.cardano.client.plutus.annotation.PlutusField;
+import com.bloxbean.cardano.client.plutus.spec.PlutusData;
 import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.util.Tuple;
@@ -426,7 +427,7 @@ class InputBuildersTest extends BaseTest {
         );
 
         TxBuilderContext context = new TxBuilderContext(utxoSupplier, protocolParams);
-        TxInputBuilder.Result inputResult = InputBuilders.createFromUtxos(() -> utxos, changeAddress, HexUtil.encodeHexString("somedatum_hash".getBytes(StandardCharsets.UTF_8)))
+        TxInputBuilder.Result inputResult = InputBuilders.createFromUtxos(() -> utxos, changeAddress, null, HexUtil.encodeHexString("somedatum_hash".getBytes(StandardCharsets.UTF_8)))
                 .apply(context, outputs);
 
         assertThat(inputResult.getInputs()).hasSize(1);
@@ -449,7 +450,7 @@ class InputBuildersTest extends BaseTest {
     }
 
     @Test
-    void createFromUtxos_withDatumObj() throws CborException, CborSerializationException {
+    void createFromUtxos_withDatumObj_shouldContainInlineDatumInChangeOutput() throws CborException, CborSerializationException {
         List<Utxo> utxos = List.of(
                 Utxo.builder()
                         .txHash("d5975c341088ca1c0ed2384a3139d34a1de4b31ef6c9cd3ac0c4eb55108fdf85")
@@ -489,7 +490,7 @@ class InputBuildersTest extends BaseTest {
                 new TransactionInput("d5975c341088ca1c0ed2384a3139d34a1de4b31ef6c9cd3ac0c4eb55108fdf85", 1)
         );
 
-        String expectedDatumHash = Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(datum).getDatumHash();
+        PlutusData expectedDatum = Configuration.INSTANCE.getPlutusObjectConverter().toPlutusData(datum);
         assertThat(inputResult.getChanges()).hasSize(1);
         assertThat(inputResult.getChanges()).contains(
                 TransactionOutput.builder()
@@ -497,7 +498,7 @@ class InputBuildersTest extends BaseTest {
                         .value(Value.builder()
                                 .coin(BigInteger.valueOf(7000000))
                                 .build())
-                        .datumHash(HexUtil.decodeHexString(expectedDatumHash))
+                        .inlineDatum(expectedDatum)
                         .build()
         );
     }

--- a/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/ScriptTxV3IT.java
+++ b/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/ScriptTxV3IT.java
@@ -6,12 +6,13 @@ import com.bloxbean.cardano.client.api.exception.ApiException;
 import com.bloxbean.cardano.client.api.model.Amount;
 import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.api.model.Utxo;
-import com.bloxbean.cardano.client.backend.model.TxContentRedeemers;
 import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.exception.CborDeserializationException;
 import com.bloxbean.cardano.client.function.helper.ScriptUtxoFinders;
 import com.bloxbean.cardano.client.function.helper.SignerProviders;
 import com.bloxbean.cardano.client.plutus.spec.*;
 import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.util.JsonUtil;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,7 @@ public class ScriptTxV3IT extends TestDataBaseIT {
     private boolean aikenEvaluation = false;
 
     @Test
-    void alwaysTrueScript() throws ApiException {
+    void alwaysTrueScript() throws ApiException, CborDeserializationException {
         PlutusV3Script plutusScript = PlutusV3Script.builder()
                 .type("PlutusScriptV3")
                 .cborHex("46450101002499")
@@ -60,7 +61,7 @@ public class ScriptTxV3IT extends TestDataBaseIT {
         Optional<Utxo> optionalUtxo = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scriptAddress, plutusData);
         ScriptTx scriptTx = new ScriptTx()
                 .collectFrom(optionalUtxo.get(), plutusData)
-                .payToAddress(receiver1, Amount.lovelace(scriptAmt))
+                .payToAddress(receiver1, Amount.ada(1))
                 .attachSpendingValidator(plutusScript)
                 .withChangeAddress(scriptAddress, plutusData);
 
@@ -81,9 +82,74 @@ public class ScriptTxV3IT extends TestDataBaseIT {
 
         checkIfUtxoAvailable(result1.getValue(), sender2Addr);
 
-        // Example of getting the redeemer datum hash and then getting the datum values.
-        List<TxContentRedeemers> redeemers = getBackendService().getTransactionService()
-                .getTransactionRedeemers(result1.getValue()).getValue();
+        //Validate inline datum in script change output
+        var utxoOpt = utxoSupplier.getTxOutput(result1.getValue(), 1);
+        assertTrue(utxoOpt.isPresent());
+        Utxo scriptChangeUtxo = utxoOpt.get();
+        assertThat(scriptChangeUtxo.getAddress()).isEqualTo(scriptAddress);
+        assertThat(scriptChangeUtxo.getInlineDatum()).isNotEmpty();
+        assertThat(PlutusData.deserialize(HexUtil.decodeHexString(scriptChangeUtxo.getInlineDatum()))).isEqualTo(plutusData);
+    }
+
+    @Test
+    void alwaysTrueScript_datumHashInChangeOutput() throws ApiException, CborDeserializationException {
+        PlutusV3Script plutusScript = PlutusV3Script.builder()
+                .type("PlutusScriptV3")
+                .cborHex("46450101002499")
+                .build();
+
+        String scriptAddress = AddressProvider.getEntAddress(plutusScript, Networks.testnet()).toBech32();
+        BigInteger scriptAmt = new BigInteger("2479280");
+
+        Random rand = new Random();
+        long randInt = System.currentTimeMillis();
+        BigIntPlutusData plutusData = new BigIntPlutusData(BigInteger.valueOf(randInt)); //any random number
+
+        Tx tx = new Tx();
+        tx.payToContract(scriptAddress, Amount.lovelace(scriptAmt), plutusData)
+                .from(sender2Addr);
+
+        QuickTxBuilder quickTxBuilder = new QuickTxBuilder(backendService);
+        var result = quickTxBuilder.compose(tx)
+                .withSigner(SignerProviders.signerFrom(sender2))
+                .complete();
+
+        assertThat(result.getTxStatus()).isEqualTo(TxStatus.SUBMITTED);
+
+        System.out.println(result.getResponse());
+        checkIfUtxoAvailable(result.getValue(), scriptAddress);
+
+        Optional<Utxo> optionalUtxo = ScriptUtxoFinders.findFirstByInlineDatum(utxoSupplier, scriptAddress, plutusData);
+        ScriptTx scriptTx = new ScriptTx()
+                .collectFrom(optionalUtxo.get(), plutusData)
+                .payToAddress(receiver1, Amount.ada(1))
+                .attachSpendingValidator(plutusScript)
+                .withChangeAddress(scriptAddress, plutusData.getDatumHash());
+
+        Result<String> result1 = quickTxBuilder.compose(scriptTx)
+                .feePayer(sender2Addr)
+                .withSigner(SignerProviders.signerFrom(sender2))
+                .withRequiredSigners(sender2.getBaseAddress())
+                .withVerifier(txn -> {
+                    System.out.println(JsonUtil.getPrettyJson(txn));
+                    assertThat(txn.getBody().getRequiredSigners()).hasSize(1);
+                    assertThat(txn.getBody().getRequiredSigners().get(0)) //Verify sender's payment cred hash in required signer
+                            .isEqualTo(sender2.getBaseAddress().getPaymentCredentialHash().get());
+                })
+                .completeAndWait(System.out::println);
+
+        System.out.println(result1);
+        assertTrue(result1.isSuccessful());
+
+        checkIfUtxoAvailable(result1.getValue(), sender2Addr);
+
+        //Validate inline datum in script change output
+        var utxoOpt = utxoSupplier.getTxOutput(result1.getValue(), 1);
+        assertTrue(utxoOpt.isPresent());
+        Utxo scriptChangeUtxo = utxoOpt.get();
+        assertThat(scriptChangeUtxo.getAddress()).isEqualTo(scriptAddress);
+        assertThat(scriptChangeUtxo.getDataHash()).isNotEmpty();
+        assertThat(scriptChangeUtxo.getDataHash()).isEqualTo(plutusData.getDatumHash());
     }
 
     @Test


### PR DESCRIPTION
#510 

## Summary
This PR fixes an issue where `ScriptTx.withChangeAddress(address, datum)` was converting datum objects to datum hashes instead of adding them as inline datums to change outputs. 

## Problem Description
When using the QuickTx API to create script transactions with change outputs, the datum provided via `withChangeAddress()` was being converted to a datum hash rather than being included as an inline datum:

  ```java
  // Example usage
  ScriptTx scriptTx = new ScriptTx()
      .collectFrom(utxo, plutusData)
      .payToAddress(receiver, amount)
      .withChangeAddress(scriptAddress, plutusData);  // plutusData was converted to hash
```

## Solution

  Modified `InputBuilders` to properly support both inline datums and datum hashes in change outputs:

  1. Updated the core method signature to accept both datum types:
  
  ```
  public static TxInputBuilder createFromUtxos(
      Supplier<List<Utxo>> supplier, 
      String changeAddress, 
      PlutusData changeOutputDatum,      // For inline datum
      String changeOutputDatumHash        // For datum hash (backward compatibility)
  )
  ```

  2. Prioritized inline datum over datum hash in the implementation:
  
  ```
  if (changeOutputDatum != null)
      changeOutput.setInlineDatum(changeOutputDatum);
  else if (changeOutputDatumHash != null && !changeOutputDatumHash.isEmpty())
      changeOutput.setDatumHash(HexUtil.decodeHexString(changeOutputDatumHash));
  ```    

  3. Maintained backward compatibility for existing datum hash usage


## Testing

  - Updated unit test InputBuildersTest to verify inline datum is correctly added to change outputs
  - Added integration test in ScriptTxV3IT to validate inline datum scenario
  - Added separate test for datum hash to ensure backward compatibility
