### PR TITLE
docs: add new API documentation for CIP standards

### DIFF
--- a/docs/docs/apis/standards/cip20-api.md
+++ b/docs/docs/apis/standards/cip20-api.md
@@ -1,0 +1,295 @@
+---
+title: "CIP20 API"
+description: "Transaction Message/Comment Metadata implementation"
+sidebar_position: 4
+---
+
+# CIP20 API
+
+CIP20 (Cardano Improvement Proposal 20) defines a standard for adding messages, comments, or memos to Cardano transactions using transaction metadata. This allows you to attach informational text, invoice numbers, or similar data to transactions on the Cardano blockchain.
+
+## Key Features
+
+- **Standard Compliance**: Full CIP20 specification support
+- **Message Metadata**: Add messages/comments to transactions
+- **Validation**: Built-in validation for message length (max 64 characters)
+- **Multiple Messages**: Support for multiple messages in a single transaction
+- **Easy Integration**: Simple API for adding metadata to transactions
+
+## Dependencies
+
+- **Group ID**: com.bloxbean.cardano
+- **Artifact ID**: cardano-client-cip20
+- **Dependencies**: metadata
+
+## Usage Examples
+
+### Creating Message Metadata
+
+The following example shows how to create CIP20 compliant message metadata with multiple messages.
+
+```java
+// Create message metadata
+MessageMetadata messageMetadata = MessageMetadata.create()
+    .add("Payment for services")
+    .add("Invoice #12345")
+    .add("Thank you for your business");
+
+// Get metadata as CBOR bytes
+byte[] cborBytes = messageMetadata.serialize();
+String hexMetadata = HexUtil.encodeHexString(cborBytes);
+```
+
+### Adding Messages to Transactions
+
+The following example shows how to add message metadata to a transaction using QuickTx.
+
+```java
+// Create message metadata
+MessageMetadata messageMetadata = MessageMetadata.create()
+    .add("Payment for NFT purchase")
+    .add("Transaction ID: " + System.currentTimeMillis());
+
+// Create transaction with message metadata
+Tx tx = new Tx()
+    .payToAddress(receiverAddress, Amount.ada(10))
+    .from(senderAddress)
+    .attachMetadata(messageMetadata);
+
+// Build and sign transaction
+Result<String> result = quickTxBuilder.compose(tx)
+    .feePayer(senderAddress)
+    .withSigner(SignerProviders.signerFrom(senderAccount))
+    .completeAndWait(System.out::println);
+```
+
+### Working with Message Lists
+
+The following example shows how to retrieve and work with messages from metadata.
+
+```java
+// Create message metadata
+MessageMetadata messageMetadata = MessageMetadata.create()
+    .add("First message")
+    .add("Second message")
+    .add("Third message");
+
+// Get all messages
+List<String> messages = messageMetadata.getMessages();
+
+// Process messages
+for (String message : messages) {
+    System.out.println("Message: " + message);
+}
+
+// Check message count
+System.out.println("Total messages: " + messages.size());
+```
+
+### Deserializing Message Metadata
+
+The following example shows how to deserialize message metadata from CBOR bytes.
+
+```java
+// Assume you have CBOR bytes from somewhere
+byte[] cborBytes = getMetadataBytes();
+
+// Deserialize message metadata
+MessageMetadata messageMetadata = MessageMetadata.create(cborBytes);
+
+// Get messages
+List<String> messages = messageMetadata.getMessages();
+System.out.println("Deserialized messages: " + messages);
+```
+
+### Integration with Other Metadata
+
+The following example shows how to combine CIP20 message metadata with other transaction metadata.
+
+```java
+// Create CIP20 message metadata
+MessageMetadata messageMetadata = MessageMetadata.create()
+    .add("Payment confirmation")
+    .add("Order #789");
+
+// Create additional custom metadata
+CBORMetadata customMetadata = new CBORMetadata()
+    .put(BigInteger.valueOf(100), "Custom field value")
+    .put(BigInteger.valueOf(101), "Another custom value");
+
+// Combine metadata (CIP20 uses label 674)
+CBORMetadata combinedMetadata = new CBORMetadata();
+combinedMetadata.putAll(customMetadata);
+combinedMetadata.putAll(messageMetadata);
+
+// Use in transaction
+Tx tx = new Tx()
+    .payToAddress(receiverAddress, Amount.ada(5))
+    .from(senderAddress)
+    .attachMetadata(combinedMetadata);
+```
+
+### Practical Use Cases
+
+#### Invoice Tracking
+```java
+// Create invoice metadata
+MessageMetadata invoiceMetadata = MessageMetadata.create()
+    .add("Invoice #INV-2024-001")
+    .add("Due: 2024-01-15")
+    .add("Amount: 100 ADA");
+
+Tx paymentTx = new Tx()
+    .payToAddress(merchantAddress, Amount.ada(100))
+    .from(customerAddress)
+    .attachMetadata(invoiceMetadata);
+```
+
+#### Payment Confirmations
+```java
+// Create payment confirmation metadata
+MessageMetadata confirmationMetadata = MessageMetadata.create()
+    .add("Payment confirmed")
+    .add("Ref: " + generatePaymentReference())
+    .add("Thank you!");
+
+Tx confirmationTx = new Tx()
+    .payToAddress(recipientAddress, Amount.ada(50))
+    .from(payerAddress)
+    .attachMetadata(confirmationMetadata);
+```
+
+#### Service Requests
+```java
+// Create service request metadata
+MessageMetadata serviceMetadata = MessageMetadata.create()
+    .add("Service: Web Development")
+    .add("Client: Acme Corp")
+    .add("Priority: High");
+
+Tx serviceTx = new Tx()
+    .payToAddress(developerAddress, Amount.ada(25))
+    .from(clientAddress)
+    .attachMetadata(serviceMetadata);
+```
+
+## API Reference
+
+### MessageMetadata Class
+
+The main class for creating and managing CIP20 message metadata.
+
+#### Constructor
+```java
+// Create new instance
+public static MessageMetadata create()
+
+// Create from CBOR bytes
+public static MessageMetadata create(byte[] cborBytes)
+```
+
+#### Methods
+
+##### add(String message)
+Adds a message to the metadata. Each message must be:
+- Non-null
+- Maximum 64 characters in UTF-8 encoding
+
+```java
+public MessageMetadata add(String message)
+```
+
+**Parameters:**
+- `message` - The message to add (max 64 characters)
+
+**Returns:** The MessageMetadata instance for chaining
+
+**Throws:** `IllegalArgumentException` if message is null or exceeds 64 characters
+
+##### getMessages()
+Retrieves all messages from the metadata.
+
+```java
+public List<String> getMessages()
+```
+
+**Returns:** List of all messages in the metadata
+
+##### serialize()
+Serializes the metadata to CBOR bytes.
+
+```java
+public byte[] serialize()
+```
+
+**Returns:** CBOR-encoded bytes of the metadata
+
+## CIP20 Specification Details
+
+### Metadata Label
+CIP20 uses metadata label **674** for message metadata.
+
+### Message Format
+Messages are stored as an array of strings under the "msg" key:
+```json
+{
+  "674": {
+    "msg": [
+      "First message",
+      "Second message",
+      "Third message"
+    ]
+  }
+}
+```
+
+### Constraints
+- Each message must be a maximum of 64 characters when encoded in UTF-8
+- Messages cannot be null
+- Multiple messages are supported in a single transaction
+
+## Best Practices
+
+1. **Keep messages concise** - The 64-character limit encourages brief, informative messages
+2. **Use meaningful content** - Include relevant information like invoice numbers, references, or confirmations
+3. **Validate input** - Always handle validation errors when adding messages
+4. **Consider privacy** - Remember that metadata is publicly visible on the blockchain
+5. **Combine with other standards** - CIP20 works well with CIP25 (NFT metadata) and other standards
+
+## Integration Examples
+
+### With CIP25 (NFT Metadata)
+```java
+// Create CIP25 NFT metadata
+CIP25NFT nftMetadata = CIP25NFT.create()
+    .name("My NFT")
+    .description("A sample NFT");
+
+// Create CIP20 message metadata
+MessageMetadata messageMetadata = MessageMetadata.create()
+    .add("NFT purchase")
+    .add("Collection: Art Gallery");
+
+// Combine metadata
+CBORMetadata combinedMetadata = new CBORMetadata();
+combinedMetadata.putAll(nftMetadata);
+combinedMetadata.putAll(messageMetadata);
+```
+
+### With Custom Metadata
+```java
+// Create custom metadata
+CBORMetadata customMetadata = new CBORMetadata()
+    .put(BigInteger.valueOf(100), "Custom field");
+
+// Create CIP20 message metadata
+MessageMetadata messageMetadata = MessageMetadata.create()
+    .add("Transaction note");
+
+// Combine and use in transaction
+CBORMetadata finalMetadata = new CBORMetadata();
+finalMetadata.putAll(customMetadata);
+finalMetadata.putAll(messageMetadata);
+```
+
+For more information about CIP20, refer to the [official CIP20 specification](https://cips.cardano.org/cips/cip20/).

--- a/docs/docs/apis/standards/cip25-api.md
+++ b/docs/docs/apis/standards/cip25-api.md
@@ -1,0 +1,299 @@
+---
+title: "CIP25 API"
+description: "NFT Metadata Standard implementation"
+sidebar_position: 1
+---
+
+# CIP25 API
+
+CIP25 (Cardano Improvement Proposal 25) defines a standard for NFT metadata on the Cardano blockchain. The Cardano Client Library provides APIs to create and manage CIP25 compliant NFT metadata.
+
+## Key Features
+
+- **Standard Compliance**: Full CIP25 specification support
+- **Metadata Creation**: Easy creation of NFT metadata
+- **Validation**: Built-in validation for CIP25 compliance
+- **Flexible**: Support for various NFT attributes
+
+## Dependencies
+
+- **Group ID**: com.bloxbean.cardano
+- **Artifact ID**: cardano-client-cip25
+- **Dependencies**: plutus, metadata
+
+## Usage Examples
+
+### Creating NFT Metadata
+
+The following example shows how to create CIP25 compliant NFT metadata with various attributes and files.
+
+```java
+// Create CIP25 NFT metadata
+CIP25NFT cip25NFT = CIP25NFT.create()
+        .name("MyAwesomeNFT")
+        .image("https://example.com/image.png")
+        .description("A sample CIP25 NFT")
+        .addFile(CIP25File.create()
+                .mediaType("image/png")
+                .name("image.png")
+                .src("https://example.com/image.png")
+        )
+        .addAttribute("color", "blue")
+        .addAttribute("rarity", "legendary");
+
+// Get metadata as PlutusData
+PlutusData metadata = cip25NFT.getMetadataAsPlutusData();
+```
+
+### Minting NFT with CIP25 Metadata
+
+The following example shows how to mint an NFT using a Plutus script with CIP25 metadata attached.
+
+```java
+// Create minting script
+PlutusV2Script mintingScript = PlutusV2Script.builder()
+        .type("PlutusScriptV2")
+        .cborHex("...")
+        .build();
+
+// Create NFT asset
+Asset nftAsset = Asset.builder()
+        .name("MyAwesomeNFT")
+        .value(BigInteger.ONE)
+        .build();
+
+// Mint NFT with metadata
+Tx tx = new Tx()
+        .mintAsset(mintingScript, List.of(nftAsset), metadata, receiverAddress)
+        .from(senderAddress);
+```
+
+### Validating Metadata
+
+The following example shows how to validate NFT metadata for CIP25 compliance and retrieve any validation errors.
+
+```java
+// Validate CIP25 compliance
+boolean isValid = CIP25NFT.isValidMetadata(metadata);
+
+// Get validation errors
+List<String> errors = CIP25NFT.getValidationErrors(metadata);
+```
+
+### Working with Files
+
+The following example shows how to add multiple files to NFT metadata.
+
+```java
+CIP25NFT nft = CIP25NFT.create()
+    .name("Multi-file NFT")
+    .description("NFT with multiple files")
+    .addFile(CIP25File.create()
+        .mediaType("image/png")
+        .name("thumbnail.png")
+        .src("https://example.com/thumbnail.png"))
+    .addFile(CIP25File.create()
+        .mediaType("video/mp4")
+        .name("animation.mp4")
+        .src("https://example.com/animation.mp4"));
+```
+
+### Adding Custom Attributes
+
+The following example shows how to add custom attributes to NFT metadata.
+
+```java
+CIP25NFT nft = CIP25NFT.create()
+    .name("Custom Attribute NFT")
+    .description("NFT with custom attributes")
+    .addAttribute("color", "blue")
+    .addAttribute("rarity", "legendary")
+    .addAttribute("power", "100")
+    .addAttribute("category", "gaming");
+```
+
+## API Reference
+
+### CIP25NFT Class
+
+Main class for creating and managing CIP25 NFT metadata.
+
+#### Constructor
+```java
+// Create new instance
+public static CIP25NFT create()
+```
+
+#### Methods
+
+##### name(String name)
+Sets the name of the NFT.
+
+```java
+public CIP25NFT name(String name)
+```
+
+##### description(String description)
+Sets the description of the NFT.
+
+```java
+public CIP25NFT description(String description)
+```
+
+##### image(String image)
+Sets the image URL of the NFT.
+
+```java
+public CIP25NFT image(String image)
+```
+
+##### addFile(CIP25File file)
+Adds a file to the NFT metadata.
+
+```java
+public CIP25NFT addFile(CIP25File file)
+```
+
+##### addAttribute(String key, String value)
+Adds a custom attribute to the NFT.
+
+```java
+public CIP25NFT addAttribute(String key, String value)
+```
+
+##### getMetadataAsPlutusData()
+Converts the metadata to PlutusData format.
+
+```java
+public PlutusData getMetadataAsPlutusData()
+```
+
+##### isValidMetadata(PlutusData metadata)
+Validates metadata for CIP25 compliance.
+
+```java
+public static boolean isValidMetadata(PlutusData metadata)
+```
+
+##### getValidationErrors(PlutusData metadata)
+Gets validation errors for metadata.
+
+```java
+public static List<String> getValidationErrors(PlutusData metadata)
+```
+
+### CIP25File Class
+
+Represents a file in CIP25 metadata.
+
+#### Constructor
+```java
+// Create new instance
+public static CIP25File create()
+```
+
+#### Methods
+```java
+// Set media type
+public CIP25File mediaType(String mediaType)
+
+// Set file name
+public CIP25File name(String name)
+
+// Set file source URL
+public CIP25File src(String src)
+```
+
+## CIP25 Specification Details
+
+### Metadata Label
+CIP25 uses metadata label **721** for NFT metadata.
+
+### Metadata Structure
+NFT metadata follows this structure:
+```json
+{
+  "721": {
+    "policy_id": {
+      "asset_name": {
+        "name": "NFT Name",
+        "image": "https://example.com/image.png",
+        "description": "NFT Description",
+        "files": [
+          {
+            "mediaType": "image/png",
+            "name": "image.png",
+            "src": "https://example.com/image.png"
+          }
+        ],
+        "attributes": [
+          {
+            "trait_type": "color",
+            "value": "blue"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### File Structure
+Files in CIP25 metadata support:
+- **mediaType**: MIME type of the file
+- **name**: Display name of the file
+- **src**: URL or IPFS hash of the file
+
+### Attributes
+Custom attributes support:
+- **trait_type**: The type of attribute
+- **value**: The value of the attribute
+
+## Best Practices
+
+1. **Use HTTPS URLs**: Always use HTTPS URLs for images and files
+2. **Optimize Images**: Use appropriate image sizes and formats
+3. **Validate Metadata**: Always validate metadata before minting
+4. **Use IPFS**: Consider using IPFS for decentralized file storage
+5. **Document Attributes**: Document custom attributes for better discoverability
+
+## Integration Examples
+
+### With CIP20 (Transaction Messages)
+```java
+// Create CIP25 NFT metadata
+CIP25NFT nftMetadata = CIP25NFT.create()
+    .name("MyNFT")
+    .image("https://example.com/image.png")
+    .description("An NFT with transaction messages");
+
+// Create CIP20 message metadata
+MessageMetadata messageMetadata = MessageMetadata.create()
+    .add("NFT purchase")
+    .add("Collection: Art Gallery");
+
+// Combine metadata
+CBORMetadata combinedMetadata = new CBORMetadata();
+combinedMetadata.putAll(nftMetadata);
+combinedMetadata.putAll(messageMetadata);
+```
+
+### With CIP67 (Asset Name Labels)
+```java
+// Create CIP67-compliant asset name
+int label = 222; // NFT label
+byte[] labelPrefix = CIP67AssetNameUtil.labelToPrefix(label);
+String assetName = HexUtil.encodeHexString(labelPrefix) + "MyNFT";
+
+// Create CIP25 NFT with CIP67-compliant name
+CIP25NFT nft = CIP25NFT.create()
+    .name("My CIP67 NFT")
+    .image("https://example.com/image.png");
+
+Asset nftAsset = Asset.builder()
+    .name(assetName)
+    .value(BigInteger.ONE)
+    .build();
+```
+
+For more information about CIP25, refer to the [official CIP25 specification](https://cips.cardano.org/cips/cip25/).

--- a/docs/docs/apis/standards/cip27-api.md
+++ b/docs/docs/apis/standards/cip27-api.md
@@ -1,0 +1,220 @@
+---
+title: "CIP27 API"
+description: "CNFT Community Royalties Standard implementation"
+sidebar_position: 5
+---
+
+# CIP27 API
+
+CIP27 (Cardano Improvement Proposal 27) defines a standard for CNFT (Community NFT) royalties on the Cardano blockchain. The Cardano Client Library provides APIs to create and manage royalty metadata for NFTs.
+
+## Key Features
+
+- **Royalty Management**: Set royalty rates and recipient addresses
+- **Standard Compliance**: Full CIP27 specification support
+- **Validation**: Built-in validation for royalty rates (0.0-1.0)
+- **NFT Integration**: Seamless integration with CIP25 NFT metadata
+
+## Dependencies
+
+- **Group ID**: com.bloxbean.cardano
+- **Artifact ID**: cardano-client-cip27
+- **Dependencies**: cip25
+
+## Usage Examples
+
+### Creating Royalty Metadata
+
+```java
+// Create royalty token
+RoyaltyToken royaltyToken = RoyaltyToken.create()
+    .address("addr1q9...") // Recipient address
+    .rate(0.05); // 5% royalty rate
+
+// Create royalty metadata
+RoyaltyTokenMetadata royaltyMetadata = RoyaltyTokenMetadata.create()
+    .royaltyToken(royaltyToken);
+
+// Get metadata as CBOR bytes
+byte[] cborBytes = royaltyMetadata.serialize();
+```
+
+### Integration with CIP25 NFT Metadata
+
+```java
+// Create CIP25 NFT metadata
+CIP25NFT nftMetadata = CIP25NFT.create()
+    .name("My Royalty NFT")
+    .image("https://example.com/image.png")
+    .description("An NFT with royalties");
+
+// Create royalty metadata
+RoyaltyToken royaltyToken = RoyaltyToken.create()
+    .address("addr1q9...")
+    .rate(0.1); // 10% royalty
+
+RoyaltyTokenMetadata royaltyMetadata = RoyaltyTokenMetadata.create()
+    .royaltyToken(royaltyToken);
+
+// Combine metadata
+CBORMetadata combinedMetadata = new CBORMetadata();
+combinedMetadata.putAll(nftMetadata);
+combinedMetadata.putAll(royaltyMetadata);
+```
+
+### Minting NFT with Royalties
+
+```java
+// Create minting script
+PlutusV2Script mintingScript = PlutusV2Script.builder()
+    .type("PlutusScriptV2")
+    .cborHex("...")
+    .build();
+
+// Create NFT asset
+Asset nftAsset = Asset.builder()
+    .name("RoyaltyNFT")
+    .value(BigInteger.ONE)
+    .build();
+
+// Create combined metadata
+CBORMetadata metadata = new CBORMetadata();
+metadata.putAll(nftMetadata);
+metadata.putAll(royaltyMetadata);
+
+// Mint NFT with royalty metadata
+Tx tx = new Tx()
+    .mintAsset(mintingScript, List.of(nftAsset), metadata, receiverAddress)
+    .from(senderAddress);
+```
+
+### Retrieving Royalty Information
+
+```java
+// Deserialize royalty metadata
+RoyaltyTokenMetadata royaltyMetadata = RoyaltyTokenMetadata.create(cborBytes);
+
+// Get royalty token
+RoyaltyToken royaltyToken = royaltyMetadata.getRoyaltyToken();
+
+if (royaltyToken != null) {
+    String recipientAddress = royaltyToken.getAddress();
+    Double royaltyRate = royaltyToken.getRate();
+    
+    System.out.println("Royalty recipient: " + recipientAddress);
+    System.out.println("Royalty rate: " + (royaltyRate * 100) + "%");
+}
+```
+
+## API Reference
+
+### RoyaltyTokenMetadata Class
+
+Main class for managing CIP27 royalty metadata.
+
+#### Constructor
+```java
+// Create new instance
+public static RoyaltyTokenMetadata create()
+
+// Create from CBOR bytes
+public static RoyaltyTokenMetadata create(byte[] cborBytes)
+```
+
+#### Methods
+```java
+// Set royalty token
+public RoyaltyTokenMetadata royaltyToken(RoyaltyToken royaltyToken)
+
+// Get royalty token
+public RoyaltyToken getRoyaltyToken()
+```
+
+### RoyaltyToken Class
+
+Represents a royalty configuration for an NFT.
+
+#### Constructor
+```java
+// Create new instance
+public static RoyaltyToken create()
+```
+
+#### Methods
+```java
+// Set recipient address
+public RoyaltyToken address(String address)
+
+// Set royalty rate (0.0-1.0)
+public RoyaltyToken rate(Double rate)
+
+// Get recipient address
+public String getAddress()
+
+// Get royalty rate
+public Double getRate()
+```
+
+## CIP27 Specification Details
+
+### Metadata Label
+CIP27 uses metadata label **777** for royalty metadata.
+
+### Royalty Rate Validation
+- Must be between 0.0 and 1.0 (inclusive)
+- Represents percentage as decimal (0.1 = 10%)
+- Throws `IllegalArgumentException` for invalid rates
+
+### Address Format
+- Must be a valid bech32 payment address
+- Supports both single addresses and address lists
+
+## Best Practices
+
+1. **Validate rates**: Always ensure royalty rates are between 0.0 and 1.0
+2. **Use valid addresses**: Ensure recipient addresses are valid bech32 addresses
+3. **Combine with CIP25**: Use CIP27 alongside CIP25 for complete NFT metadata
+4. **Test thoroughly**: Verify royalty calculations before deployment
+
+## Integration Examples
+
+### With CIP25 (NFT Metadata)
+```java
+// Create CIP25 NFT metadata
+CIP25NFT nftMetadata = CIP25NFT.create()
+    .name("Royalty NFT")
+    .image("https://example.com/image.png")
+    .description("An NFT with royalties");
+
+// Create royalty metadata
+RoyaltyToken royaltyToken = RoyaltyToken.create()
+    .address("addr1q9...")
+    .rate(0.1); // 10% royalty
+
+RoyaltyTokenMetadata royaltyMetadata = RoyaltyTokenMetadata.create()
+    .royaltyToken(royaltyToken);
+
+// Combine metadata
+CBORMetadata combinedMetadata = new CBORMetadata();
+combinedMetadata.putAll(nftMetadata);
+combinedMetadata.putAll(royaltyMetadata);
+```
+
+### With CIP20 (Transaction Messages)
+```java
+// Create royalty metadata
+RoyaltyTokenMetadata royaltyMetadata = RoyaltyTokenMetadata.create()
+    .royaltyToken(royaltyToken);
+
+// Create transaction message
+MessageMetadata messageMetadata = MessageMetadata.create()
+    .add("Royalty NFT purchase")
+    .add("Collection: Premium Art");
+
+// Combine metadata
+CBORMetadata combinedMetadata = new CBORMetadata();
+combinedMetadata.putAll(royaltyMetadata);
+combinedMetadata.putAll(messageMetadata);
+```
+
+For more information about CIP27, refer to the [official CIP27 specification](https://cips.cardano.org/cips/cip27/).

--- a/docs/docs/apis/standards/cip30-api.md
+++ b/docs/docs/apis/standards/cip30-api.md
@@ -1,0 +1,278 @@
+---
+title: "CIP30 API"
+description: "dApp Connector and Data Signing implementation"
+sidebar_position: 6
+---
+
+# CIP30 API
+
+CIP30 (Cardano Improvement Proposal 30) defines a standard for dApp-wallet communication on the Cardano blockchain. The Cardano Client Library provides APIs for data signing and signature verification according to the CIP30 specification.
+
+## Key Features
+
+- **Data Signing**: Sign arbitrary data using CIP30's signData() method
+- **Signature Verification**: Verify CIP30 data signatures
+- **COSE Integration**: Built on CIP8 COSE signature standard
+- **Address Validation**: Validate addresses in signatures
+- **Standard Compliance**: Full CIP30 specification support
+
+## Dependencies
+
+- **Group ID**: com.bloxbean.cardano
+- **Artifact ID**: cardano-client-cip30
+- **Dependencies**: cip8, core
+
+## Usage Examples
+
+### Signing Data with CIP30
+
+```java
+// Create account for signing
+Account signerAccount = Account.createFromMnemonic(Networks.testnet(), "your mnemonic words");
+
+// Get address bytes
+byte[] addressBytes = signerAccount.baseAddress().getBytes();
+
+// Create payload to sign
+String message = "Hello from dApp!";
+byte[] payload = message.getBytes(StandardCharsets.UTF_8);
+
+// Sign data using CIP30DataSigner
+DataSignature dataSignature = CIP30DataSigner.INSTANCE.signData(
+    addressBytes, 
+    payload, 
+    signerAccount
+);
+
+// Get signature as hex string
+String signatureHex = dataSignature.signature();
+String keyHex = dataSignature.key();
+
+System.out.println("Signature: " + signatureHex);
+System.out.println("Key: " + keyHex);
+```
+
+### Verifying CIP30 Signatures
+
+```java
+// Create DataSignature from hex strings
+DataSignature dataSignature = new DataSignature(signatureHex, keyHex);
+
+// Verify the signature
+boolean isValid = CIP30DataSigner.INSTANCE.verifyDataSignature(
+    addressBytes,
+    payload,
+    dataSignature
+);
+
+if (isValid) {
+    System.out.println("Signature is valid");
+} else {
+    System.out.println("Signature verification failed");
+}
+```
+
+### Working with DataSignature Objects
+
+```java
+// Create DataSignature
+DataSignature dataSignature = new DataSignature(signatureHex, keyHex);
+
+// Get address from signature
+byte[] addressFromSignature = dataSignature.address();
+
+// Get curve identifier
+Integer crv = dataSignature.crv();
+
+// Get algorithm identifier
+Integer alg = dataSignature.alg();
+
+// Verify address matches
+boolean addressMatches = Arrays.equals(addressBytes, addressFromSignature);
+```
+
+### Signing with Hash Payload
+
+```java
+// Sign with payload hashing (for large payloads)
+DataSignature dataSignature = CIP30DataSigner.INSTANCE.signData(
+    addressBytes,
+    largePayload,
+    signerAccount,
+    true // hashPayload = true
+);
+```
+
+### UTXO Management (CIP30 UtxoSupplier)
+
+```java
+// Create CIP30 UTXO supplier
+CIP30UtxoSupplier utxoSupplier = new CIP30UtxoSupplier();
+
+// Set UTXO data
+List<Utxo> utxos = getUtxosFromWallet();
+utxoSupplier.setUtxos(utxos);
+
+// Use in transaction building
+Tx tx = new Tx()
+    .payToAddress(receiverAddress, Amount.ada(10))
+    .from(senderAddress)
+    .withUtxoSupplier(utxoSupplier);
+```
+
+## API Reference
+
+### CIP30DataSigner Class
+
+Main class for CIP30 data signing and verification.
+
+#### Methods
+
+##### signData(byte[] addressBytes, byte[] payload, Account signer)
+Signs data using CIP30's signData() method.
+
+```java
+public DataSignature signData(
+    @NonNull byte[] addressBytes, 
+    @NonNull byte[] payload, 
+    @NonNull Account signer
+) throws DataSignError
+```
+
+##### signData(byte[] addressBytes, byte[] payload, Account signer, boolean hashPayload)
+Signs data with optional payload hashing.
+
+```java
+public DataSignature signData(
+    @NonNull byte[] addressBytes,
+    @NonNull byte[] payload,
+    @NonNull Account signer,
+    boolean hashPayload
+) throws DataSignError
+```
+
+##### verifyDataSignature(byte[] addressBytes, byte[] payload, DataSignature dataSignature)
+Verifies a CIP30 data signature.
+
+```java
+public boolean verifyDataSignature(
+    byte[] addressBytes,
+    byte[] payload,
+    DataSignature dataSignature
+)
+```
+
+### DataSignature Class
+
+Represents a CIP30 data signature.
+
+#### Constructor
+```java
+// Create from signature and key hex strings
+public DataSignature(@NonNull String signature, @NonNull String key)
+```
+
+#### Methods
+```java
+// Set signature hex string
+public DataSignature signature(@NonNull String signature)
+
+// Set key hex string
+public DataSignature key(@NonNull String key)
+
+// Get address bytes from signature
+public byte[] address()
+
+// Get curve identifier
+public Integer crv()
+
+// Get algorithm identifier
+public Integer alg()
+```
+
+### CIP30UtxoSupplier Class
+
+UTXO supplier implementation for CIP30 wallets.
+
+#### Methods
+```java
+// Set UTXOs
+public void setUtxos(List<Utxo> utxos)
+
+// Get UTXOs for address
+public List<Utxo> getUtxos(String address)
+```
+
+## CIP30 Specification Details
+
+### Metadata Label
+CIP30 uses metadata label **674** for data signing metadata.
+
+### Signature Format
+CIP30 signatures follow COSE Sign1 format with:
+- **Address Header**: Address bytes in unprotected headers (-100)
+- **Content Type**: Cardano message content type (-1000)
+- **Algorithm**: EdDSA algorithm (14)
+- **Curve**: Ed25519 curve (-8)
+
+### Data Signing Process
+1. **Payload Preparation**: Convert data to bytes (UTF-8 for text)
+2. **Header Creation**: Create COSE headers with address and content type
+3. **Signature Generation**: Sign using EdDSA with Ed25519 curve
+4. **Verification**: Verify signature against public key
+
+### Constants
+The API uses the following constants defined in `CIP30Constant`:
+
+- **ADDRESS_KEY**: Header key for address (-100)
+- **CONTENT_TYPE**: Content type for Cardano messages (-1000)
+- **ALGORITHM_ID**: EdDSA algorithm identifier (14)
+- **CURVE_ID**: Ed25519 curve identifier (-8)
+
+## Best Practices
+
+1. **Validate addresses**: Always verify that signature addresses match expected addresses
+2. **Handle errors**: Use try-catch blocks for DataSignError exceptions
+3. **Hash large payloads**: Use payload hashing for large data to improve performance
+4. **Verify signatures**: Always verify signatures before processing signed data
+5. **Use proper encoding**: Ensure payload is properly encoded (UTF-8 for text)
+
+## Integration with Other Standards
+
+### With CIP8 (Message Signing)
+CIP30 builds on CIP8's COSE signature standard:
+
+```java
+// CIP30 uses CIP8 COSE signatures internally
+DataSignature dataSignature = CIP30DataSigner.INSTANCE.signData(
+    addressBytes, 
+    payload, 
+    signerAccount
+);
+
+// The signature contains CIP8 COSE Sign1 data
+String signatureHex = dataSignature.signature();
+COSESign1 coseSign1 = COSESign1.deserialize(HexUtil.decodeHexString(signatureHex));
+```
+
+### With dApp Wallets
+```java
+// Typical dApp integration pattern
+public class DAppConnector {
+    private CIP30DataSigner signer = CIP30DataSigner.INSTANCE;
+    
+    public String requestSignature(String message, Account userAccount) {
+        try {
+            byte[] addressBytes = userAccount.baseAddress().getBytes();
+            byte[] payload = message.getBytes(StandardCharsets.UTF_8);
+            
+            DataSignature signature = signer.signData(addressBytes, payload, userAccount);
+            return signature.signature();
+        } catch (DataSignError e) {
+            throw new RuntimeException("Failed to sign data", e);
+        }
+    }
+}
+```
+
+For more information about CIP30, refer to the [official CIP30 specification](https://cips.cardano.org/cips/cip30/).

--- a/docs/docs/apis/standards/cip67-api.md
+++ b/docs/docs/apis/standards/cip67-api.md
@@ -1,0 +1,253 @@
+---
+title: "CIP67 API"
+description: "Asset Name Label Registry implementation"
+sidebar_position: 7
+---
+
+# CIP67 API
+
+CIP67 (Cardano Improvement Proposal 67) defines a standard for asset name labels on the Cardano blockchain. The Cardano Client Library provides utilities for creating, validating, and working with CIP67-compliant asset names.
+
+## Key Features
+
+- **Label Encoding**: Convert decimal labels to CIP67 asset name prefixes
+- **Label Decoding**: Extract labels from CIP67 asset names
+- **Validation**: Verify CIP67 compliance and checksum validation
+- **CRC8 Checksum**: Built-in CRC8 checksum calculation and verification
+- **Standard Compliance**: Full CIP67 specification support
+
+## Dependencies
+
+- **Group ID**: com.bloxbean.cardano
+- **Artifact ID**: cardano-client-cip67
+- **Dependencies**: crypto
+
+## Usage Examples
+
+### Converting Labels to Asset Name Prefixes
+
+```java
+// Convert a decimal label to CIP67 asset name prefix
+int label = 222; // Label range: [0, 65535]
+byte[] prefixBytes = CIP67AssetNameUtil.labelToPrefix(label);
+
+// Convert to hex string for display
+String prefixHex = HexUtil.encodeHexString(prefixBytes);
+System.out.println("Label " + label + " -> Prefix: " + prefixHex);
+// Output: Label 222 -> Prefix: 000de140
+```
+
+### Extracting Labels from Asset Names
+
+```java
+// Extract label from CIP67 asset name prefix
+byte[] prefixBytes = HexUtil.decodeHexString("000de140");
+int extractedLabel = CIP67AssetNameUtil.prefixToLabel(prefixBytes);
+
+System.out.println("Prefix 000de140 -> Label: " + extractedLabel);
+// Output: Prefix 000de140 -> Label: 222
+```
+
+### Validating CIP67 Asset Names
+
+```java
+// Validate asset name from bytes
+byte[] assetNameBytes = HexUtil.decodeHexString("000de140");
+boolean isValidBytes = CIP67AssetNameUtil.isValidAssetName(assetNameBytes);
+
+System.out.println("Asset name valid (bytes): " + isValidBytes);
+// Output: Asset name valid (bytes): true
+
+// Validate asset name from integer
+int assetNameInt = 0x000de140;
+boolean isValidInt = CIP67AssetNameUtil.isValidAssetName(assetNameInt);
+
+System.out.println("Asset name valid (int): " + isValidInt);
+// Output: Asset name valid (int): true
+```
+
+### Working with Asset Names in Transactions
+
+```java
+// Create asset name with CIP67 label
+int label = 222; // NFT label
+byte[] labelPrefix = CIP67AssetNameUtil.labelToPrefix(label);
+
+// Create full asset name by combining prefix with unique suffix
+byte[] uniqueSuffix = "MyNFT".getBytes(StandardCharsets.UTF_8);
+byte[] fullAssetName = new byte[labelPrefix.length + uniqueSuffix.length];
+System.arraycopy(labelPrefix, 0, fullAssetName, 0, labelPrefix.length);
+System.arraycopy(uniqueSuffix, 0, fullAssetName, labelPrefix.length, uniqueSuffix.length);
+
+// Create asset with CIP67-compliant name
+Asset nftAsset = Asset.builder()
+    .name(HexUtil.encodeHexString(fullAssetName))
+    .value(BigInteger.ONE)
+    .build();
+```
+
+### Batch Processing of Asset Names
+
+```java
+// Process multiple asset names
+List<String> assetNameHexes = Arrays.asList(
+    "000de140", // Valid CIP67 asset name
+    "000de141", // Invalid padding
+    "100de140", // Invalid padding
+    "000de130"  // Invalid checksum
+);
+
+for (String assetNameHex : assetNameHexes) {
+    byte[] assetNameBytes = HexUtil.decodeHexString(assetNameHex);
+    boolean isValid = CIP67AssetNameUtil.isValidAssetName(assetNameBytes);
+    
+    if (isValid) {
+        int label = CIP67AssetNameUtil.prefixToLabel(assetNameBytes);
+        System.out.println(assetNameHex + " -> Valid, Label: " + label);
+    } else {
+        System.out.println(assetNameHex + " -> Invalid");
+    }
+}
+```
+
+### Common Label Examples
+
+```java
+// Common CIP67 labels
+Map<Integer, String> commonLabels = new HashMap<>();
+commonLabels.put(222, "NFT Standard");
+commonLabels.put(333, "Fungible Token Standard");
+commonLabels.put(444, "Rich Fungible Token Standard");
+
+for (Map.Entry<Integer, String> entry : commonLabels.entrySet()) {
+    int label = entry.getKey();
+    String description = entry.getValue();
+    
+    byte[] prefix = CIP67AssetNameUtil.labelToPrefix(label);
+    String prefixHex = HexUtil.encodeHexString(prefix);
+    
+    System.out.println("Label " + label + " (" + description + ") -> " + prefixHex);
+}
+```
+
+## API Reference
+
+### CIP67AssetNameUtil Class
+
+Utility class for CIP67 asset name operations.
+
+#### Static Methods
+
+##### labelToPrefix(int label)
+Converts a decimal label to CIP67 asset name prefix.
+
+```java
+public static byte[] labelToPrefix(int label)
+```
+
+**Parameters:**
+- `label` - Decimal label in range [0, 65535]
+
+**Returns:** 4-byte prefix array
+
+##### prefixToLabel(byte[] labelBytes)
+Extracts the label from CIP67 asset name prefix.
+
+```java
+public static int prefixToLabel(byte[] labelBytes)
+```
+
+**Parameters:**
+- `labelBytes` - 4-byte prefix array
+
+**Returns:** Decimal label
+
+##### isValidAssetName(int assetName)
+Validates a CIP67 asset name from integer value.
+
+```java
+public static boolean isValidAssetName(int assetName)
+```
+
+**Parameters:**
+- `assetName` - Asset name as integer
+
+**Returns:** true if valid CIP67 asset name
+
+##### isValidAssetName(byte[] assetName)
+Validates a CIP67 asset name from byte array.
+
+```java
+public static boolean isValidAssetName(byte[] assetName)
+```
+
+**Parameters:**
+- `assetName` - Asset name as byte array
+
+**Returns:** true if valid CIP67 asset name
+
+## CIP67 Specification Details
+
+### Asset Name Structure
+CIP67 asset names have the following structure:
+- **Bits 0-3**: Reserved (must be 0000)
+- **Bits 4-11**: CRC8 checksum
+- **Bits 12-31**: Label (20 bits, range 0-1048575, but typically 0-65535)
+- **Bits 32+**: Asset-specific data
+
+### Label Constraints
+- **Range**: 0 to 65535 (16-bit range commonly used)
+- **Encoding**: Big-endian format
+- **Checksum**: CRC8 validation required
+
+### Validation Rules
+1. **Padding Check**: Bits 0-3 must be 0000
+2. **Checksum Verification**: CRC8 checksum must match calculated value
+3. **Label Range**: Label must be within valid range
+
+## Common Label Registry
+
+| Label | Description | Prefix (Hex) |
+|-------|-------------|--------------|
+| 222 | NFT Standard | 000de140 |
+| 333 | Fungible Token Standard | 0014d140 |
+| 444 | Rich Fungible Token Standard | 001bc140 |
+
+## Best Practices
+
+1. **Use Standard Labels**: Use established labels (222, 333, 444) for common asset types
+2. **Validate Asset Names**: Always validate asset names before using them
+3. **Handle Errors**: Check validation results before processing asset names
+4. **Preserve Checksums**: Don't modify asset name prefixes without recalculating checksums
+5. **Document Custom Labels**: Document any custom labels used in your application
+
+## Integration with Other Standards
+
+### With CIP68 (Datum Metadata)
+```java
+// Create CIP68-compliant asset name
+int label = 222; // NFT label for CIP68
+byte[] labelPrefix = CIP67AssetNameUtil.labelToPrefix(label);
+
+// Combine with asset-specific data
+String assetName = HexUtil.encodeHexString(labelPrefix) + "MyUniqueNFT";
+```
+
+### With CIP25 (NFT Metadata)
+```java
+// Create CIP25 NFT with CIP67-compliant name
+int label = 222;
+byte[] labelPrefix = CIP67AssetNameUtil.labelToPrefix(label);
+String assetName = HexUtil.encodeHexString(labelPrefix) + "MyNFT";
+
+CIP25NFT nft = CIP25NFT.create()
+    .name("My CIP67 NFT")
+    .image("https://example.com/image.png");
+
+Asset nftAsset = Asset.builder()
+    .name(assetName)
+    .value(BigInteger.ONE)
+    .build();
+```
+
+For more information about CIP67, refer to the [official CIP67 specification](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0067).

--- a/docs/docs/apis/standards/cip68-api.md
+++ b/docs/docs/apis/standards/cip68-api.md
@@ -1,0 +1,394 @@
+---
+description: CIP68 Datum Metadata Api
+sidebar_label: CIP68 Datum Metadata Api
+sidebar_position: 2
+---
+
+# CIP68 Datum Metadata Api
+
+**Version:** **0.5.1** and later
+
+CIP68 defines a metadata standard for native assets making use of output datums not only for NFTs but any asset class.
+Cardano Client Lib provides a simple API to build CIP68 compatible datum metadata and simplify the process of building transactions
+to mint CIP68 compatible native tokens.
+
+## Key Features
+
+- **Datum-Based Metadata**: Uses output datums for metadata storage
+- **Multiple Asset Types**: Support for NFTs, Fungible Tokens, and Rich Fungible Tokens
+- **Reference Tokens**: Automatic reference token creation
+- **Standard Compliance**: Full CIP68 specification support
+- **Plutus Integration**: Native Plutus data support
+
+## Dependencies
+
+- **Group Id   :** com.bloxbean.cardano
+- **Artifact Id:** cardano-client-cip68
+
+## CIP68 Apis
+Cardano Client Lib provides the following 3 main APIs to build CIP68 compatible datum metadata for different types of assets.
+1. **CIP68NFT** : For NFTs (222 NFT Standard)
+2. **CIP68FT**  : For Fungible Tokens (333 Fungible Token Standard)
+3. **CIP68RFT** : For Rich (444 Rich-FT Standard)
+
+Apart from the above APIs, there is an API **CIP68ReferenceToken** which is used for reference tokens. A reference token 
+instance can be created from the above 3 APIs.
+
+## Usage Examples
+
+### CIP68 NFT Datum Metadata Api
+
+The following example shows how to create a CIP68NFT instance and use it to mint a CIP68 NFT.
+
+In **Line 8**, create a CIP68NFT instance by calling the static method `CIP68NFT.create()`. Then set the name, description, 
+image and other properties of the NFT according to the CIP68 standard. 
+
+In **Line 19**, get the corresponding CIP68ReferenceToken instance from CIP68NFT instance. 
+
+In **Line 22**, get the Asset instance from CIP68ReferenceToken instance. This Asset instance can be used to mint the reference token.
+
+In **Line 25**, get the Asset instance from CIP68NFT instance. This Asset instance can be used to mint the user token.
+
+In **Line 28**, get the Datum from CIP68ReferenceToken instance. This Datum instance can be used to mint the reference token with CIP68 metadata
+in datum.
+
+In **Line 37**, create a ScriptTx instance and define to mint the reference token and user token.
+
+```java showLineNumbers
+ //Minting Script
+PlutusV2Script mintingScript = PlutusV2Script.builder()
+                .type("PlutusScriptV2")
+                .cborHex("...")
+                .build();
+
+//Define CIP-68 compatible NFT metadata
+CIP68NFT nft = CIP68NFT.create()
+                .name("MyCIP68NFT")
+                .image("https://xyz.com/image.png")
+                .description("A sample CIP-68 NFT")
+                .addFile(CIP68File.create()
+                        .mediaType("image/png")
+                        .name("image1.png")
+                        .src("https://xyz.com/image.png")
+                );
+
+//Get CIP68ReferenceToken from CIP68NFT
+CIP68ReferenceToken referenceToken = nft.getReferenceToken();
+        
+//Create Reference Token Asset with quantity 1
+Asset referenzToken = referenceToken.getAsset();
+        
+//Create User Token Asset with quantity 1
+Asset userToken = nft.getAsset(BigInteger.valueOf(1));
+
+//Get Datum from CIP68ReferenceToken
+PlutusData datumMetadata = referenceToken.getDatumAsPlutusData();
+
+//Receiver of the user token
+String userTokenReceiver = receiverAddr;
+        
+//Receiver of the reference token which is the minting script address
+String referenceTokenReceiver = AddressProvider.getEntAddress(mintingScript, Networks.preprod()).toBech32();
+
+//Define ScriptTx to mint Reference Token and User Token
+ScriptTx scriptTx = new ScriptTx()
+        .mintAsset(mintingScript, List.of(referenzToken), PlutusData.unit(), referenceTokenReceiver, datumMetadata)
+        .mintAsset(mintingScript, List.of(userToken),PlutusData.unit(), userTokenReceiver);
+        
+Result<String> result = quickTxBuilder.compose(scriptTx)
+                .feePayer(account.baseAddress())
+                .withSigner(SignerProviders.signerFrom(account))
+                .completeAndWait(System.out::println);
+```
+
+### CIP68 FT Datum Metadata Api
+
+CIP68FT is used to mint CIP68 compatible Fungible Tokens (333). The following example shows how to create a CIP68FT instance.
+From CIP68FT instance, you can get a CIP68ReferenceToken instance. The remaining steps are similar to previous section (CIP68NFT).
+
+```java
+CIP68FT ft = CIP68FT.create()
+                .name("SampleFungibleToken")
+                .ticker("SFT")
+                .url("https://xyz.com")
+                .logo("https://xyz.com/logo.png")
+                .decimals(6)
+                .description("Sample CIP-68 FT");
+```
+
+### CIP68 RFT Datum Metadata Api
+
+CIP68RFT is used to mint CIP68 compatible Rich Fungible Tokens (444). The following example shows how to create a CIP68RFT instance.
+From CIP68RFT instance, you can get a CIP68ReferenceToken instance. The remaining steps are similar to CIP68NFT section.
+
+```java
+CIP68RFT rft = CIP68RFT.create()
+                .name("SampleRichFungibleToken")
+                .image("https://xyz.com/image.png")
+                .description("Sample CIP-68 RFT")
+                .addFile(CIP68File.create()
+                        .mediaType("image/png")
+                        .name("image.png")
+                        .src("https://xyz.com/image.png")
+                )
+                .property("<key1>", "<key1Value>");
+```
+
+## API Reference
+
+### CIP68NFT Class
+Main class for creating CIP68 NFT metadata.
+
+#### Constructor
+```java
+// Create new instance
+public static CIP68NFT create()
+```
+
+#### Methods
+```java
+// Set NFT name
+public CIP68NFT name(String name)
+
+// Set NFT description
+public CIP68NFT description(String description)
+
+// Set NFT image URL
+public CIP68NFT image(String image)
+
+// Add file to NFT
+public CIP68NFT addFile(CIP68File file)
+
+// Add property to NFT
+public CIP68NFT property(String key, String value)
+
+// Get reference token
+public CIP68ReferenceToken getReferenceToken()
+
+// Get asset with quantity
+public Asset getAsset(BigInteger quantity)
+
+// Convert to Plutus data
+public PlutusData toPlutusData()
+```
+
+### CIP68FT Class
+Main class for creating CIP68 Fungible Token metadata.
+
+#### Methods
+```java
+// Set token name
+public CIP68FT name(String name)
+
+// Set token description
+public CIP68FT description(String description)
+
+// Set token ticker
+public CIP68FT ticker(String ticker)
+
+// Set token decimals
+public CIP68FT decimals(int decimals)
+
+// Set token URL
+public CIP68FT url(String url)
+
+// Set token logo
+public CIP68FT logo(String logo)
+
+// Convert to Plutus data
+public PlutusData toPlutusData()
+```
+
+### CIP68RFT Class
+Main class for creating CIP68 Rich Fungible Token metadata.
+
+#### Methods
+```java
+// Set token name
+public CIP68RFT name(String name)
+
+// Set token description
+public CIP68RFT description(String description)
+
+// Set token image
+public CIP68RFT image(String image)
+
+// Set token decimals
+public CIP68RFT decimals(int decimals)
+
+// Add file to token
+public CIP68RFT addFile(CIP68File file)
+
+// Add property to token
+public CIP68RFT property(String key, String value)
+
+// Convert to Plutus data
+public PlutusData toPlutusData()
+```
+
+### CIP68ReferenceToken Class
+Represents a CIP68 reference token.
+
+#### Methods
+```java
+// Get asset
+public Asset getAsset()
+
+// Get datum as Plutus data
+public PlutusData getDatumAsPlutusData()
+```
+
+### CIP68File Class
+Represents a file in CIP68 metadata.
+
+#### Constructor
+```java
+// Create new instance
+public static CIP68File create()
+```
+
+#### Methods
+```java
+// Set media type
+public CIP68File mediaType(String mediaType)
+
+// Set file name
+public CIP68File name(String name)
+
+// Set file source
+public CIP68File src(String src)
+```
+
+## Policy Creation for CIP68 Tokens
+
+To mint CIP68 tokens, you need to create a minting policy. Here's an example of how to create a simple minting policy:
+
+```java
+// Create account for policy
+Account policyAccount = Account.createFromMnemonic(Networks.testnet(), "your mnemonic words");
+
+// Create verification key from account
+VerificationKey verificationKey = new VerificationKey(policyAccount.hdKeyPair().getPublicKey().getKeyData());
+
+// Create script pubkey
+ScriptPubkey scriptPubkey = new ScriptPubkey(verificationKey);
+
+// Create script all (requires signature from the key)
+ScriptAll scriptAll = new ScriptAll(List.of(scriptPubkey));
+
+// Create policy
+Policy policy = new Policy(scriptAll);
+
+// Create PlutusV2Script from policy
+PlutusV2Script mintingScript = PlutusV2Script.builder()
+        .type("PlutusScriptV2")
+        .cborHex(policy.getCborHex())
+        .build();
+```
+
+## CIP68 Specification Details
+
+### Datum Structure
+CIP68 uses output datums to store metadata with the following structure:
+- **Version**: Metadata version (typically "1.0")
+- **Type**: Asset type (NFT, FT, RFT)
+- **Metadata**: Asset-specific metadata as Plutus data
+
+### Asset Labels
+CIP68 uses CIP67-compliant asset labels:
+- **222**: NFT Standard
+- **333**: Fungible Token Standard  
+- **444**: Rich Fungible Token Standard
+
+### Reference Token Pattern
+- **Reference Token**: Contains metadata in datum
+- **User Token**: Contains actual asset value
+- **Separation**: Metadata and value are stored separately
+
+### Datum Hash
+- **Purpose**: Reference tokens use datum hash as unique identifier
+- **Storage**: Metadata stored in datum, not transaction metadata
+- **Retrieval**: Use datum hash to fetch metadata from blockchain
+
+## Best Practices
+
+1. **Use Reference Tokens**: Always create reference tokens for metadata storage
+2. **Validate Datums**: Ensure datum structure follows CIP68 specification
+3. **Use CIP67 Labels**: Apply appropriate CIP67 asset name labels
+4. **Optimize Metadata**: Keep datum metadata size reasonable
+5. **Handle Errors**: Validate datum deserialization and structure
+
+## Advanced CIP68 Features
+
+### CIP68 Utilities
+
+The CIP68 module provides utility classes for working with datum metadata:
+
+#### CIP68Util
+```java
+// Utility functions for CIP68 operations
+CIP68Util util = new CIP68Util();
+
+// Convert between different datum formats
+PlutusData convertedDatum = util.convertToPlutusData(metadataMap);
+
+// Validate datum structure
+boolean isValid = util.validateDatum(datum);
+```
+
+#### CIP68TokenTemplate
+```java
+// Create token template for consistent token creation
+CIP68TokenTemplate template = CIP68TokenTemplate.create()
+    .label(222) // NFT label
+    .name("MyToken")
+    .description("Token description");
+
+// Apply template to create token
+CIP68NFT token = template.applyToNFT();
+```
+
+#### DatumProperties
+```java
+// Create datum properties
+DatumProperties properties = DatumProperties.create()
+    .version("1.0")
+    .type("NFT")
+    .metadata(metadataMap);
+
+// Get properties from existing datum
+DatumProperties extracted = DatumProperties.fromDatum(datum);
+String version = extracted.getVersion();
+String type = extracted.getType();
+```
+
+## Integration with Other Standards
+
+CIP68 works seamlessly with other Cardano standards:
+
+### With CIP67 (Asset Name Labels)
+```java
+// Create CIP68 NFT with CIP67-compliant asset name
+CIP68NFT nft = CIP68NFT.create()
+    .name("MyCIP68NFT")
+    .description("NFT with CIP67 asset naming");
+
+// The asset name will automatically include CIP67 label 222
+String assetName = nft.getAssetNameAsHex();
+```
+
+### With CIP25 (NFT Metadata)
+```java
+// Combine CIP68 datum metadata with CIP25 transaction metadata
+CIP68NFT cip68NFT = CIP68NFT.create()
+    .name("MyNFT")
+    .description("Combined metadata NFT");
+
+CIP25NFT cip25NFT = CIP25NFT.create()
+    .name("MyNFT")
+    .image("https://example.com/image.png");
+
+// Use CIP68 for datum, CIP25 for transaction metadata
+CBORMetadata transactionMetadata = new CBORMetadata();
+transactionMetadata.putAll(cip25NFT);
+```

--- a/docs/docs/apis/standards/cip8-api.md
+++ b/docs/docs/apis/standards/cip8-api.md
@@ -1,0 +1,328 @@
+---
+title: "CIP8 API"
+description: "Message Signing with COSE Signatures implementation"
+sidebar_position: 3
+---
+
+# CIP8 API
+
+CIP8 (Cardano Improvement Proposal 8) defines a standard for message signing using COSE (CBOR Object Signing and Encryption) signatures. The Cardano Client Library provides APIs to create, sign, and verify messages according to the CIP8 specification.
+
+## Key Features
+
+- **COSE Signatures**: Full COSE Sign1 and COSE Sign support
+- **Message Signing**: Sign arbitrary messages with private keys
+- **Signature Verification**: Verify signatures against public keys
+- **Header Management**: Flexible protected and unprotected header handling
+- **Standard Compliance**: Full CIP8 specification support
+
+## Dependencies
+
+- **Group ID**: com.bloxbean.cardano
+- **Artifact ID**: cardano-client-cip8
+- **Dependencies**: common, crypto
+
+## Usage Examples
+
+### Creating COSE Sign1 Signatures
+
+The following example shows how to create a COSE Sign1 signature for a message using the CIP8 API.
+
+```java
+// Create headers for the signature
+HeaderMap protectedHeaders = new HeaderMap()
+    .algorithmId(14) // EdDSA algorithm
+    .contentType(-1000); // Cardano message content type
+
+HeaderMap unprotectedHeaders = new HeaderMap()
+    .addOtherHeader(-100, "Some header value");
+
+Headers headers = new Headers(protectedHeaders, unprotectedHeaders);
+
+// Create the message payload
+String message = "Hello World";
+byte[] payload = message.getBytes(StandardCharsets.UTF_8);
+
+// Create COSE Sign1 builder
+COSESign1Builder builder = new COSESign1Builder(headers, payload, false);
+builder.hashPayload(); // Hash the payload with Blake2b-224
+
+// Create signature structure for signing
+SigStructure sigStructure = builder.makeDataToSign();
+
+// Sign with private key
+byte[] signature = privateKey.sign(sigStructure.toBytes());
+
+// Build the final COSE Sign1 object
+COSESign1 coseSign1 = builder.build(signature);
+
+// Serialize to bytes for transmission
+byte[] serialized = coseSign1.toBytes();
+String hexSignature = HexUtil.encodeHexString(serialized);
+```
+
+### Creating COSE Sign Signatures (Multiple Signers)
+
+The following example shows how to create a COSE Sign signature with multiple signers.
+
+```java
+// Create headers for the signature
+HeaderMap protectedHeaders = new HeaderMap()
+    .algorithmId(14) // EdDSA algorithm
+    .contentType(-1000); // Cardano message content type
+
+Headers headers = new Headers(protectedHeaders, new HeaderMap());
+
+// Create the message payload
+String message = "Multi-signer message";
+byte[] payload = message.getBytes(StandardCharsets.UTF_8);
+
+// Create COSE Sign builder
+COSESignBuilder builder = new COSESignBuilder(headers, payload, false);
+builder.hashPayload(); // Hash the payload with Blake2b-224
+
+// Create signature structure for signing
+SigStructure sigStructure = builder.makeDataToSign();
+
+// Sign with multiple private keys
+List<COSESignature> signatures = new ArrayList<>();
+for (PrivateKey privateKey : privateKeys) {
+    byte[] signature = privateKey.sign(sigStructure.toBytes());
+    COSESignature coseSignature = new COSESignature()
+        .signature(signature);
+    signatures.add(coseSignature);
+}
+
+// Build the final COSE Sign object
+COSESign coseSign = builder.build(signatures);
+
+// Serialize to bytes for transmission
+byte[] serialized = coseSign.toBytes();
+```
+
+### Signature Verification
+
+The following example shows how to verify a COSE signature.
+
+```java
+// Deserialize the signature from bytes
+COSESign1 coseSign1 = COSESign1.deserialize(signatureBytes);
+
+// Verify the signature
+boolean isValid = COSEUtil.verifyCoseSign1(coseSign1, publicKey);
+
+if (isValid) {
+    System.out.println("Signature is valid");
+    
+    // Extract the payload
+    byte[] payload = coseSign1.payload();
+    String message = new String(payload, StandardCharsets.UTF_8);
+    System.out.println("Message: " + message);
+} else {
+    System.out.println("Signature verification failed");
+}
+```
+
+### Working with Headers
+
+The following example shows how to work with protected and unprotected headers.
+
+```java
+// Create protected headers
+HeaderMap protectedHeaders = new HeaderMap()
+    .algorithmId(14) // EdDSA algorithm
+    .contentType(-1000) // Cardano message content type
+    .keyId("key-123"); // Key identifier
+
+// Create unprotected headers
+HeaderMap unprotectedHeaders = new HeaderMap()
+    .addOtherHeader(-100, "Custom header value")
+    .addOtherHeader(-101, "Another custom value");
+
+// Combine into Headers object
+Headers headers = new Headers(protectedHeaders, unprotectedHeaders);
+
+// Access header values
+Integer algorithmId = headers._protected().algorithmId();
+Integer contentType = headers._protected().contentType();
+String keyId = headers._protected().keyId();
+
+// Access unprotected header values
+Object customValue = headers.unprotected().getOtherHeader(-100);
+```
+
+### Creating COSE Keys
+
+The following example shows how to create and work with COSE keys.
+
+```java
+// Create a COSE key from a public key
+COSEKey coseKey = new COSEKey()
+    .keyType(1) // Octet Key Pair
+    .algorithm(14) // EdDSA
+    .crv(-8) // Ed25519 curve
+    .x(publicKeyBytes); // Public key bytes
+
+// Serialize the key
+byte[] keyBytes = coseKey.toBytes();
+String keyHex = HexUtil.encodeHexString(keyBytes);
+
+// Deserialize a COSE key
+COSEKey deserializedKey = COSEKey.deserialize(HexUtil.decodeHexString(keyHex));
+
+// Extract public key bytes
+byte[] extractedPublicKey = deserializedKey.x();
+```
+
+## API Reference
+
+### Core Classes
+
+#### COSESign1Builder
+Builder class for creating COSE Sign1 signatures.
+
+```java
+// Constructor
+COSESign1Builder(Headers headers, byte[] payload, boolean isPayloadExternal)
+
+// Methods
+SigStructure makeDataToSign() // Create signature structure
+COSESign1 build(byte[] signature) // Build final signature
+COSESign1Builder hashPayload() // Hash payload with Blake2b-224
+```
+
+#### COSESignBuilder
+Builder class for creating COSE Sign signatures with multiple signers.
+
+```java
+// Constructor
+COSESignBuilder(Headers headers, byte[] payload, boolean isPayloadExternal)
+
+// Methods
+SigStructure makeDataToSign() // Create signature structure
+COSESign build(List<COSESignature> signatures) // Build final signature
+COSESignBuilder hashPayload() // Hash payload with Blake2b-224
+```
+
+#### Headers
+Manages protected and unprotected headers.
+
+```java
+// Constructor
+Headers(HeaderMap protectedHeaders, HeaderMap unprotectedHeaders)
+
+// Methods
+HeaderMap _protected() // Get protected headers
+HeaderMap unprotected() // Get unprotected headers
+Headers copy() // Create a copy
+```
+
+#### HeaderMap
+Manages individual header maps.
+
+```java
+// Methods
+HeaderMap algorithmId(Integer algorithmId) // Set algorithm ID
+HeaderMap contentType(Integer contentType) // Set content type
+HeaderMap keyId(String keyId) // Set key ID
+HeaderMap addOtherHeader(Integer key, Object value) // Add custom header
+Integer algorithmId() // Get algorithm ID
+Integer contentType() // Get content type
+String keyId() // Get key ID
+Object getOtherHeader(Integer key) // Get custom header
+```
+
+#### COSEUtil
+Utility class for signature verification.
+
+```java
+// Static methods
+boolean verifyCoseSign1(COSESign1 coseSign1, PublicKey publicKey)
+boolean verifyCoseSign(COSESign coseSign, List<PublicKey> publicKeys)
+```
+
+## CIP8 Specification Details
+
+### COSE Sign1 Structure
+CIP8 uses COSE Sign1 format with the following structure:
+- **Protected Headers**: Algorithm ID, content type, key ID
+- **Unprotected Headers**: Custom headers, address information
+- **Payload**: Message data (optionally hashed with Blake2b-224)
+- **Signature**: EdDSA signature over the structure
+
+### Signature Process
+1. **Header Creation**: Create protected and unprotected headers
+2. **Payload Preparation**: Optionally hash payload with Blake2b-224
+3. **Structure Building**: Create COSE Sign1 structure
+4. **Signing**: Sign using EdDSA with Ed25519 curve
+5. **Serialization**: Convert to CBOR bytes
+
+### Algorithm Identifiers
+The following algorithm identifiers are commonly used:
+
+- **14**: EdDSA (Edwards Curve Digital Signature Algorithm)
+- **-8**: Ed25519 curve identifier
+- **1**: Octet Key Pair key type
+- **-1000**: Cardano message content type
+
+### Hash Algorithm
+- **Blake2b-224**: Used for payload hashing (224-bit output)
+- **Purpose**: Reduce payload size for large messages
+
+## Best Practices
+
+1. **Always hash payloads** for large messages using `hashPayload()` method
+2. **Use appropriate algorithm IDs** based on your key type (EdDSA = 14 for Ed25519)
+3. **Include key identifiers** in protected headers for key management
+4. **Validate signatures** before processing signed messages
+5. **Handle serialization errors** gracefully when deserializing signatures
+
+## Advanced CIP8 Features
+
+### COSE Encryption
+
+CIP8 also provides COSE encryption capabilities:
+
+#### COSEEncrypt
+```java
+// Create COSE encryption object
+COSEEncrypt coseEncrypt = new COSEEncrypt()
+    .headers(headers)
+    .ciphertext(encryptedData)
+    .recipients(recipients);
+```
+
+#### Password-Based Encryption
+```java
+// Create password-based encryption
+PasswordEncryption passwordEncryption = new PasswordEncryption()
+    .password("your-password")
+    .salt(saltBytes);
+```
+
+#### Public Key Encryption
+```java
+// Create public key encryption
+PubKeyEncryption pubKeyEncryption = new PubKeyEncryption()
+    .publicKey(publicKeyBytes)
+    .algorithm(algorithmId);
+```
+
+### COSE Recipients
+
+```java
+// Create COSE recipient
+COSERecipient recipient = new COSERecipient()
+    .headers(recipientHeaders)
+    .encryptedKey(encryptedKeyBytes);
+```
+
+## Integration with Other CIPs
+
+CIP8 is commonly used with other Cardano standards:
+
+- **CIP30**: Uses CIP8 for dApp wallet data signing
+- **CIP25**: Can include CIP8 signatures in NFT metadata
+- **CIP68**: Can include CIP8 signatures in datum metadata
+
+For more information about CIP8, refer to the [official CIP8 specification](https://cips.cardano.org/cips/cip8/).


### PR DESCRIPTION
- Introduced new documentation for CIP8, CIP20, CIP25, CIP27, CIP30, CIP67, and CIP68 APIs.
- Each API includes key features, usage examples, and API references to facilitate integration and usage.
- Enhanced documentation structure to support better navigation and understanding of Cardano's CIP standards.