### PR TITLE
refactor: Introduce RawData interface and rename FieldType flags for cleaner sh…

### DIFF
--- a/annotation-processor/src/main/java/com/bloxbean/cardano/client/plutus/annotation/processor/ClassDefinitionGenerator.java
+++ b/annotation-processor/src/main/java/com/bloxbean/cardano/client/plutus/annotation/processor/ClassDefinitionGenerator.java
@@ -240,13 +240,13 @@ public class ClassDefinitionGenerator {
             // Raw Pair type (from shared type lookup — not parameterized)
             fieldType.setType(Type.CONSTRUCTOR);
             fieldType.setJavaType(new JavaType(typeName.toString(), true));
-            fieldType.setNonConstrPlutusData(true);
+            fieldType.setRawDataType(true);
         } else {
             if (isSupportedType(typeName, typeMirror)) {
                 fieldType.setType(Type.CONSTRUCTOR);
                 fieldType.setJavaType(new JavaType(typeName.toString(), true));
-                fieldType.setNonConstrPlutusData(isBytesWrapperType(typeMirror));
-                fieldType.setSharedType(isSharedType(typeMirror));
+                fieldType.setRawDataType(isRawDataType(typeMirror));
+                fieldType.setDataType(isDataType(typeMirror));
             } else {
                 throw new NotSupportedException("Type not supported: " + typeName);
             }
@@ -322,15 +322,14 @@ public class ClassDefinitionGenerator {
                 e);
     }
 
+    private static final String DATA_INTERFACE_FQN = "com.bloxbean.cardano.client.plutus.blueprint.model.Data";
+    private static final String RAW_DATA_INTERFACE_FQN = "com.bloxbean.cardano.client.plutus.blueprint.model.RawData";
+
     /**
-     * Checks if a type is a shared type — a hand-written class that has its own
-     * {@code toPlutusData()} method and is NOT a generated {@code @Constr} model class.
-     * <p>
-     * Generated {@code @Constr} model classes also have {@code toPlutusData()} (via the
-     * {@code Data<T>} interface), but they delegate to a Converter. Shared types implement
-     * the conversion logic directly.
+     * Checks if a type implements {@code Data<T>} — a constr-based shared type
+     * that is NOT a generated {@code @Constr} model class.
      */
-    private boolean isSharedType(TypeMirror typeMirror) {
+    private boolean isDataType(TypeMirror typeMirror) {
         if (typeMirror == null) return false;
         Types typeUtils = processingEnvironment.getTypeUtils();
         Element element = typeUtils.asElement(typeMirror);
@@ -338,31 +337,21 @@ public class ClassDefinitionGenerator {
         TypeElement typeElement = (TypeElement) element;
         // @Constr-annotated classes are generated model classes, not shared types
         if (typeElement.getAnnotation(Constr.class) != null) return false;
-        // Check for toPlutusData() method (including inherited)
-        for (Element member : elements.getAllMembers(typeElement)) {
-            if (member instanceof ExecutableElement) {
-                ExecutableElement method = (ExecutableElement) member;
-                if (method.getSimpleName().toString().equals("toPlutusData")
-                        && method.getParameters().isEmpty()) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        TypeElement dataInterface = elements.getTypeElement(DATA_INTERFACE_FQN);
+        if (dataInterface == null) return false;
+        return typeUtils.isAssignable(typeUtils.erasure(typeMirror), typeUtils.erasure(dataInterface.asType()));
     }
 
-    private static final String BYTE_ARRAY_WRAPPER_FQN = "com.bloxbean.cardano.client.plutus.aiken.blueprint.std.ByteArrayWrapper";
-
     /**
-     * Checks if a type extends ByteArrayWrapper (bytes-wrapper shared type).
-     * These types serialize to BytesPlutusData rather than ConstrPlutusData.
+     * Checks if a type implements {@code RawData} — a bytes-wrapper shared type
+     * whose on-chain encoding is raw {@code PlutusData} (not {@code ConstrPlutusData}).
      */
-    private boolean isBytesWrapperType(TypeMirror typeMirror) {
+    private boolean isRawDataType(TypeMirror typeMirror) {
         if (typeMirror == null) return false;
-        TypeElement wrapperElement = elements.getTypeElement(BYTE_ARRAY_WRAPPER_FQN);
-        if (wrapperElement == null) return false; // ByteArrayWrapper not on classpath
+        TypeElement rawDataInterface = elements.getTypeElement(RAW_DATA_INTERFACE_FQN);
+        if (rawDataInterface == null) return false;
         Types typeUtils = processingEnvironment.getTypeUtils();
-        return typeUtils.isAssignable(typeMirror, wrapperElement.asType());
+        return typeUtils.isAssignable(typeMirror, rawDataInterface.asType());
     }
 
     private boolean isAssignableToMap(TypeMirror typeMirror) {

--- a/annotation-processor/src/main/java/com/bloxbean/cardano/client/plutus/annotation/processor/ConverterCodeGenerator.java
+++ b/annotation-processor/src/main/java/com/bloxbean/cardano/client/plutus/annotation/processor/ConverterCodeGenerator.java
@@ -816,7 +816,7 @@ public class ConverterCodeGenerator implements CodeGenerator {
             case CONSTRUCTOR:
                 TypeName fieldTypeName = bestGuess(field.getFieldType().getJavaType().getName());
                 if (field.getFieldType().isSharedType()) {
-                    if (field.getFieldType().isNonConstrPlutusData()) {
+                    if (field.getFieldType().isRawDataType()) {
                         // Shared bytes-wrapper types — static fromPlutusData, no cast
                         codeBlock = CodeBlock.builder()
                                 .add("//Field $L\n", field.getName())
@@ -833,7 +833,7 @@ public class ConverterCodeGenerator implements CodeGenerator {
                     }
                 } else {
                     ClassName converterClazz = getConverterClassFromField(field.getFieldType());
-                    if (field.getFieldType().isNonConstrPlutusData()) {
+                    if (field.getFieldType().isRawDataType()) {
                         // Bytes-wrapper shared types (e.g., VerificationKeyHash) — pass PlutusData directly, no cast
                         codeBlock = CodeBlock.builder()
                                 .add("//Field $L\n", field.getName())
@@ -1142,14 +1142,14 @@ public class ConverterCodeGenerator implements CodeGenerator {
             default:
                 if (itemType.isSharedType()) {
                     String typeFqn = itemType.getJavaType().getName();
-                    if (itemType.isNonConstrPlutusData()) {
+                    if (itemType.isRawDataType()) {
                         return String.format("%s.fromPlutusData(%s)", typeFqn, fieldName);
                     }
                     return String.format("%s.fromPlutusData((ConstrPlutusData)%s)", typeFqn, fieldName);
                 }
                 ClassName converterClassName = getConverterClassFromField(itemType);
                 String converterClazz = converterClassName.packageName() + "." + converterClassName.simpleName();
-                if (itemType.isNonConstrPlutusData()) {
+                if (itemType.isRawDataType()) {
                     return String.format("new %s().fromPlutusData(%s)", converterClazz, fieldName);
                 }
                 return String.format("new %s().fromPlutusData((ConstrPlutusData)%s)", converterClazz, fieldName);

--- a/annotation-processor/src/main/java/com/bloxbean/cardano/client/plutus/annotation/processor/model/FieldType.java
+++ b/annotation-processor/src/main/java/com/bloxbean/cardano/client/plutus/annotation/processor/model/FieldType.java
@@ -19,37 +19,35 @@ public class FieldType {
     private String fqTypeName; //Fully qualified type name. This can be used to get the exact type.
     private List<FieldType> genericTypes = new ArrayList<>();
     /**
-     * Indicates that this field's on-chain representation is <em>not</em> a {@code ConstrPlutusData}.
+     * {@code true} when the type implements {@code RawData} — i.e., its on-chain
+     * encoding is raw {@code PlutusData} (e.g. {@code BytesPlutusData}) rather than
+     * {@code ConstrPlutusData}.
      * <p>
-     * Most custom/complex types in Plutus are encoded as constructors ({@code ConstrPlutusData}),
-     * and the generated deserialization code casts accordingly:
-     * <pre>new FooConverter().fromPlutusData((ConstrPlutusData) data.get(i))</pre>
-     *
-     * However, some shared types use a different encoding:
-     * <ul>
-     *   <li>Bytes-wrapper types (e.g., {@code VerificationKeyHash}, {@code ScriptHash}) are encoded
-     *       as raw {@code BytesPlutusData}</li>
-     *   <li>Pair/Tuple types are encoded as {@code ListPlutusData}</li>
-     * </ul>
-     *
-     * When this flag is {@code true}, the generated code passes the raw {@code PlutusData} directly
-     * to the converter without casting to {@code ConstrPlutusData}:
+     * When set, the generated deserialization code passes the raw {@code PlutusData}
+     * directly to the converter without casting to {@code ConstrPlutusData}:
      * <pre>new FooConverter().fromPlutusData(data.get(i))</pre>
      */
-    private boolean nonConstrPlutusData;
+    private boolean rawDataType;
 
     /**
-     * Indicates that this field's type is a shared type that has its own
-     * {@code toPlutusData()} instance method and {@code fromPlutusData()} static method.
+     * {@code true} when the type implements {@code Data<T>} — a constr-based shared
+     * type that has its own {@code toPlutusData()} instance method and
+     * {@code fromPlutusData()} static method.
      * <p>
-     * When {@code true}, the generated converter inlines calls directly:
+     * When set, the generated converter inlines calls directly:
      * <pre>obj.getField().toPlutusData()</pre>
      * <pre>Type.fromPlutusData(data)</pre>
-     * instead of delegating through a generated converter class:
-     * <pre>new TypeConverter().toPlutusData(obj.getField())</pre>
-     * <pre>new TypeConverter().fromPlutusData(data)</pre>
+     * instead of delegating through a generated converter class.
      */
-    private boolean sharedType;
+    private boolean dataType;
+
+    /**
+     * Convenience: {@code true} when this field's type is any kind of shared type
+     * (either {@link #dataType} or {@link #rawDataType}).
+     */
+    public boolean isSharedType() {
+        return dataType || rawDataType;
+    }
 
     public boolean isMap() {
         return javaType == JavaType.MAP;

--- a/annotation-processor/src/test/java/com/bloxbean/cardano/client/plutus/annotation/processor/ClassDefinitionGeneratorTest.java
+++ b/annotation-processor/src/test/java/com/bloxbean/cardano/client/plutus/annotation/processor/ClassDefinitionGeneratorTest.java
@@ -1,0 +1,125 @@
+package com.bloxbean.cardano.client.plutus.annotation.processor;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ClassDefinitionGenerator}'s type detection logic
+ * ({@code isDataType()} and {@code isRawDataType()}) by compiling a model
+ * with fields of each shared-type family and inspecting the generated converter source.
+ *
+ * <p>The test resource {@code SharedTypeFieldModel.java} has three fields:
+ * <ul>
+ *   <li>{@code Address address}       — implements {@code Data<T>} → dataType</li>
+ *   <li>{@code VerificationKeyHash vkh} — implements {@code RawData} → rawDataType</li>
+ *   <li>{@code Model2 nested}          — {@code @Constr} class → regular (converter-delegated)</li>
+ * </ul>
+ */
+@DisplayName("ClassDefinitionGenerator — shared type detection")
+public class ClassDefinitionGeneratorTest {
+
+    private static String converterSource;
+
+    @BeforeAll
+    static void compileModel() throws IOException {
+        Compilation compilation = javac()
+                .withProcessors(new ConstrAnnotationProcessor())
+                .compile(
+                        JavaFileObjects.forResource("SharedTypeFieldModel.java"),
+                        JavaFileObjects.forResource("Model2.java"));
+
+        assertThat(compilation).succeeded();
+
+        JavaFileObject converter = compilation.generatedSourceFiles().stream()
+                .filter(f -> f.getName().contains("SharedTypeFieldModelConverter"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("SharedTypeFieldModelConverter not generated"));
+
+        converterSource = converter.getCharContent(true).toString();
+    }
+
+    @Nested
+    @DisplayName("isDataType() — Data<T> interface detection")
+    class DataTypeDetection {
+
+        @Test
+        @DisplayName("should generate inline toPlutusData() for Data<T> field (Address)")
+        void dataTypeField_shouldGenerateInlineToPlutusData() {
+            // Data<T> shared types serialize via obj.getField().toPlutusData() — not through a converter
+            assertThat(converterSource).contains("obj.getAddress().toPlutusData()");
+        }
+
+        @Test
+        @DisplayName("should deserialize Data<T> field with ConstrPlutusData cast")
+        void dataTypeField_shouldDeserializeWithConstrCast() {
+            // Data<T> types are constr-based, so deserialization casts to ConstrPlutusData
+            assertThat(converterSource).contains("Address.fromPlutusData(((ConstrPlutusData)");
+        }
+
+        @Test
+        @DisplayName("should NOT delegate Data<T> field through a generated converter")
+        void dataTypeField_shouldNotUseConverter() {
+            assertThat(converterSource).doesNotContain("AddressConverter");
+        }
+    }
+
+    @Nested
+    @DisplayName("isRawDataType() — RawData interface detection")
+    class RawDataTypeDetection {
+
+        @Test
+        @DisplayName("should generate inline toPlutusData() for RawData field (VerificationKeyHash)")
+        void rawDataTypeField_shouldGenerateInlineToPlutusData() {
+            // RawData shared types also serialize inline
+            assertThat(converterSource).contains("obj.getVkh().toPlutusData()");
+        }
+
+        @Test
+        @DisplayName("should deserialize RawData field WITHOUT ConstrPlutusData cast")
+        void rawDataTypeField_shouldDeserializeWithoutConstrCast() {
+            // RawData types use raw PlutusData — no ConstrPlutusData cast
+            assertThat(converterSource).contains("VerificationKeyHash.fromPlutusData(data.getPlutusDataList()");
+            assertThat(converterSource).doesNotContain("VerificationKeyHash.fromPlutusData((ConstrPlutusData)");
+        }
+
+        @Test
+        @DisplayName("should NOT delegate RawData field through a generated converter")
+        void rawDataTypeField_shouldNotUseConverter() {
+            assertThat(converterSource).doesNotContain("VerificationKeyHashConverter");
+        }
+    }
+
+    @Nested
+    @DisplayName("Regular @Constr types — neither Data<T> nor RawData")
+    class RegularConstrType {
+
+        @Test
+        @DisplayName("should delegate @Constr field through generated converter for serialization")
+        void constrTypeField_shouldUsConverterForSerialization() {
+            assertThat(converterSource).contains("Model2Converter().toPlutusData(obj.getNested())");
+        }
+
+        @Test
+        @DisplayName("should delegate @Constr field through generated converter for deserialization with ConstrPlutusData cast")
+        void constrTypeField_shouldUseConverterForDeserialization() {
+            assertThat(converterSource).contains("Model2Converter().fromPlutusData(((ConstrPlutusData)");
+        }
+
+        @Test
+        @DisplayName("should NOT inline toPlutusData() for @Constr field")
+        void constrTypeField_shouldNotInlineToPlutusData() {
+            assertThat(converterSource).doesNotContain("obj.getNested().toPlutusData()");
+        }
+    }
+}

--- a/annotation-processor/src/test/resources/SharedTypeFieldModel.java
+++ b/annotation-processor/src/test/resources/SharedTypeFieldModel.java
@@ -1,0 +1,29 @@
+package com.test;
+
+import com.bloxbean.cardano.client.plutus.annotation.Constr;
+import com.bloxbean.cardano.client.plutus.aiken.blueprint.std.Address;
+import com.bloxbean.cardano.client.plutus.aiken.blueprint.std.VerificationKeyHash;
+
+/**
+ * Test POJO that combines all three field-type families:
+ * <ul>
+ *   <li>{@code Address} — implements {@code Data<T>} (dataType=true)</li>
+ *   <li>{@code VerificationKeyHash} — implements {@code RawData} via ByteArrayWrapper (rawDataType=true)</li>
+ *   <li>{@code Model2} — regular {@code @Constr} class (neither dataType nor rawDataType)</li>
+ * </ul>
+ */
+@Constr
+public class SharedTypeFieldModel {
+    public Address address;
+    public VerificationKeyHash vkh;
+    public Model2 nested;
+
+    public Address getAddress() { return address; }
+    public void setAddress(Address address) { this.address = address; }
+
+    public VerificationKeyHash getVkh() { return vkh; }
+    public void setVkh(VerificationKeyHash vkh) { this.vkh = vkh; }
+
+    public Model2 getNested() { return nested; }
+    public void setNested(Model2 nested) { this.nested = nested; }
+}

--- a/plutus-aiken/src/main/java/com/bloxbean/cardano/client/plutus/aiken/blueprint/std/ByteArrayWrapper.java
+++ b/plutus-aiken/src/main/java/com/bloxbean/cardano/client/plutus/aiken/blueprint/std/ByteArrayWrapper.java
@@ -1,12 +1,13 @@
 package com.bloxbean.cardano.client.plutus.aiken.blueprint.std;
 
+import com.bloxbean.cardano.client.plutus.blueprint.model.RawData;
 import com.bloxbean.cardano.client.plutus.spec.BytesPlutusData;
 import com.bloxbean.cardano.client.plutus.spec.PlutusData;
 
 import java.util.Arrays;
 import java.util.Objects;
 
-abstract class ByteArrayWrapper {
+abstract class ByteArrayWrapper implements RawData {
 
     private final byte[] value;
 

--- a/plutus/src/main/java/com/bloxbean/cardano/client/plutus/blueprint/model/RawData.java
+++ b/plutus/src/main/java/com/bloxbean/cardano/client/plutus/blueprint/model/RawData.java
@@ -1,0 +1,15 @@
+package com.bloxbean.cardano.client.plutus.blueprint.model;
+
+import com.bloxbean.cardano.client.plutus.spec.PlutusData;
+
+/**
+ * Marker interface for types whose on-chain encoding is raw {@link PlutusData}
+ * (e.g.&nbsp;{@code BytesPlutusData}) rather than {@code ConstrPlutusData}.
+ *
+ * <p>Implementing this interface lets the annotation processor detect bytes-wrapper
+ * shared types via a clean type check instead of scanning for a {@code toPlutusData()}
+ * method.</p>
+ */
+public interface RawData {
+    PlutusData toPlutusData();
+}


### PR DESCRIPTION
…ared-type detection

Replace method-scanning (`toPlutusData()` lookup) and hardcoded FQN checks (`ByteArrayWrapper`) with interface-based type detection: `Data<T>` for constr-based shared types and `RawData` for bytes-wrapper shared types.

- Add `RawData` marker interface in plutus module
- Make `ByteArrayWrapper` implement `RawData`
- Rename FieldType flags: `sharedType` → `dataType`, `nonConstrPlutusData` → `rawDataType`
- Add `isSharedType()` convenience method (`dataType || rawDataType`)
- Simplify ClassDefinitionGenerator with `isAssignable` checks against interfaces
- Add compile-testing unit tests for all three field-type families