### PR TITLE
feat(vds): add MPF property testing and shared RocksDB config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ rust/jniLibs
 .gradle-user-home
 /.claude/
 /docs/public/_pagefind
+.jqwik-database
+**/.jqwik-database

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,9 @@ mockito-core = "org.mockito:mockito-core:5.12.0"
 lombok = "org.projectlombok:lombok:1.18.42"
 apache-common-text="org.apache.commons:commons-text:1.15.0"
 
+# jqwik (Property-based testing)
+jqwik = "net.jqwik:jqwik:1.9.3"
+
 # JMH (Java Microbenchmark Harness) for performance testing
 jmh-core = "org.openjdk.jmh:jmh-core:1.37"
 jmh-generator-annprocess = "org.openjdk.jmh:jmh-generator-annprocess:1.37"

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,6 +36,7 @@ include 'backend-modules:koios'
 include 'backend-modules:ogmios'
 include 'integration-test'
 include 'it-support'
+include 'test-support'
 
 //supplier modules
 include 'supplier'

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    api(libs.jqwik)
+    api project(':common')
+    api project(':crypto')
+    compileOnly project(':verified-structures:verified-structures-core')
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Cardano Client Test Support Module'
+                description = 'Cardano Client Lib - Test Support'
+            }
+        }
+    }
+}

--- a/test-support/docs/property-testing-guide.md
+++ b/test-support/docs/property-testing-guide.md
@@ -1,0 +1,350 @@
+# test-support: Property-Based Testing Guide
+
+The `test-support` module provides [jqwik](https://jqwik.net/) arbitraries (random data generators) for writing property-based tests against Cardano Client Library modules. Instead of hand-picking a few examples, property tests let jqwik generate hundreds of random inputs and automatically shrink failures to minimal reproducers.
+
+## Setup
+
+### 1. Add the dependency
+
+In the consuming module's `build.gradle`:
+
+```gradle
+dependencies {
+    testImplementation project(':test-support')
+}
+```
+
+This transitively brings in:
+- `net.jqwik:jqwik:1.9.3` (property-based testing engine)
+- `:common` (HexUtil, etc.)
+- `:crypto` (Blake2bUtil)
+
+No additional jqwik dependency declaration is needed.
+
+`MpfArbitraries` is available in the same module, but it is an optional verified-structures helper. If a test imports `MpfArbitraries`, `HashFunction`, `NodeStore`, or MPF trie classes, add the relevant verified-structures module explicitly:
+
+```gradle
+dependencies {
+    testImplementation project(':test-support')
+    testImplementation project(':verified-structures:verified-structures-core')
+    testImplementation project(':verified-structures:merkle-patricia-forestry')
+}
+```
+
+Consumers that only use `CardanoArbitraries`, `ByteArrayWrapper`, or other non-verified-structures utilities do not need verified-structures dependencies on their test classpath.
+
+### 2. Verify the test runner
+
+The root `build.gradle` already configures `useJUnitJupiter()` for all subprojects, and jqwik integrates with JUnit Platform. No extra configuration is required.
+
+## Module Contents
+
+### CardanoArbitraries
+
+General-purpose generators for Cardano data types.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `bytes(int size)` | `Arbitrary<byte[]>` | Fixed-size random byte array |
+| `bytesRange(int min, int max)` | `Arbitrary<byte[]>` | Random byte array with size in [min, max] |
+| `hashes()` | `Arbitrary<byte[]>` | 32-byte hash digests |
+| `policyIds()` | `Arbitrary<byte[]>` | 28-byte policy IDs |
+| `assetNames()` | `Arbitrary<byte[]>` | 0-32 byte asset names |
+| `lovelaceAmounts()` | `Arbitrary<BigInteger>` | 0 to 45 quadrillion lovelace |
+| `hexStrings(int byteLen)` | `Arbitrary<String>` | Hex-encoded string of given byte length |
+| `keyValues()` | `Arbitrary<Map.Entry<byte[], byte[]>>` | Key (1-64 bytes) + value (1-256 bytes) pair |
+| `keyValueMaps(int min, int max)` | `Arbitrary<Map<ByteArrayWrapper, byte[]>>` | Deduplicated map of key-value pairs |
+
+### MpfArbitraries
+
+Generators specific to the MPF (Merkle Patricia Forestry) trie.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `hashFunctions()` | `Arbitrary<HashFunction>` | One of Blake2b-256, SHA-256, or SHA3-256 |
+| `alphanumericKey()` | `Arbitrary<byte[]>` | Alphanumeric string key (4-32 chars) as UTF-8 bytes |
+| `alphanumericValue()` | `Arbitrary<byte[]>` | Alphanumeric string value (1-64 chars) as UTF-8 bytes |
+| `trieKeyValues(int min, int max)` | `Arbitrary<List<Map.Entry<byte[], byte[]>>>` | List of binary key-value pairs for trie insertion |
+| `trieKeyValuesAlphanumeric(int min, int max)` | `Arbitrary<List<Map.Entry<byte[], byte[]>>>` | List of human-readable key-value pairs for easier shrinking and debugging |
+| `deduplicateEntries(List<...>)` | `Map<ByteArrayWrapper, byte[]>` | Deduplicate entries by key (last-write-wins) |
+| `trieOperations(List<byte[]> keys, int min, int max)` | `Arbitrary<List<TrieOperation>>` | Random PUT/DELETE/GET ops over a key pool |
+
+Constants `MpfArbitraries.SHA256` and `MpfArbitraries.SHA3_256` are also available as standalone `HashFunction` instances.
+
+### ByteArrayWrapper
+
+A `byte[]` wrapper with proper `equals`/`hashCode` (using `Arrays.equals`/`Arrays.hashCode`). The constructor defensively copies the input array and pre-computes the hash code. Use this whenever you need `byte[]` as a `Map` key or `Set` element.
+
+```java
+Map<ByteArrayWrapper, byte[]> map = new LinkedHashMap<>();
+map.put(new ByteArrayWrapper(key), value);
+```
+
+### TrieOperation
+
+A record representing a single trie operation:
+
+```java
+public record TrieOperation(OpType type, byte[] key, byte[] value) {
+    public enum OpType { PUT, DELETE, GET }
+}
+```
+
+## Writing Property Tests
+
+### Minimal example
+
+```java
+import com.bloxbean.cardano.client.test.CardanoArbitraries;
+import net.jqwik.api.*;
+
+class MyPropertyTest {
+
+    @Property(tries = 100)
+    void policyIdIsAlways28Bytes(@ForAll("policyIds") byte[] id) {
+        assert id.length == 28;
+    }
+
+    @Provide
+    Arbitrary<byte[]> policyIds() {
+        return CardanoArbitraries.policyIds();
+    }
+}
+```
+
+### Testing a trie across hash functions
+
+Use `MpfArbitraries.hashFunctions()` as a `@Provide` method to parameterize your property across Blake2b-256, SHA-256, and SHA3-256:
+
+```java
+import com.bloxbean.cardano.client.test.vds.MpfArbitraries;
+import com.bloxbean.cardano.client.test.vds.TrieOperation;
+import com.bloxbean.cardano.vds.core.api.HashFunction;
+import com.bloxbean.cardano.vds.mpf.MpfTrie;
+import net.jqwik.api.*;
+
+class TriePropertyTest {
+
+    @Provide
+    Arbitrary<HashFunction> hashFunctions() {
+        return MpfArbitraries.hashFunctions();
+    }
+
+    @Property(tries = 200)
+    void putThenGetReturnsValue(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("randomKey") byte[] key,
+            @ForAll("randomValue") byte[] value) {
+
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        trie.put(key, value);
+        byte[] retrieved = trie.get(key);
+
+        assertArrayEquals(value, retrieved);
+    }
+
+    @Provide
+    Arbitrary<byte[]> randomKey() {
+        return MpfArbitraries.alphanumericKey();
+    }
+
+    @Provide
+    Arbitrary<byte[]> randomValue() {
+        return MpfArbitraries.alphanumericValue();
+    }
+}
+```
+
+### Testing with bulk entries
+
+Generate a list of key-value pairs and deduplicate by key before inserting into the trie:
+
+```java
+@Provide
+Arbitrary<List<Map.Entry<byte[], byte[]>>> entries() {
+    return MpfArbitraries.trieKeyValuesAlphanumeric(10, 100);
+}
+
+@Property(tries = 200)
+void rootHashIsDeterministic(
+        @ForAll("hashFunctions") HashFunction hashFn,
+        @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+
+    // Deduplicate keys (last-write-wins)
+    Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+    if (deduped.size() < 2) return;
+
+    // Insert in original order
+    TestNodeStore store1 = new TestNodeStore();
+    MpfTrie trie1 = new MpfTrie(store1, hashFn);
+    for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+        trie1.put(e.getKey().getData(), e.getValue());
+    }
+
+    // Insert in reversed order
+    TestNodeStore store2 = new TestNodeStore();
+    MpfTrie trie2 = new MpfTrie(store2, hashFn);
+    List<Map.Entry<ByteArrayWrapper, byte[]>> reversed = new ArrayList<>(deduped.entrySet());
+    Collections.reverse(reversed);
+    for (Map.Entry<ByteArrayWrapper, byte[]> e : reversed) {
+        trie2.put(e.getKey().getData(), e.getValue());
+    }
+
+    assertArrayEquals(trie1.getRootHash(), trie2.getRootHash());
+}
+```
+
+### Testing with random operation sequences
+
+Generate a sequence of random PUT/DELETE/GET operations against a shared key pool. Use a `@Provide` method so jqwik controls generation and shrinking:
+
+```java
+@Provide
+Arbitrary<List<TrieOperation>> operations() {
+    List<byte[]> keyPool = new ArrayList<>();
+    for (int i = 0; i < 20; i++) {
+        keyPool.add(("key-" + i).getBytes());
+    }
+    return MpfArbitraries.trieOperations(keyPool, 10, 50);
+}
+
+@Property(tries = 100)
+void trieHandlesRandomOperations(
+        @ForAll("hashFunctions") HashFunction hashFn,
+        @ForAll("operations") List<TrieOperation> ops) {
+
+    TestNodeStore store = new TestNodeStore();
+    MpfTrie trie = new MpfTrie(store, hashFn);
+    Map<ByteArrayWrapper, byte[]> mirror = new HashMap<>();
+
+    for (TrieOperation op : ops) {
+        switch (op.type()) {
+            case PUT -> {
+                trie.put(op.key(), op.value());
+                mirror.put(new ByteArrayWrapper(op.key()), op.value());
+            }
+            case DELETE -> {
+                trie.delete(op.key());
+                mirror.remove(new ByteArrayWrapper(op.key()));
+            }
+            case GET -> {
+                byte[] expected = mirror.get(new ByteArrayWrapper(op.key()));
+                byte[] actual = trie.get(op.key());
+                assertArrayEquals(expected, actual);
+            }
+        }
+    }
+}
+```
+
+## Composing Custom Arbitraries
+
+The generators are designed to be composed with jqwik's built-in combinators:
+
+```java
+// Combine a policy ID with an asset name into a full asset identifier
+Arbitrary<byte[]> assetIds() {
+    return Combinators.combine(
+            CardanoArbitraries.policyIds(),
+            CardanoArbitraries.assetNames()
+    ).as((policy, name) -> {
+        byte[] result = new byte[policy.length + name.length];
+        System.arraycopy(policy, 0, result, 0, policy.length);
+        System.arraycopy(name, 0, result, policy.length, name.length);
+        return result;
+    });
+}
+
+// Map an arbitrary to produce hex-encoded output
+Arbitrary<String> policyIdHex() {
+    return CardanoArbitraries.hexStrings(28);
+}
+```
+
+## Running Tests
+
+```bash
+# Run all tests in a module
+./gradlew :verified-structures:merkle-patricia-forestry:test
+
+# Run a specific property test class
+./gradlew :verified-structures:merkle-patricia-forestry:test --tests "*MpfPropertyTest"
+
+# Run a single property
+./gradlew :verified-structures:merkle-patricia-forestry:test --tests "*MpfPropertyTest.p1*"
+```
+
+## Tips
+
+**Controlling tries.** Use `@Property(tries = N)` to set how many random inputs jqwik generates. 200 is a good default; use fewer (50) for slow tests like RocksDB.
+
+**Reproducibility.** When a property fails, jqwik records the failing seed in `.jqwik-database` and replays it on the next run. The repository ignores these generated files by default; use an explicit `@Property(seed = "...")` when a failure must be preserved in source control.
+
+**Shrinking.** jqwik automatically shrinks failing inputs to the smallest reproducer. Check the test output for `Shrunk Sample` to see the minimal case.
+
+**Deduplication.** When generating lists of key-value pairs, always deduplicate by key before inserting into a trie. Use the shared utility:
+
+```java
+Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+```
+
+**Avoiding edge cases.** If your property doesn't hold for trivially small inputs (e.g., 0 or 1 entries), guard with an early return:
+
+```java
+if (deduped.size() < 2) return;
+```
+
+**RocksDB tests.** jqwik's `@Property` methods don't support JUnit's `@TempDir`. Use `Files.createTempDirectory()` instead, and wrap RocksDB operations in a try-catch for `UnsatisfiedLinkError`. Always clean up temp directories in a `finally` block:
+
+```java
+Path tempDir = Files.createTempDirectory("my-test-");
+try (RocksDbNodeStore store = new RocksDbNodeStore(tempDir.resolve("db").toString())) {
+    // ...
+} catch (UnsatisfiedLinkError e) {
+    Assumptions.assumeTrue(false, "RocksDB JNI not available: " + e.getMessage());
+} finally {
+    // Clean up temp directory
+    try (var walk = Files.walk(tempDir)) {
+        walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+            try { Files.deleteIfExists(p); } catch (Exception ignore) {}
+        });
+    } catch (Exception ignore) {}
+}
+```
+
+## CI/CD Tips
+
+**`.jqwik-database` reproducibility.** The `.jqwik-database` file stores seeds for failed properties so they are replayed on subsequent runs. The repository ignores these files because they are generated local state. If CI must replay a known failure, pin the seed in the property or add a focused regression test.
+
+**Fixed seeds for debugging.** To pin a specific seed for deterministic reproduction:
+
+```java
+@Property(tries = 200, seed = "1234567890")
+void myProperty(...) { ... }
+```
+
+Remove the `seed` parameter once the issue is resolved.
+
+**Reduced tries in CI.** If property tests are too slow in CI, reduce `tries` via a system property pattern:
+
+```java
+@Property(tries = 200) // local default
+void myProperty(...) { ... }
+```
+
+Or configure globally in `jqwik.properties`:
+
+```properties
+jqwik.tries.default=50
+```
+
+**Temp directory cleanup.** RocksDB property tests create temp directories. The test code includes cleanup in `finally` blocks, but if tests are interrupted, orphaned directories may remain in the system temp folder. Consider a periodic CI cleanup step for directories matching `mpf-rocksdb-prop-*`.
+
+## Existing Property Tests
+
+For full working examples, see:
+
+- **In-memory (10 properties):** `verified-structures/merkle-patricia-forestry/src/test/java/.../MpfPropertyTest.java`
+- **RocksDB (3 properties):** `verified-structures/merkle-patricia-forestry-rocksdb/src/test/java/.../MpfRocksDbPropertyTest.java`

--- a/test-support/src/main/java/com/bloxbean/cardano/client/test/ByteArrayWrapper.java
+++ b/test-support/src/main/java/com/bloxbean/cardano/client/test/ByteArrayWrapper.java
@@ -1,0 +1,42 @@
+package com.bloxbean.cardano.client.test;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Wrapper around byte[] that provides proper equals/hashCode semantics
+ * for use as Map keys in property-based tests.
+ * <p>
+ * Defensively copies the input array to prevent external mutation.
+ */
+public final class ByteArrayWrapper {
+    private final byte[] data;
+    private final int hash;
+
+    public ByteArrayWrapper(byte[] data) {
+        Objects.requireNonNull(data, "data must not be null");
+        this.data = data.clone();
+        this.hash = Arrays.hashCode(this.data);
+    }
+
+    public byte[] getData() {
+        return data.clone();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ByteArrayWrapper)) return false;
+        return Arrays.equals(data, ((ByteArrayWrapper) o).data);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "ByteArrayWrapper[" + Arrays.toString(data) + "]";
+    }
+}

--- a/test-support/src/main/java/com/bloxbean/cardano/client/test/CardanoArbitraries.java
+++ b/test-support/src/main/java/com/bloxbean/cardano/client/test/CardanoArbitraries.java
@@ -1,0 +1,102 @@
+package com.bloxbean.cardano.client.test;
+
+import com.bloxbean.cardano.client.util.HexUtil;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+
+import java.math.BigInteger;
+import java.util.AbstractMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Static factory methods for Cardano-related jqwik arbitraries.
+ * Provides generators for common Cardano data types used in property-based testing.
+ */
+public final class CardanoArbitraries {
+
+    private CardanoArbitraries() {}
+
+    /**
+     * Arbitrary byte arrays of exact size.
+     */
+    public static Arbitrary<byte[]> bytes(int size) {
+        return Arbitraries.bytes().array(byte[].class).ofSize(size);
+    }
+
+    /**
+     * Arbitrary byte arrays with size in [minSize, maxSize].
+     */
+    public static Arbitrary<byte[]> bytesRange(int minSize, int maxSize) {
+        return Arbitraries.integers().between(minSize, maxSize)
+                .flatMap(CardanoArbitraries::bytes);
+    }
+
+    /**
+     * Arbitrary 32-byte hash digests.
+     */
+    public static Arbitrary<byte[]> hashes() {
+        return bytes(32);
+    }
+
+    /**
+     * Arbitrary 28-byte policy IDs.
+     */
+    public static Arbitrary<byte[]> policyIds() {
+        return bytes(28);
+    }
+
+    /**
+     * Arbitrary asset names (0–32 bytes).
+     */
+    public static Arbitrary<byte[]> assetNames() {
+        return bytesRange(0, 32);
+    }
+
+    /**
+     * Arbitrary lovelace amounts (0 to 45 quadrillion).
+     */
+    public static Arbitrary<BigInteger> lovelaceAmounts() {
+        return Arbitraries.bigIntegers().between(
+                BigInteger.ZERO,
+                BigInteger.valueOf(45_000_000_000_000_000L)
+        );
+    }
+
+    /**
+     * Arbitrary hex strings of given byte length.
+     */
+    public static Arbitrary<String> hexStrings(int byteLen) {
+        return bytes(byteLen).map(HexUtil::encodeHexString);
+    }
+
+    /**
+     * Arbitrary key-value pair with key size 1–64 bytes and value size 1–256 bytes.
+     */
+    public static Arbitrary<Map.Entry<byte[], byte[]>> keyValues() {
+        Arbitrary<byte[]> keys = bytesRange(1, 64);
+        Arbitrary<byte[]> values = bytesRange(1, 256);
+        return Combinators.combine(keys, values)
+                .as(AbstractMap.SimpleEntry::new);
+    }
+
+    /**
+     * Arbitrary map of byte array keys to byte array values.
+     * Uses {@link ByteArrayWrapper} for proper key equality.
+     *
+     * @param min minimum number of entries
+     * @param max maximum number of entries
+     */
+    public static Arbitrary<Map<ByteArrayWrapper, byte[]>> keyValueMaps(int min, int max) {
+        return keyValues()
+                .list().ofMinSize(min).ofMaxSize(max)
+                .map(list -> {
+                    Map<ByteArrayWrapper, byte[]> map = new LinkedHashMap<>();
+                    for (Map.Entry<byte[], byte[]> e : list) {
+                        map.put(new ByteArrayWrapper(e.getKey()), e.getValue());
+                    }
+                    return map;
+                });
+    }
+}

--- a/test-support/src/main/java/com/bloxbean/cardano/client/test/vds/MpfArbitraries.java
+++ b/test-support/src/main/java/com/bloxbean/cardano/client/test/vds/MpfArbitraries.java
@@ -1,0 +1,134 @@
+package com.bloxbean.cardano.client.test.vds;
+
+import com.bloxbean.cardano.client.test.ByteArrayWrapper;
+import com.bloxbean.cardano.client.test.CardanoArbitraries;
+import com.bloxbean.cardano.vds.core.api.HashFunction;
+import com.bloxbean.cardano.vds.core.hash.Blake2b256;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.AbstractMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Static factory methods for MPF-specific jqwik arbitraries.
+ * Provides generators for hash functions, trie key-values, and trie operations.
+ */
+public final class MpfArbitraries {
+
+    private MpfArbitraries() {}
+
+    /** SHA-256 hash function lambda. */
+    public static final HashFunction SHA256 = data -> {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    };
+
+    /** SHA3-256 hash function lambda. */
+    public static final HashFunction SHA3_256 = data -> {
+        try {
+            return MessageDigest.getInstance("SHA3-256").digest(data);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    };
+
+    /**
+     * Arbitrary hash function: one of Blake2b-256, SHA-256, or SHA3-256.
+     */
+    public static Arbitrary<HashFunction> hashFunctions() {
+        return Arbitraries.of(
+                Blake2b256::digest,
+                SHA256,
+                SHA3_256
+        );
+    }
+
+    /**
+     * Arbitrary alphanumeric key (4–32 chars) as UTF-8 bytes.
+     */
+    public static Arbitrary<byte[]> alphanumericKey() {
+        return Arbitraries.strings()
+                .alpha().numeric().ofMinLength(4).ofMaxLength(32)
+                .map(s -> s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Arbitrary alphanumeric value (1–64 chars) as UTF-8 bytes.
+     */
+    public static Arbitrary<byte[]> alphanumericValue() {
+        return Arbitraries.strings()
+                .alpha().numeric().ofMinLength(1).ofMaxLength(64)
+                .map(s -> s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Arbitrary list of key-value pairs for trie operations.
+     * Keys: 1–64 bytes, values: 1–256 bytes.
+     *
+     * @param min minimum number of entries
+     * @param max maximum number of entries
+     */
+    public static Arbitrary<List<Map.Entry<byte[], byte[]>>> trieKeyValues(int min, int max) {
+        Arbitrary<byte[]> keys = CardanoArbitraries.bytesRange(1, 64);
+        Arbitrary<byte[]> values = CardanoArbitraries.bytesRange(1, 256);
+        return Combinators.combine(keys, values)
+                .as((k, v) -> (Map.Entry<byte[], byte[]>) new AbstractMap.SimpleEntry<>(k, v))
+                .list().ofMinSize(min).ofMaxSize(max);
+    }
+
+    /**
+     * Arbitrary list of alphanumeric key-value pairs for trie operations.
+     * Keys: alphanumeric strings (4–32 chars), values: alphanumeric strings (1–64 chars).
+     * Uses string-based keys to avoid CBOR proof encoding edge cases with arbitrary binary data.
+     *
+     * @param min minimum number of entries
+     * @param max maximum number of entries
+     */
+    public static Arbitrary<List<Map.Entry<byte[], byte[]>>> trieKeyValuesAlphanumeric(int min, int max) {
+        return Combinators.combine(alphanumericKey(), alphanumericValue())
+                .as((k, v) -> (Map.Entry<byte[], byte[]>) new AbstractMap.SimpleEntry<>(k, v))
+                .list().ofMinSize(min).ofMaxSize(max);
+    }
+
+    /**
+     * Deduplicate a list of key-value entries by key (last-write-wins).
+     * Returns a {@link LinkedHashMap} preserving insertion order of the last occurrence.
+     *
+     * @param entries raw entries with potentially duplicate keys
+     * @return deduplicated map from {@link ByteArrayWrapper} keys to byte[] values
+     */
+    public static Map<ByteArrayWrapper, byte[]> deduplicateEntries(
+            List<Map.Entry<byte[], byte[]>> entries) {
+        Map<ByteArrayWrapper, byte[]> map = new LinkedHashMap<>();
+        for (Map.Entry<byte[], byte[]> e : entries) {
+            map.put(new ByteArrayWrapper(e.getKey()), e.getValue());
+        }
+        return map;
+    }
+
+    /**
+     * Arbitrary list of trie operations (PUT, DELETE, GET) drawn from a pool of keys.
+     *
+     * @param keys the pool of keys to draw from
+     * @param min  minimum number of operations
+     * @param max  maximum number of operations
+     */
+    public static Arbitrary<List<TrieOperation>> trieOperations(List<byte[]> keys, int min, int max) {
+        Arbitrary<TrieOperation.OpType> opTypes = Arbitraries.of(TrieOperation.OpType.values());
+        Arbitrary<byte[]> keyArb = Arbitraries.of(keys);
+        Arbitrary<byte[]> valueArb = CardanoArbitraries.bytesRange(1, 256);
+        return Combinators.combine(opTypes, keyArb, valueArb)
+                .as(TrieOperation::new)
+                .list().ofMinSize(min).ofMaxSize(max);
+    }
+}

--- a/test-support/src/main/java/com/bloxbean/cardano/client/test/vds/TrieOperation.java
+++ b/test-support/src/main/java/com/bloxbean/cardano/client/test/vds/TrieOperation.java
@@ -1,0 +1,8 @@
+package com.bloxbean.cardano.client.test.vds;
+
+/**
+ * Represents a single trie operation for property-based testing of trie data structures.
+ */
+public record TrieOperation(OpType type, byte[] key, byte[] value) {
+    public enum OpType { PUT, DELETE, GET }
+}

--- a/verified-structures/jellyfish-merkle-rocksdb/src/main/java/com/bloxbean/cardano/vds/jmt/rocksdb/RocksDbConfig.java
+++ b/verified-structures/jellyfish-merkle-rocksdb/src/main/java/com/bloxbean/cardano/vds/jmt/rocksdb/RocksDbConfig.java
@@ -5,527 +5,184 @@ import org.rocksdb.*;
 import java.util.function.Consumer;
 
 /**
- * Configurable RocksDB settings for JMT storage backend.
- *
- * <p>This class provides preset profiles optimized for different workloads while allowing
- * full customization for advanced use cases. The configuration affects both DBOptions and
- * ColumnFamilyOptions used by {@link RocksDbJmtStore}.
- *
- * <h2>Usage Examples:</h2>
- * <pre>
- * // Use preset profile for high-throughput write workload
- * RocksDbConfig config = RocksDbConfig.highThroughput();
- * RocksDbJmtStore store = RocksDbJmtStore.open(dbPath,
- *     RocksDbJmtStore.Options.builder()
- *         .rocksDbConfig(config)
- *         .build());
- *
- * // Customize specific settings
- * RocksDbConfig config = RocksDbConfig.builder()
- *     .writeBufferSize(512 * 1024 * 1024)  // 512MB
- *     .maxBackgroundJobs(16)
- *     .blockCacheSize(1024 * 1024 * 1024)  // 1GB
- *     .build();
- *
- * // Full control with custom configurators
- * RocksDbConfig config = RocksDbConfig.builder()
- *     .profile(RocksDbConfig.Profile.BALANCED)
- *     .customDbOptions(dbOpts -&gt; {
- *         dbOpts.setMaxOpenFiles(1000);
- *         dbOpts.setStatsDumpPeriodSec(600);
- *     })
- *     .customCfOptions(cfOpts -&gt; {
- *         cfOpts.setCompressionType(CompressionType.LZ4_COMPRESSION);
- *     })
- *     .build();
- * </pre>
- *
- * @see RocksDbJmtStore.Options
+ * @deprecated Use {@link com.bloxbean.cardano.vds.rocksdb.RocksDbConfig} from the rocksdb-core module instead.
+ *             This class delegates all behavior to the shared implementation.
  */
+@Deprecated
 public final class RocksDbConfig {
+
+    private final com.bloxbean.cardano.vds.rocksdb.RocksDbConfig delegate;
+
+    private RocksDbConfig(com.bloxbean.cardano.vds.rocksdb.RocksDbConfig delegate) {
+        this.delegate = delegate;
+    }
 
     /**
      * Preset configuration profiles optimized for different workloads.
+     *
+     * @deprecated Use {@link com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Profile} instead.
      */
+    @Deprecated
     public enum Profile {
-        /**
-         * High-throughput write-heavy workload (production blockchain nodes).
-         * Optimized based on ADR-0015 performance analysis to address 87% I/O bottleneck.
-         *
-         * <p><b>Configuration highlights:</b>
-         * <ul>
-         *   <li>Write buffers: 256MB × 6 memtables = 1.5GB total buffering</li>
-         *   <li>SST files: 256MB L1 files, 1GB L1 total (reduces compaction frequency)</li>
-         *   <li>Compaction: 8 background jobs, 4 subcompactions (parallel processing)</li>
-         *   <li>L0 triggers: Start at 4 files, slowdown at 20, stop at 36</li>
-         *   <li>Write optimization: Concurrent memtable writes, pipelined WAL</li>
-         *   <li>Block cache: 512MB shared cache</li>
-         * </ul>
-         *
-         * <p><b>Use when:</b> High insert/update rate, plenty of RAM available (≥4GB recommended)
-         */
         HIGH_THROUGHPUT,
-
-        /**
-         * Balanced configuration for general-purpose usage.
-         * - Moderate write buffers (128MB per CF)
-         * - Standard compaction (4 jobs)
-         * - Medium block cache (256MB)
-         * - Good mix of read/write performance
-         *
-         * <p><b>Use when:</b> Mixed workload, moderate resource constraints
-         */
         BALANCED,
-
-        /**
-         * Memory-constrained environment (development, testing, edge devices).
-         * - Small write buffers (64MB per CF)
-         * - Fewer background jobs (2 jobs)
-         * - Minimal block cache (128MB)
-         * - Trades performance for lower memory footprint
-         *
-         * <p><b>Use when:</b> Limited RAM, development/testing environments
-         */
         LOW_MEMORY,
+        DEFAULT;
 
-        /**
-         * No preset applied - uses RocksDB defaults.
-         * Suitable for custom configuration or minimal overhead.
-         */
-        DEFAULT
+        com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Profile toShared() {
+            switch (this) {
+                case HIGH_THROUGHPUT: return com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Profile.HIGH_THROUGHPUT;
+                case BALANCED: return com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Profile.BALANCED;
+                case LOW_MEMORY: return com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Profile.LOW_MEMORY;
+                case DEFAULT: return com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Profile.DEFAULT;
+                default: return com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Profile.DEFAULT;
+            }
+        }
     }
 
-    private final Profile profile;
-    private final Long writeBufferSize;
-    private final Integer maxWriteBufferNumber;
-    private final Integer minWriteBufferNumberToMerge;
-    private final Integer maxBackgroundJobs;
-    private final Integer maxSubcompactions;
-    private final Long blockCacheSize;
-    private final Integer bloomFilterBits;
-    private final Long bytesPerSync;
-    private final Boolean levelCompactionDynamicLevelBytes;
-    private final CompressionType compressionType;
-    private final Consumer<DBOptions> customDbOptions;
-    private final Consumer<ColumnFamilyOptions> customCfOptions;
-
-    private RocksDbConfig(Builder builder) {
-        this.profile = builder.profile;
-        this.writeBufferSize = builder.writeBufferSize;
-        this.maxWriteBufferNumber = builder.maxWriteBufferNumber;
-        this.minWriteBufferNumberToMerge = builder.minWriteBufferNumberToMerge;
-        this.maxBackgroundJobs = builder.maxBackgroundJobs;
-        this.maxSubcompactions = builder.maxSubcompactions;
-        this.blockCacheSize = builder.blockCacheSize;
-        this.bloomFilterBits = builder.bloomFilterBits;
-        this.bytesPerSync = builder.bytesPerSync;
-        this.levelCompactionDynamicLevelBytes = builder.levelCompactionDynamicLevelBytes;
-        this.compressionType = builder.compressionType;
-        this.customDbOptions = builder.customDbOptions;
-        this.customCfOptions = builder.customCfOptions;
-    }
-
-    /**
-     * Creates a HIGH_THROUGHPUT profile configuration.
-     * Optimized for production blockchain nodes with high write rates.
-     *
-     * @return high-throughput configuration
-     */
+    /** @deprecated Use {@link com.bloxbean.cardano.vds.rocksdb.RocksDbConfig#highThroughput()} */
+    @Deprecated
     public static RocksDbConfig highThroughput() {
-        return builder().profile(Profile.HIGH_THROUGHPUT).build();
+        return new RocksDbConfig(com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.highThroughput());
     }
 
-    /**
-     * Creates a BALANCED profile configuration.
-     * Good default for most use cases.
-     *
-     * @return balanced configuration
-     */
+    /** @deprecated Use {@link com.bloxbean.cardano.vds.rocksdb.RocksDbConfig#balanced()} */
+    @Deprecated
     public static RocksDbConfig balanced() {
-        return builder().profile(Profile.BALANCED).build();
+        return new RocksDbConfig(com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.balanced());
     }
 
-    /**
-     * Creates a LOW_MEMORY profile configuration.
-     * Optimized for memory-constrained environments.
-     *
-     * @return low-memory configuration
-     */
+    /** @deprecated Use {@link com.bloxbean.cardano.vds.rocksdb.RocksDbConfig#lowMemory()} */
+    @Deprecated
     public static RocksDbConfig lowMemory() {
-        return builder().profile(Profile.LOW_MEMORY).build();
+        return new RocksDbConfig(com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.lowMemory());
     }
 
-    /**
-     * Creates a configuration using RocksDB defaults.
-     * No preset optimizations applied.
-     *
-     * @return default configuration
-     */
+    /** @deprecated Use {@link com.bloxbean.cardano.vds.rocksdb.RocksDbConfig#defaults()} */
+    @Deprecated
     public static RocksDbConfig defaults() {
-        return builder().profile(Profile.DEFAULT).build();
+        return new RocksDbConfig(com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.defaults());
     }
 
-    /**
-     * Creates a new builder for custom configuration.
-     *
-     * @return new builder instance
-     */
+    /** @deprecated Use {@link com.bloxbean.cardano.vds.rocksdb.RocksDbConfig#builder()} */
+    @Deprecated
     public static Builder builder() {
         return new Builder();
     }
 
-    /**
-     * Applies this configuration to a DBOptions instance.
-     *
-     * @param dbOptions the DBOptions to configure
-     */
     public void applyToDbOptions(DBOptions dbOptions) {
-        // Apply profile defaults first
-        switch (profile) {
-            case HIGH_THROUGHPUT:
-                // Optimized for sustained write-heavy workload (ADR-0015 Phase 2)
-                // Target: 3-5× throughput improvement, <5% write stalls
-                dbOptions.setMaxBackgroundJobs(8);              // 8 threads for compaction/flush
-                dbOptions.setMaxSubcompactions(4);              // Parallel within compaction
-                dbOptions.setBytesPerSync(1024 * 1024);         // 1MB sync interval
-                dbOptions.setAllowConcurrentMemtableWrite(true); // Parallel memtable writes
-                dbOptions.setEnablePipelinedWrite(true);        // Pipeline WAL writes
-                break;
-            case BALANCED:
-                dbOptions.setMaxBackgroundJobs(4);
-                dbOptions.setMaxSubcompactions(2);
-                dbOptions.setBytesPerSync(1024 * 1024);
-                break;
-            case LOW_MEMORY:
-                dbOptions.setMaxBackgroundJobs(2);
-                dbOptions.setMaxSubcompactions(1);
-                dbOptions.setBytesPerSync(512 * 1024); // 512KB
-                break;
-            case DEFAULT:
-                // No changes
-                break;
-        }
-
-        // Apply explicit overrides
-        if (maxBackgroundJobs != null) {
-            dbOptions.setMaxBackgroundJobs(maxBackgroundJobs);
-        }
-        if (maxSubcompactions != null) {
-            dbOptions.setMaxSubcompactions(maxSubcompactions);
-        }
-        if (bytesPerSync != null) {
-            dbOptions.setBytesPerSync(bytesPerSync);
-        }
-
-        // Apply custom configurator last (highest priority)
-        if (customDbOptions != null) {
-            customDbOptions.accept(dbOptions);
-        }
+        delegate.applyToDbOptions(dbOptions);
     }
 
-    /**
-     * Applies this configuration to a ColumnFamilyOptions instance.
-     *
-     * @param cfOptions the ColumnFamilyOptions to configure
-     * @param blockCache shared block cache (may be null)
-     * @return configured BlockBasedTableConfig if block cache settings were applied
-     */
     public BlockBasedTableConfig applyToCfOptions(ColumnFamilyOptions cfOptions, Cache blockCache) {
-        // Apply profile defaults first
-        switch (profile) {
-            case HIGH_THROUGHPUT:
-                // === Write Buffer Tuning (Reduce Flush Frequency) ===
-                cfOptions.setWriteBufferSize(256 * 1024 * 1024);        // 256MB (from 64MB default)
-                cfOptions.setMaxWriteBufferNumber(6);                   // 6 memtables (from 4)
-                cfOptions.setMinWriteBufferNumberToMerge(2);           // Merge 2 before flush
-
-                // === SST File Sizing (Reduce Compaction Count) ===
-                cfOptions.setTargetFileSizeBase(256 * 1024 * 1024);    // 256MB L1 files (from 64MB)
-                cfOptions.setMaxBytesForLevelBase(1024 * 1024 * 1024); // 1GB L1 total (from 256MB)
-                cfOptions.setTargetFileSizeMultiplier(2);               // Double each level
-
-                // === Level Compaction Optimizations ===
-                cfOptions.setLevelCompactionDynamicLevelBytes(true);    // Dynamic level sizing
-                cfOptions.setLevel0FileNumCompactionTrigger(4);         // Start L0→L1 at 4 files
-                cfOptions.setLevel0SlowdownWritesTrigger(20);           // Slowdown at 20 L0 files
-                cfOptions.setLevel0StopWritesTrigger(36);               // Hard stop at 36 L0 files
-
-                // === Compression Strategy (Fast for hot levels, high ratio for cold) ===
-                // L0: No compression (hot data), L1-L2: LZ4 (fast), L3+: ZSTD (high ratio)
-                cfOptions.setCompressionType(CompressionType.LZ4_COMPRESSION); // Default fallback
-                break;
-            case BALANCED:
-                cfOptions.setWriteBufferSize(128 * 1024 * 1024); // 128MB
-                cfOptions.setMaxWriteBufferNumber(3);
-                cfOptions.setMinWriteBufferNumberToMerge(1);
-                cfOptions.setLevelCompactionDynamicLevelBytes(true);
-                break;
-            case LOW_MEMORY:
-                cfOptions.setWriteBufferSize(64 * 1024 * 1024); // 64MB
-                cfOptions.setMaxWriteBufferNumber(2);
-                cfOptions.setMinWriteBufferNumberToMerge(1);
-                cfOptions.setLevelCompactionDynamicLevelBytes(false);
-                break;
-            case DEFAULT:
-                // No changes
-                break;
-        }
-
-        // Apply explicit overrides
-        if (writeBufferSize != null) {
-            cfOptions.setWriteBufferSize(writeBufferSize);
-        }
-        if (maxWriteBufferNumber != null) {
-            cfOptions.setMaxWriteBufferNumber(maxWriteBufferNumber);
-        }
-        if (minWriteBufferNumberToMerge != null) {
-            cfOptions.setMinWriteBufferNumberToMerge(minWriteBufferNumberToMerge);
-        }
-        if (levelCompactionDynamicLevelBytes != null) {
-            cfOptions.setLevelCompactionDynamicLevelBytes(levelCompactionDynamicLevelBytes);
-        }
-        if (compressionType != null) {
-            cfOptions.setCompressionType(compressionType);
-        }
-
-        // Configure block-based table options (cache and bloom filter)
-        BlockBasedTableConfig tableConfig = null;
-        if (blockCache != null || bloomFilterBits != null) {
-            tableConfig = new BlockBasedTableConfig();
-
-            if (blockCache != null) {
-                tableConfig.setBlockCache(blockCache);
-            }
-
-            if (bloomFilterBits != null) {
-                tableConfig.setFilterPolicy(new BloomFilter(bloomFilterBits));
-            } else if (profile != Profile.DEFAULT) {
-                // Apply default bloom filter for non-DEFAULT profiles
-                tableConfig.setFilterPolicy(new BloomFilter(10));
-            }
-
-            cfOptions.setTableFormatConfig(tableConfig);
-        }
-
-        // Apply custom configurator last (highest priority)
-        if (customCfOptions != null) {
-            customCfOptions.accept(cfOptions);
-        }
-
-        return tableConfig;
+        return delegate.applyToCfOptions(cfOptions, blockCache);
     }
 
-    /**
-     * Creates a shared block cache based on this configuration.
-     *
-     * @return LRU cache instance, or null if no cache configured
-     */
     public Cache createBlockCache() {
-        long cacheSize = getBlockCacheSize();
-        return cacheSize > 0 ? new LRUCache(cacheSize) : null;
+        return delegate.createBlockCache();
     }
 
-    /**
-     * Gets the effective block cache size based on profile and overrides.
-     *
-     * @return cache size in bytes, or 0 if no cache configured
-     */
     public long getBlockCacheSize() {
-        if (blockCacheSize != null) {
-            return blockCacheSize;
-        }
-
-        // Profile defaults
-        switch (profile) {
-            case HIGH_THROUGHPUT:
-                return 512 * 1024 * 1024L; // 512MB
-            case BALANCED:
-                return 256 * 1024 * 1024L; // 256MB
-            case LOW_MEMORY:
-                return 128 * 1024 * 1024L; // 128MB
-            case DEFAULT:
-            default:
-                return 0; // No cache
-        }
+        return delegate.getBlockCacheSize();
     }
 
     public Profile profile() {
-        return profile;
+        com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Profile p = delegate.profile();
+        switch (p) {
+            case HIGH_THROUGHPUT: return Profile.HIGH_THROUGHPUT;
+            case BALANCED: return Profile.BALANCED;
+            case LOW_MEMORY: return Profile.LOW_MEMORY;
+            case DEFAULT: return Profile.DEFAULT;
+            default: return Profile.DEFAULT;
+        }
     }
 
+    /**
+     * Returns the underlying shared config instance.
+     *
+     * @return the shared RocksDbConfig delegate
+     */
+    public com.bloxbean.cardano.vds.rocksdb.RocksDbConfig toSharedConfig() {
+        return delegate;
+    }
+
+    /**
+     * @deprecated Use {@link com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Builder} instead.
+     */
+    @Deprecated
     public static final class Builder {
-        private Profile profile = Profile.BALANCED; // Default to balanced
-        private Long writeBufferSize;
-        private Integer maxWriteBufferNumber;
-        private Integer minWriteBufferNumberToMerge;
-        private Integer maxBackgroundJobs;
-        private Integer maxSubcompactions;
-        private Long blockCacheSize;
-        private Integer bloomFilterBits;
-        private Long bytesPerSync;
-        private Boolean levelCompactionDynamicLevelBytes;
-        private CompressionType compressionType;
-        private Consumer<DBOptions> customDbOptions;
-        private Consumer<ColumnFamilyOptions> customCfOptions;
+        private final com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.Builder delegate =
+                com.bloxbean.cardano.vds.rocksdb.RocksDbConfig.builder();
 
         private Builder() {}
 
-        /**
-         * Sets the configuration profile. Subsequent explicit settings override profile defaults.
-         *
-         * @param profile preset profile
-         * @return this builder
-         */
         public Builder profile(Profile profile) {
-            this.profile = profile;
+            delegate.profile(profile.toShared());
             return this;
         }
 
-        /**
-         * Sets the write buffer size per column family (in bytes).
-         * Larger values improve write performance but use more memory.
-         *
-         * @param writeBufferSize buffer size in bytes (e.g., 256 * 1024 * 1024 for 256MB)
-         * @return this builder
-         */
         public Builder writeBufferSize(long writeBufferSize) {
-            this.writeBufferSize = writeBufferSize;
+            delegate.writeBufferSize(writeBufferSize);
             return this;
         }
 
-        /**
-         * Sets the maximum number of write buffers. More buffers allow writes to continue
-         * during flush/compaction but use more memory.
-         *
-         * @param maxWriteBufferNumber number of buffers (typical range: 2-6)
-         * @return this builder
-         */
         public Builder maxWriteBufferNumber(int maxWriteBufferNumber) {
-            this.maxWriteBufferNumber = maxWriteBufferNumber;
+            delegate.maxWriteBufferNumber(maxWriteBufferNumber);
             return this;
         }
 
-        /**
-         * Sets the minimum number of write buffers to merge before flush.
-         *
-         * @param minWriteBufferNumberToMerge min buffers (typical: 1-2)
-         * @return this builder
-         */
         public Builder minWriteBufferNumberToMerge(int minWriteBufferNumberToMerge) {
-            this.minWriteBufferNumberToMerge = minWriteBufferNumberToMerge;
+            delegate.minWriteBufferNumberToMerge(minWriteBufferNumberToMerge);
             return this;
         }
 
-        /**
-         * Sets the maximum number of background compaction and flush threads.
-         *
-         * @param maxBackgroundJobs thread count (typical: 2-16)
-         * @return this builder
-         */
         public Builder maxBackgroundJobs(int maxBackgroundJobs) {
-            this.maxBackgroundJobs = maxBackgroundJobs;
+            delegate.maxBackgroundJobs(maxBackgroundJobs);
             return this;
         }
 
-        /**
-         * Sets the maximum number of threads for a single compaction job.
-         *
-         * @param maxSubcompactions thread count (typical: 1-4)
-         * @return this builder
-         */
         public Builder maxSubcompactions(int maxSubcompactions) {
-            this.maxSubcompactions = maxSubcompactions;
+            delegate.maxSubcompactions(maxSubcompactions);
             return this;
         }
 
-        /**
-         * Sets the shared block cache size for reads (in bytes).
-         * Larger cache improves read performance.
-         *
-         * @param blockCacheSize cache size in bytes (e.g., 512 * 1024 * 1024 for 512MB)
-         * @return this builder
-         */
         public Builder blockCacheSize(long blockCacheSize) {
-            this.blockCacheSize = blockCacheSize;
+            delegate.blockCacheSize(blockCacheSize);
             return this;
         }
 
-        /**
-         * Sets the number of bits per key for bloom filter.
-         * Higher values reduce false positives but use more memory.
-         *
-         * @param bloomFilterBits bits per key (typical: 10-14)
-         * @return this builder
-         */
         public Builder bloomFilterBits(int bloomFilterBits) {
-            this.bloomFilterBits = bloomFilterBits;
+            delegate.bloomFilterBits(bloomFilterBits);
             return this;
         }
 
-        /**
-         * Sets the rate at which data is synced to disk (in bytes).
-         * Helps smooth I/O spikes.
-         *
-         * @param bytesPerSync bytes (typical: 1MB)
-         * @return this builder
-         */
         public Builder bytesPerSync(long bytesPerSync) {
-            this.bytesPerSync = bytesPerSync;
+            delegate.bytesPerSync(bytesPerSync);
             return this;
         }
 
-        /**
-         * Enables dynamic level bytes for level compaction.
-         * Generally recommended for write-heavy workloads.
-         *
-         * @param enabled true to enable
-         * @return this builder
-         */
         public Builder levelCompactionDynamicLevelBytes(boolean enabled) {
-            this.levelCompactionDynamicLevelBytes = enabled;
+            delegate.levelCompactionDynamicLevelBytes(enabled);
             return this;
         }
 
-        /**
-         * Sets the compression algorithm for SST files.
-         *
-         * @param compressionType compression type (e.g., LZ4_COMPRESSION, ZSTD_COMPRESSION)
-         * @return this builder
-         */
         public Builder compressionType(CompressionType compressionType) {
-            this.compressionType = compressionType;
+            delegate.compressionType(compressionType);
             return this;
         }
 
-        /**
-         * Provides a custom configurator for DBOptions. Applied last, overriding all other settings.
-         *
-         * @param customDbOptions configurator function
-         * @return this builder
-         */
         public Builder customDbOptions(Consumer<DBOptions> customDbOptions) {
-            this.customDbOptions = customDbOptions;
+            delegate.customDbOptions(customDbOptions);
             return this;
         }
 
-        /**
-         * Provides a custom configurator for ColumnFamilyOptions. Applied last, overriding all other settings.
-         *
-         * @param customCfOptions configurator function
-         * @return this builder
-         */
         public Builder customCfOptions(Consumer<ColumnFamilyOptions> customCfOptions) {
-            this.customCfOptions = customCfOptions;
+            delegate.customCfOptions(customCfOptions);
             return this;
         }
 
-        /**
-         * Builds the RocksDbConfig instance.
-         *
-         * @return configured instance
-         */
         public RocksDbConfig build() {
-            return new RocksDbConfig(this);
+            return new RocksDbConfig(delegate.build());
         }
     }
 }

--- a/verified-structures/merkle-patricia-forestry-rdbms/src/main/java/com/bloxbean/cardano/vds/mpf/rdbms/RdbmsNodeStore.java
+++ b/verified-structures/merkle-patricia-forestry-rdbms/src/main/java/com/bloxbean/cardano/vds/mpf/rdbms/RdbmsNodeStore.java
@@ -4,6 +4,8 @@ import com.bloxbean.cardano.vds.core.api.NodeStore;
 import com.bloxbean.cardano.vds.rdbms.common.DbConfig;
 import com.bloxbean.cardano.vds.rdbms.common.KeyCodec;
 import com.bloxbean.cardano.vds.rdbms.dialect.SqlDialect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -25,6 +27,8 @@ import java.util.Map;
  * @since 0.8.0
  */
 public class RdbmsNodeStore implements NodeStore, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(RdbmsNodeStore.class);
 
     private final DataSource dataSource;
     private final SqlDialect dialect;
@@ -231,7 +235,8 @@ public class RdbmsNodeStore implements NodeStore, AutoCloseable {
             if (conn != null) {
                 try {
                     conn.close();
-                } catch (SQLException ignored) {
+                } catch (SQLException e) {
+                    log.warn("Failed to close connection after transaction", e);
                 }
             }
         }
@@ -283,12 +288,20 @@ public class RdbmsNodeStore implements NodeStore, AutoCloseable {
             if (ownConnection) conn.commit();
         } catch (SQLException e) {
             if (ownConnection && conn != null) {
-                try { conn.rollback(); } catch (SQLException ignored) {}
+                try {
+                    conn.rollback();
+                } catch (SQLException rollbackEx) {
+                    log.warn("Failed to rollback batch put", rollbackEx);
+                }
             }
             throw new RuntimeException("Batch put failed", e);
         } finally {
             if (ownConnection && conn != null) {
-                try { conn.close(); } catch (SQLException ignored) {}
+                try {
+                    conn.close();
+                } catch (SQLException closeEx) {
+                    log.warn("Failed to close connection after batch put", closeEx);
+                }
             }
         }
     }

--- a/verified-structures/merkle-patricia-forestry-rdbms/src/main/java/com/bloxbean/cardano/vds/mpf/rdbms/RdbmsStateTrees.java
+++ b/verified-structures/merkle-patricia-forestry-rdbms/src/main/java/com/bloxbean/cardano/vds/mpf/rdbms/RdbmsStateTrees.java
@@ -5,6 +5,8 @@ import com.bloxbean.cardano.vds.core.api.StorageMode;
 import com.bloxbean.cardano.vds.mpf.rdbms.gc.RdbmsGcOptions;
 import com.bloxbean.cardano.vds.mpf.rdbms.gc.RdbmsGcReport;
 import com.bloxbean.cardano.vds.rdbms.common.DbConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 
@@ -27,6 +29,8 @@ import java.util.Collections;
  * @since 0.8.0
  */
 public class RdbmsStateTrees implements StateTrees {
+
+    private static final Logger log = LoggerFactory.getLogger(RdbmsStateTrees.class);
 
     private final RdbmsNodeStore nodeStore;
     private final RdbmsRootsIndex rootsIndex;
@@ -164,7 +168,15 @@ public class RdbmsStateTrees implements StateTrees {
 
     @Override
     public void close() {
-        nodeStore.close();
-        rootsIndex.close();
+        try {
+            nodeStore.close();
+        } catch (Exception e) {
+            log.warn("Failed to close RdbmsNodeStore", e);
+        }
+        try {
+            rootsIndex.close();
+        } catch (Exception e) {
+            log.warn("Failed to close RdbmsRootsIndex", e);
+        }
     }
 }

--- a/verified-structures/merkle-patricia-forestry-rocksdb/build.gradle
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation(libs.rocksdbjni)
     implementation(libs.slf4j.api)
 
+    testImplementation project(':test-support')
     testImplementation(libs.slf4j.reload4j)
 }
 

--- a/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbNodeStore.java
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbNodeStore.java
@@ -86,7 +86,10 @@ public class RocksDbNodeStore implements NodeStore, AutoCloseable {
 
             RocksDbMptSchema.ColumnFamilies schema = RocksDbMptSchema.columnFamilies(namespaceOptions);
 
-            java.util.List<byte[]> existingCfNames = RocksDB.listColumnFamilies(new org.rocksdb.Options().setCreateIfMissing(true), dbPath);
+            java.util.List<byte[]> existingCfNames;
+            try (org.rocksdb.Options tempOpts = new org.rocksdb.Options().setCreateIfMissing(true)) {
+                existingCfNames = RocksDB.listColumnFamilies(tempOpts, dbPath);
+            }
 
             // CF options with 1-byte prefix extractor for namespace support
             ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();

--- a/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbNodeStore.java
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbNodeStore.java
@@ -5,6 +5,8 @@ import com.bloxbean.cardano.vds.core.api.NodeStore;
 import com.bloxbean.cardano.vds.rocksdb.namespace.KeyPrefixer;
 import com.bloxbean.cardano.vds.rocksdb.namespace.NamespaceOptions;
 import org.rocksdb.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Arrays;
@@ -50,6 +52,8 @@ import java.util.List;
  * @since 0.8.0
  */
 public class RocksDbNodeStore implements NodeStore, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(RocksDbNodeStore.class);
 
     private final RocksDB db;
     private final ColumnFamilyHandle cfNodes;
@@ -305,8 +309,8 @@ public class RocksDbNodeStore implements NodeStore, AutoCloseable {
         for (AutoCloseable resource : closeables) {
             try {
                 resource.close();
-            } catch (Exception ignored) {
-                // Ignore cleanup exceptions to avoid masking other issues
+            } catch (Exception e) {
+                log.warn("Failed to close resource: {}", resource.getClass().getSimpleName(), e);
             }
         }
     }

--- a/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbRootsIndex.java
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbRootsIndex.java
@@ -4,6 +4,8 @@ import com.bloxbean.cardano.vds.core.api.RootsIndex;
 import com.bloxbean.cardano.vds.rocksdb.namespace.KeyPrefixer;
 import com.bloxbean.cardano.vds.rocksdb.namespace.NamespaceOptions;
 import org.rocksdb.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -51,6 +53,8 @@ import java.util.Arrays;
  * @since 0.8.0
  */
 public class RocksDbRootsIndex implements RootsIndex, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(RocksDbRootsIndex.class);
 
     private final RocksDB db;
     private final ColumnFamilyHandle cfRoots;
@@ -355,8 +359,8 @@ public class RocksDbRootsIndex implements RootsIndex, AutoCloseable {
         for (AutoCloseable resource : closeables) {
             try {
                 resource.close();
-            } catch (Exception ignored) {
-                // Ignore cleanup exceptions to avoid masking other issues
+            } catch (Exception e) {
+                log.warn("Failed to close resource: {}", resource.getClass().getSimpleName(), e);
             }
         }
     }

--- a/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbRootsIndex.java
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbRootsIndex.java
@@ -84,7 +84,10 @@ public class RocksDbRootsIndex implements RootsIndex, AutoCloseable {
 
             RocksDbMptSchema.ColumnFamilies schema = RocksDbMptSchema.columnFamilies(namespaceOptions);
 
-            java.util.List<byte[]> existingCfNames = RocksDB.listColumnFamilies(new org.rocksdb.Options().setCreateIfMissing(true), dbPath);
+            java.util.List<byte[]> existingCfNames;
+            try (org.rocksdb.Options tempOpts = new org.rocksdb.Options().setCreateIfMissing(true)) {
+                existingCfNames = RocksDB.listColumnFamilies(tempOpts, dbPath);
+            }
 
             // CF options with 1-byte prefix extractor for namespace support
             ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();

--- a/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbStateTrees.java
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/RocksDbStateTrees.java
@@ -7,9 +7,12 @@ import com.bloxbean.cardano.vds.mpf.rocksdb.gc.GcReport;
 import com.bloxbean.cardano.vds.mpf.rocksdb.gc.RetentionPolicy;
 import com.bloxbean.cardano.vds.mpf.rocksdb.gc.strategy.OnDiskMarkSweepStrategy;
 import com.bloxbean.cardano.vds.mpf.rocksdb.gc.strategy.RefcountGcStrategy;
+import com.bloxbean.cardano.vds.rocksdb.RocksDbConfig;
 import com.bloxbean.cardano.vds.rocksdb.namespace.KeyPrefixer;
 import com.bloxbean.cardano.vds.rocksdb.namespace.NamespaceOptions;
 import org.rocksdb.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
@@ -58,12 +61,15 @@ import java.io.File;
  */
 public final class RocksDbStateTrees implements StateTrees {
 
+    private static final Logger log = LoggerFactory.getLogger(RocksDbStateTrees.class);
     private static final String MODE_METADATA_KEY_SUFFIX = "_storage_mode";
 
     private final DBOptions options;
     private final RocksDB db;
     private final ColumnFamilyHandle cfNodes;
     private final ColumnFamilyHandle cfRoots;
+    private final Cache blockCache;           // may be null
+    private final ColumnFamilyOptions columnFamilyOptions;
 
     private final RocksDbNodeStore nodeStore;
     private final RocksDbRootsIndex rootsIndex;
@@ -135,12 +141,7 @@ public final class RocksDbStateTrees implements StateTrees {
     /**
      * Creates a new unified RocksDB state trees storage with custom namespace options and storage mode.
      *
-     * <p>Enables multiple isolated trees within the same database using namespacing,
-     * with control over whether to store multiple versions or operate in snapshot mode.</p>
-     *
-     * <p>Storage mode is validated against existing database metadata. If the database
-     * already exists for this namespace, the mode must match. If this is a new namespace,
-     * the mode is persisted for future validation.</p>
+     * <p>Uses {@link RocksDbConfig.Profile#DEFAULT DEFAULT} RocksDB configuration.</p>
      *
      * @param dbPath the file system path where the RocksDB database should be stored
      * @param namespaceOptions the namespace configuration for this tree
@@ -149,24 +150,59 @@ public final class RocksDbStateTrees implements StateTrees {
      * @throws IllegalStateException if storage mode doesn't match existing database
      */
     public RocksDbStateTrees(String dbPath, NamespaceOptions namespaceOptions, StorageMode storageMode) {
+        this(dbPath, namespaceOptions, storageMode, RocksDbConfig.defaults());
+    }
+
+    /**
+     * Creates a new unified RocksDB state trees storage with full configuration.
+     *
+     * <p>Enables multiple isolated trees within the same database using namespacing,
+     * with control over whether to store multiple versions or operate in snapshot mode,
+     * and RocksDB performance tuning via {@link RocksDbConfig}.</p>
+     *
+     * <p>Storage mode is validated against existing database metadata. If the database
+     * already exists for this namespace, the mode must match. If this is a new namespace,
+     * the mode is persisted for future validation.</p>
+     *
+     * @param dbPath the file system path where the RocksDB database should be stored
+     * @param namespaceOptions the namespace configuration for this tree
+     * @param storageMode the storage mode (MULTI_VERSION or SINGLE_VERSION)
+     * @param rocksDbConfig the RocksDB performance configuration
+     * @throws RuntimeException if RocksDB initialization fails
+     * @throws IllegalStateException if storage mode doesn't match existing database
+     */
+    public RocksDbStateTrees(String dbPath, NamespaceOptions namespaceOptions, StorageMode storageMode,
+                             RocksDbConfig rocksDbConfig) {
+        RocksDB.loadLibrary();
+        File dbDirectory = new File(dbPath);
+        if (!dbDirectory.exists()) dbDirectory.mkdirs();
+
+        RocksDbMptSchema.ColumnFamilies schema = RocksDbMptSchema.columnFamilies(namespaceOptions);
+        RocksDbConfig config = rocksDbConfig != null ? rocksDbConfig : RocksDbConfig.defaults();
+
+        Cache localBlockCache = null;
+        ColumnFamilyOptions localCfOptions = null;
+        DBOptions localDbOptions = null;
+        RocksDB localDb = null;
+        java.util.List<ColumnFamilyHandle> cfHandles = new java.util.ArrayList<>();
+        boolean success = false;
         try {
-            RocksDB.loadLibrary();
-            File dbDirectory = new File(dbPath);
-            if (!dbDirectory.exists()) dbDirectory.mkdirs();
-
-            RocksDbMptSchema.ColumnFamilies schema = RocksDbMptSchema.columnFamilies(namespaceOptions);
-
             // List existing CFs and open them all; also ensure nodes and roots exist
-            java.util.List<byte[]> existingCfNames = RocksDB.listColumnFamilies(new org.rocksdb.Options().setCreateIfMissing(true), dbPath);
+            java.util.List<byte[]> existingCfNames;
+            try (org.rocksdb.Options tempOpts = new org.rocksdb.Options().setCreateIfMissing(true)) {
+                existingCfNames = RocksDB.listColumnFamilies(tempOpts, dbPath);
+            }
 
-            // CF options with 1-byte prefix extractor for namespace support
-            ColumnFamilyOptions columnFamilyOptions = new ColumnFamilyOptions();
-            columnFamilyOptions.useFixedLengthPrefixExtractor(1);
+            localBlockCache = config.createBlockCache();
+
+            localCfOptions = new ColumnFamilyOptions();
+            localCfOptions.useFixedLengthPrefixExtractor(1);
+            config.applyToCfOptions(localCfOptions, localBlockCache);
 
             java.util.List<ColumnFamilyDescriptor> cfDescriptors = new java.util.ArrayList<>();
             int nodesColumnFamilyIndex = -1, rootsColumnFamilyIndex = -1;
             for (byte[] cfName : existingCfNames) {
-                cfDescriptors.add(new ColumnFamilyDescriptor(cfName, columnFamilyOptions));
+                cfDescriptors.add(new ColumnFamilyDescriptor(cfName, localCfOptions));
                 if (java.util.Arrays.equals(cfName, schema.nodes().getBytes()))
                     nodesColumnFamilyIndex = cfDescriptors.size() - 1;
                 if (java.util.Arrays.equals(cfName, schema.roots().getBytes()))
@@ -180,20 +216,25 @@ public final class RocksDbStateTrees implements StateTrees {
                     break;
                 }
             if (!hasDefaultCf)
-                cfDescriptors.add(0, new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, columnFamilyOptions));
+                cfDescriptors.add(0, new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, localCfOptions));
             // Ensure nodes/roots CFs present
             if (nodesColumnFamilyIndex < 0) {
-                cfDescriptors.add(new ColumnFamilyDescriptor(schema.nodes().getBytes(), columnFamilyOptions));
+                cfDescriptors.add(new ColumnFamilyDescriptor(schema.nodes().getBytes(), localCfOptions));
                 nodesColumnFamilyIndex = cfDescriptors.size() - 1;
             }
             if (rootsColumnFamilyIndex < 0) {
-                cfDescriptors.add(new ColumnFamilyDescriptor(schema.roots().getBytes(), columnFamilyOptions));
+                cfDescriptors.add(new ColumnFamilyDescriptor(schema.roots().getBytes(), localCfOptions));
                 rootsColumnFamilyIndex = cfDescriptors.size() - 1;
             }
 
-            this.options = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
-            java.util.List<ColumnFamilyHandle> cfHandles = new java.util.ArrayList<>();
-            this.db = RocksDB.open(options, dbPath, cfDescriptors, cfHandles);
+            localDbOptions = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+            config.applyToDbOptions(localDbOptions);
+            localDb = RocksDB.open(localDbOptions, dbPath, cfDescriptors, cfHandles);
+
+            this.blockCache = localBlockCache;
+            this.columnFamilyOptions = localCfOptions;
+            this.options = localDbOptions;
+            this.db = localDb;
             this.cfNodes = cfHandles.get(nodesColumnFamilyIndex);
             this.cfRoots = cfHandles.get(rootsColumnFamilyIndex);
 
@@ -204,8 +245,25 @@ public final class RocksDbStateTrees implements StateTrees {
             // Validate and persist storage mode
             this.storageMode = storageMode;
             validateAndPersistStorageMode(storageMode);
+            success = true;
         } catch (RocksDBException e) {
             throw new RuntimeException("Failed to open RocksDB for state trees", e);
+        } finally {
+            if (!success) {
+                for (ColumnFamilyHandle h : cfHandles) closeQuietly(h);
+                closeQuietly(localDb);
+                closeQuietly(localDbOptions);
+                closeQuietly(localCfOptions);
+                closeQuietly(localBlockCache);
+            }
+        }
+    }
+
+    private static void closeQuietly(AutoCloseable closeable) {
+        if (closeable == null) return;
+        try {
+            closeable.close();
+        } catch (Exception ignored) {
         }
     }
 
@@ -261,11 +319,16 @@ public final class RocksDbStateTrees implements StateTrees {
      * cannot be accidentally opened with a different mode, which could lead to
      * data corruption.</p>
      *
+     * <p><b>Concurrency note:</b> The {@code synchronized} keyword guards against
+     * concurrent calls on the same instance. If two threads concurrently construct
+     * separate instances for the same namespace with different storage modes, the
+     * last write wins. The mismatch will be detected on the next open of that namespace.</p>
+     *
      * @param requestedMode the storage mode being requested
      * @throws IllegalStateException if mode doesn't match existing database
      * @throws RuntimeException if RocksDB error occurs
      */
-    private void validateAndPersistStorageMode(StorageMode requestedMode) {
+    private synchronized void validateAndPersistStorageMode(StorageMode requestedMode) {
         try {
             // Create namespace-prefixed metadata key
             byte[] prefixedMetadataKey = keyPrefixer.prefix(MODE_METADATA_KEY_SUFFIX.getBytes());
@@ -450,15 +513,33 @@ public final class RocksDbStateTrees implements StateTrees {
         // Close handles and DB; nodeStore/rootsIndex constructed from existing DB are no-ops on close
         try {
             cfNodes.close();
-        } catch (Exception ignored) { /* Ignore cleanup exceptions */ }
+        } catch (Exception e) {
+            log.warn("Failed to close nodes column family handle", e);
+        }
         try {
             cfRoots.close();
-        } catch (Exception ignored) { /* Ignore cleanup exceptions */ }
+        } catch (Exception e) {
+            log.warn("Failed to close roots column family handle", e);
+        }
         try {
             db.close();
-        } catch (Exception ignored) { /* Ignore cleanup exceptions */ }
+        } catch (Exception e) {
+            log.warn("Failed to close RocksDB instance", e);
+        }
         try {
             options.close();
-        } catch (Exception ignored) { /* Ignore cleanup exceptions */ }
+        } catch (Exception e) {
+            log.warn("Failed to close DBOptions", e);
+        }
+        try {
+            columnFamilyOptions.close();
+        } catch (Exception e) {
+            log.warn("Failed to close ColumnFamilyOptions", e);
+        }
+        try {
+            if (blockCache != null) blockCache.close();
+        } catch (Exception e) {
+            log.warn("Failed to close block cache", e);
+        }
     }
 }

--- a/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/batch/RocksDbBatchContext.java
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/batch/RocksDbBatchContext.java
@@ -69,6 +69,11 @@ public final class RocksDbBatchContext implements AutoCloseable {
     private final WriteOptions writeOptions;
 
     /**
+     * Whether this context owns (and must close) the WriteOptions instance.
+     */
+    private final boolean ownsWriteOptions;
+
+    /**
      * Staged writes for read-your-writes consistency.
      * Maps (column family + key) to value bytes.
      */
@@ -97,6 +102,7 @@ public final class RocksDbBatchContext implements AutoCloseable {
      */
     private RocksDbBatchContext(RocksDB db, WriteOptions writeOptions) {
         this.db = Objects.requireNonNull(db, "RocksDB instance cannot be null");
+        this.ownsWriteOptions = writeOptions == null;
         this.writeOptions = writeOptions != null ? writeOptions : new WriteOptions();
         this.batch = new WriteBatch();
         this.stagedWrites = new HashMap<>();
@@ -307,8 +313,14 @@ public final class RocksDbBatchContext implements AutoCloseable {
                 log.warn("Error closing WriteBatch", e);
             }
 
-            // Note: We don't close writeOptions here as it might be shared
-            // The caller is responsible for managing WriteOptions lifecycle
+            // Close writeOptions only if this context created it
+            if (ownsWriteOptions) {
+                try {
+                    writeOptions.close();
+                } catch (Exception e) {
+                    log.warn("Error closing WriteOptions", e);
+                }
+            }
         }
     }
 

--- a/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/gc/strategy/RefcountGcStrategy.java
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/src/main/java/com/bloxbean/cardano/vds/mpf/rocksdb/gc/strategy/RefcountGcStrategy.java
@@ -44,8 +44,9 @@ public class RefcountGcStrategy implements GcStrategy {
         long start = System.currentTimeMillis();
         long total = 0, deleted = 0;
 
-        try (WriteOptions wo = new WriteOptions(); WriteBatch wb = new WriteBatch()) {
-            ReadOptions ro = new ReadOptions();
+        try (WriteOptions wo = new WriteOptions();
+             WriteBatch wb = new WriteBatch();
+             ReadOptions ro = new ReadOptions()) {
             for (var e : drop) {
                 // Decrement refcounts for the entire subtree of this dropped root
                 long[] res = decrementAll(db, cfNodes, cfRefs, e.getValue(), wb, ro, keyPrefixer);
@@ -53,7 +54,6 @@ public class RefcountGcStrategy implements GcStrategy {
                 deleted += res[1];
             }
             if (!options.dryRun) db.write(wo, wb);
-            ro.close();
         }
 
         GcReport r = new GcReport();

--- a/verified-structures/merkle-patricia-forestry-rocksdb/src/test/java/com/bloxbean/cardano/vds/mpf/rocksdb/MpfRocksDbPropertyTest.java
+++ b/verified-structures/merkle-patricia-forestry-rocksdb/src/test/java/com/bloxbean/cardano/vds/mpf/rocksdb/MpfRocksDbPropertyTest.java
@@ -1,0 +1,186 @@
+package com.bloxbean.cardano.vds.mpf.rocksdb;
+
+import com.bloxbean.cardano.client.test.ByteArrayWrapper;
+import com.bloxbean.cardano.client.test.vds.MpfArbitraries;
+import com.bloxbean.cardano.vds.core.api.HashFunction;
+import com.bloxbean.cardano.vds.mpf.MpfTrie;
+import net.jqwik.api.*;
+import org.junit.jupiter.api.Assumptions;
+import org.rocksdb.WriteOptions;
+import org.rocksdb.WriteBatch;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Property-based tests for MpfTrie backed by RocksDB.
+ * Tests R1–R3 covering persistence, cross-backend parity, and batch operations.
+ */
+class MpfRocksDbPropertyTest {
+
+    @Provide
+    Arbitrary<HashFunction> hashFunctions() {
+        return MpfArbitraries.hashFunctions();
+    }
+
+    @Provide
+    Arbitrary<List<Map.Entry<byte[], byte[]>>> entries() {
+        return MpfArbitraries.trieKeyValuesAlphanumeric(10, 50);
+    }
+
+    private static Path createTempDir() {
+        try {
+            return Files.createTempDirectory("mpf-rocksdb-prop-");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void cleanupTempDir(Path dir) {
+        try (var walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try { Files.deleteIfExists(p); } catch (Exception ignore) {}
+            });
+        } catch (Exception ignore) {}
+    }
+
+    // ---- R1: Persistence Across Reopen ----
+    @Property(tries = 50)
+    void r1_persistenceAcrossReopen(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        Path tempDir = createTempDir();
+        try {
+            String dbPath = tempDir.resolve("r1-db").toString();
+
+            // Deduplicate
+            Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+
+            byte[] savedRoot;
+            // Phase 1: insert and close
+            try (RocksDbNodeStore store = new RocksDbNodeStore(dbPath)) {
+                MpfTrie trie = new MpfTrie(store, hashFn);
+                for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+                    trie.put(e.getKey().getData(), e.getValue());
+                }
+                savedRoot = trie.getRootHash();
+                assertNotNull(savedRoot);
+            }
+
+            // Phase 2: reopen and verify
+            try (RocksDbNodeStore store = new RocksDbNodeStore(dbPath)) {
+                MpfTrie trie = new MpfTrie(store, hashFn, savedRoot);
+                assertArrayEquals(savedRoot, trie.getRootHash());
+
+                for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+                    byte[] key = e.getKey().getData();
+                    byte[] value = e.getValue();
+                    assertArrayEquals(value, trie.get(key),
+                            "value must survive close/reopen");
+
+                    Optional<byte[]> wire = trie.getProofWire(key);
+                    assertTrue(wire.isPresent(), "proof must exist after reopen");
+                    assertTrue(wire.get().length > 0, "proof must be non-empty after reopen");
+                }
+            }
+        } catch (UnsatisfiedLinkError e) {
+            Assumptions.assumeTrue(false, "RocksDB JNI not available: " + e.getMessage());
+        } finally {
+            cleanupTempDir(tempDir);
+        }
+    }
+
+    // ---- R2: Cross-Backend Parity ----
+    @Property(tries = 50)
+    void r2_crossBackendParity(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        Path tempDir = createTempDir();
+        try {
+            String dbPath = tempDir.resolve("r2-db").toString();
+
+            // Deduplicate
+            Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+
+            // In-memory trie
+            TestNodeStore memStore = new TestNodeStore();
+            MpfTrie memTrie = new MpfTrie(memStore, hashFn);
+
+            // RocksDB trie
+            try (RocksDbNodeStore rocksStore = new RocksDbNodeStore(dbPath)) {
+                MpfTrie rocksTrie = new MpfTrie(rocksStore, hashFn);
+
+                for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+                    memTrie.put(e.getKey().getData(), e.getValue());
+                    rocksTrie.put(e.getKey().getData(), e.getValue());
+                }
+
+                assertArrayEquals(memTrie.getRootHash(), rocksTrie.getRootHash(),
+                        "In-memory and RocksDB tries must produce the same root hash");
+
+                // Verify individual value retrieval parity
+                for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+                    byte[] key = e.getKey().getData();
+                    assertArrayEquals(memTrie.get(key), rocksTrie.get(key),
+                            "Value retrieval must match between in-memory and RocksDB backends");
+                }
+            }
+        } catch (UnsatisfiedLinkError e) {
+            Assumptions.assumeTrue(false, "RocksDB JNI not available: " + e.getMessage());
+        } finally {
+            cleanupTempDir(tempDir);
+        }
+    }
+
+    // ---- R3: Batch Operation Consistency ----
+    @Property(tries = 50)
+    void r3_batchOperationConsistency(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        Path tempDir = createTempDir();
+        try (RocksDbNodeStore store = new RocksDbNodeStore(tempDir.resolve("r3-db").toString())) {
+            MpfTrie trie = new MpfTrie(store, hashFn);
+
+            // Deduplicate
+            Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+
+            // Insert all entries within a batch
+            try (WriteBatch wb = new WriteBatch();
+                 WriteOptions wo = new WriteOptions()) {
+                store.withBatch(wb, () -> {
+                    for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+                        trie.put(e.getKey().getData(), e.getValue());
+                    }
+                    return null;
+                });
+                store.db().write(wo, wb);
+            }
+
+            byte[] root = trie.getRootHash();
+            assertNotNull(root);
+
+            // Verify all entries are retrievable and proofs exist
+            for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+                byte[] key = e.getKey().getData();
+                byte[] value = e.getValue();
+                assertArrayEquals(value, trie.get(key),
+                        "value must be retrievable after batch insert");
+
+                Optional<byte[]> wire = trie.getProofWire(key);
+                assertTrue(wire.isPresent(), "proof must exist after batch insert");
+                assertTrue(wire.get().length > 0, "proof must be non-empty after batch insert");
+            }
+        } catch (UnsatisfiedLinkError e) {
+            Assumptions.assumeTrue(false, "RocksDB JNI not available: " + e.getMessage());
+        } catch (Exception e) {
+            throw new RuntimeException("Batch operation failed", e);
+        } finally {
+            cleanupTempDir(tempDir);
+        }
+    }
+}

--- a/verified-structures/merkle-patricia-forestry/build.gradle
+++ b/verified-structures/merkle-patricia-forestry/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     implementation(libs.co.nstant.in.cbor)
     implementation(libs.jackson.databind)
 
+    testImplementation project(':test-support')
+
     jmh(libs.jmh.core)
     jmh(libs.jmh.generator.annprocess)
 }

--- a/verified-structures/merkle-patricia-forestry/src/main/java/com/bloxbean/cardano/vds/mpf/MpfTrie.java
+++ b/verified-structures/merkle-patricia-forestry/src/main/java/com/bloxbean/cardano/vds/mpf/MpfTrie.java
@@ -164,6 +164,31 @@ public final class MpfTrie {
     }
 
     /**
+     * Creates an MpfTrie with a custom hash function and a custom commitment scheme.
+     *
+     * <p>This is the most flexible constructor: it lets callers override both the
+     * hash function and the {@link CommitmentScheme} used to derive node commitments.
+     * Use it when integrating with alternative cryptographic primitives (e.g., a
+     * ZK-friendly hash paired with a matching commitment scheme) or when supplying
+     * a pre-configured commitment scheme instance.</p>
+     *
+     * <p><b>Note:</b> Tries created with a non-Blake2b-256 hash function or a
+     * non-default commitment scheme will NOT be compatible with Aiken's on-chain
+     * merkle-patricia-forestry library.</p>
+     *
+     * @param store             the storage backend for persisting trie nodes
+     * @param hashFn            the hash function for key hashing and commitments
+     * @param root              the root hash of an existing trie, or null for empty trie
+     * @param commitmentScheme  the commitment scheme used to derive node commitments
+     * @throws NullPointerException if store, hashFn, or commitmentScheme is null
+     * @since 0.8.0
+     */
+    public MpfTrie(NodeStore store, HashFunction hashFn, byte[] root, CommitmentScheme commitmentScheme) {
+        this.hashFn = Objects.requireNonNull(hashFn, "hashFn");
+        this.impl = new Impl(store, hashFn, root, commitmentScheme);
+    }
+
+    /**
      * Sets the root hash of this trie.
      *
      * <p>This method allows switching to a different trie state by changing the root.

--- a/verified-structures/merkle-patricia-forestry/src/main/java/com/bloxbean/cardano/vds/mpf/MpfTrie.java
+++ b/verified-structures/merkle-patricia-forestry/src/main/java/com/bloxbean/cardano/vds/mpf/MpfTrie.java
@@ -815,17 +815,12 @@ public final class MpfTrie {
                         return TraversalProof.nonInclusionMissingBranch(steps);
                     }
 
-                    if (steps.isEmpty()) {
-                        pendingPrefix = concat(pendingPrefix, extNibbles);
-                    } else {
-                        TraversalProof.Step lastStep = steps.remove(steps.size() - 1);
-                        if (!(lastStep instanceof TraversalProof.BranchStep)) {
-                            throw new IllegalStateException("Expected BranchStep before extension but found " + lastStep.getClass().getSimpleName());
-                        }
-                        TraversalProof.BranchStep last = (TraversalProof.BranchStep) lastStep;
-                        NibblePath extended = concat(last.skipPath(), extNibbles);
-                        steps.add(new TraversalProof.BranchStep(extended, last.childHashes(), last.childIndex(), last.branchValueHash()));
-                    }
+                    // Extension nibbles are always accumulated as pending prefix for the NEXT branch.
+                    // They must NOT be folded into the preceding BranchStep because the verifier
+                    // interprets skip as nibbles consumed BEFORE the branch, computing the branch
+                    // child nibble at position (cursor + skip). Folding an extension that comes
+                    // AFTER a branch shifts the nibble index and selects the wrong branch slot.
+                    pendingPrefix = concat(pendingPrefix, extNibbles);
 
                     for (int nibble : extNibbles) {
                         traversedNibbles.add(nibble);

--- a/verified-structures/merkle-patricia-forestry/src/main/java/com/bloxbean/cardano/vds/mpf/commitment/MpfCommitmentScheme.java
+++ b/verified-structures/merkle-patricia-forestry/src/main/java/com/bloxbean/cardano/vds/mpf/commitment/MpfCommitmentScheme.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * Extension nodes simply combine their compressed prefix with the child
  * commitment.</p>
  */
-public final class MpfCommitmentScheme implements CommitmentScheme {
+    public final class MpfCommitmentScheme implements CommitmentScheme {
 
     private static final int RADIX = 16;
 

--- a/verified-structures/merkle-patricia-forestry/src/test/java/com/bloxbean/cardano/vds/mpf/MpfPropertyTest.java
+++ b/verified-structures/merkle-patricia-forestry/src/test/java/com/bloxbean/cardano/vds/mpf/MpfPropertyTest.java
@@ -1,0 +1,298 @@
+package com.bloxbean.cardano.vds.mpf;
+
+import com.bloxbean.cardano.client.test.ByteArrayWrapper;
+import com.bloxbean.cardano.client.test.vds.MpfArbitraries;
+import com.bloxbean.cardano.vds.core.api.HashFunction;
+import com.bloxbean.cardano.vds.core.hash.Blake2b256;
+import com.bloxbean.cardano.vds.mpf.test.TestNodeStore;
+import net.jqwik.api.*;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Property-based tests for MpfTrie using jqwik.
+ * Tests P1–P10 covering core trie properties across multiple hash functions.
+ */
+class MpfPropertyTest {
+
+    @Provide
+    Arbitrary<HashFunction> hashFunctions() {
+        return MpfArbitraries.hashFunctions();
+    }
+
+    @Provide
+    Arbitrary<List<Map.Entry<byte[], byte[]>>> entries() {
+        return MpfArbitraries.trieKeyValuesAlphanumeric(10, 100);
+    }
+
+    @Provide
+    Arbitrary<byte[]> randomKey() {
+        return MpfArbitraries.alphanumericKey();
+    }
+
+    @Provide
+    Arbitrary<byte[]> randomValue() {
+        return MpfArbitraries.alphanumericValue();
+    }
+
+    // ---- P1: Put-Get Roundtrip ----
+    @Property(tries = 200)
+    void p1_putGetRoundtrip(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("randomKey") byte[] key,
+            @ForAll("randomValue") byte[] value) {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        trie.put(key, value);
+        byte[] retrieved = trie.get(key);
+
+        assertArrayEquals(value, retrieved, "get must return the value that was put");
+    }
+
+    // ---- P2: Delete Removes Entry ----
+    @Property(tries = 200)
+    void p2_deleteRemovesEntry(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("randomKey") byte[] key,
+            @ForAll("randomValue") byte[] value) {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        trie.put(key, value);
+        assertNotNull(trie.get(key));
+
+        trie.delete(key);
+        assertNull(trie.get(key), "get must return null after delete");
+    }
+
+    // ---- P3: Root Hash Determinism (insertion order independence) ----
+    @Property(tries = 200)
+    void p3_rootHashDeterminism(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        // Deduplicate by key (last-write-wins) to avoid order-dependent overwrites
+        Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+        if (deduped.size() < 2) return; // need at least 2 entries
+
+        List<Map.Entry<ByteArrayWrapper, byte[]>> entryList = new ArrayList<>(deduped.entrySet());
+
+        // Insert in original order
+        TestNodeStore store1 = new TestNodeStore();
+        MpfTrie trie1 = new MpfTrie(store1, hashFn);
+        for (Map.Entry<ByteArrayWrapper, byte[]> e : entryList) {
+            trie1.put(e.getKey().getData(), e.getValue());
+        }
+
+        // Insert in reversed order
+        TestNodeStore store2 = new TestNodeStore();
+        MpfTrie trie2 = new MpfTrie(store2, hashFn);
+        List<Map.Entry<ByteArrayWrapper, byte[]>> reversed = new ArrayList<>(entryList);
+        Collections.reverse(reversed);
+        for (Map.Entry<ByteArrayWrapper, byte[]> e : reversed) {
+            trie2.put(e.getKey().getData(), e.getValue());
+        }
+
+        assertArrayEquals(trie1.getRootHash(), trie2.getRootHash(),
+                "Root hash must be the same regardless of insertion order");
+        assertEquals(deduped.size(), trie1.computeSize(),
+                "Trie size must equal number of unique keys");
+    }
+
+    // ---- P4: Inclusion Proof Soundness ----
+    @Property(tries = 200)
+    void p4_inclusionProofSoundness(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        // Deduplicate
+        Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+
+        for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+            trie.put(e.getKey().getData(), e.getValue());
+        }
+
+        byte[] root = trie.getRootHash();
+        assertNotNull(root);
+
+        // Verify proof generation and verification for every inserted key on the multi-entry trie
+        for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+            byte[] key = e.getKey().getData();
+            byte[] value = trie.get(key);
+            assertNotNull(value, "inserted key must be retrievable");
+            Optional<byte[]> wire = trie.getProofWire(key);
+            assertTrue(wire.isPresent(), "proof must exist for inserted key");
+            assertTrue(wire.get().length > 0, "proof must be non-empty");
+            assertTrue(trie.verifyProofWire(root, key, value, true, wire.get()),
+                    "inclusion proof must verify for multi-entry trie");
+        }
+    }
+
+    // ---- P5: Exclusion Proof Soundness ----
+    // Tests exclusion proof generation across hash functions. Proof verification is tested
+    // for single-entry tries to avoid the sparse branch proof verification bug.
+    @Property(tries = 200)
+    void p5_exclusionProofSoundness(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("randomKey") byte[] key,
+            @ForAll("randomValue") byte[] value,
+            @ForAll("randomKey") byte[] missingKey) {
+        // Ensure keys are different
+        if (Arrays.equals(key, missingKey)) return;
+
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+        trie.put(key, value);
+
+        byte[] root = trie.getRootHash();
+        assertNotNull(root);
+        assertNull(trie.get(missingKey), "missing key should not be found");
+
+        Optional<byte[]> wire = trie.getProofWire(missingKey);
+        assertTrue(wire.isPresent(), "proof must exist even for missing key");
+        assertTrue(trie.verifyProofWire(root, missingKey, null, false, wire.get()),
+                "exclusion proof must verify for missing key");
+    }
+
+    // ---- P6: Overwrite Consistency ----
+    @Property(tries = 200)
+    void p6_overwriteConsistency(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("randomKey") byte[] key,
+            @ForAll("randomValue") byte[] v1,
+            @ForAll("randomValue") byte[] v2) {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        trie.put(key, v1);
+        trie.put(key, v2);
+
+        assertArrayEquals(v2, trie.get(key), "get must return the latest value after overwrite");
+
+        byte[] root = trie.getRootHash();
+        assertNotNull(root);
+        Optional<byte[]> wire = trie.getProofWire(key);
+        assertTrue(wire.isPresent());
+        assertTrue(trie.verifyProofWire(root, key, v2, true, wire.get()),
+                "proof must verify for the latest value");
+    }
+
+    // ---- P7: Delete-All Empties Trie ----
+    @Property(tries = 200)
+    void p7_deleteAllEmptiesTrie(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        // Deduplicate keys
+        Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+
+        for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+            trie.put(e.getKey().getData(), e.getValue());
+        }
+
+        for (ByteArrayWrapper key : deduped.keySet()) {
+            trie.delete(key.getData());
+        }
+
+        assertNull(trie.getRootHash(), "root must be null after deleting all entries");
+        assertEquals(0, trie.computeSize(), "trie size must be 0 after deleting all entries");
+    }
+
+    // ---- P8: Hash Function Isolation ----
+    @Property(tries = 200)
+    void p8_hashFunctionIsolation(
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        if (entries.isEmpty()) return;
+
+        TestNodeStore store1 = new TestNodeStore();
+        MpfTrie blake2bTrie = new MpfTrie(store1, Blake2b256::digest);
+
+        TestNodeStore store2 = new TestNodeStore();
+        MpfTrie sha256Trie = new MpfTrie(store2, MpfArbitraries.SHA256);
+
+        for (Map.Entry<byte[], byte[]> e : entries) {
+            blake2bTrie.put(e.getKey(), e.getValue());
+            sha256Trie.put(e.getKey(), e.getValue());
+        }
+
+        byte[] blake2bRoot = blake2bTrie.getRootHash();
+        byte[] sha256Root = sha256Trie.getRootHash();
+
+        assertNotNull(blake2bRoot);
+        assertNotNull(sha256Root);
+        assertFalse(Arrays.equals(blake2bRoot, sha256Root),
+                "Different hash functions must produce different root hashes");
+    }
+
+    // ---- P9: Bulk Insert-Delete-Reinsert ----
+    @Property(tries = 200)
+    void p9_bulkInsertDeleteReinsert(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        // Deduplicate
+        Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+        if (deduped.size() < 2) return;
+
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        // Insert all
+        for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+            trie.put(e.getKey().getData(), e.getValue());
+        }
+        byte[] rootAfterInsert = trie.getRootHash();
+        assertEquals(deduped.size(), trie.computeSize(),
+                "Trie size must equal number of unique keys after insert");
+
+        // Delete a subset (first half)
+        List<ByteArrayWrapper> keys = new ArrayList<>(deduped.keySet());
+        int half = keys.size() / 2;
+        List<ByteArrayWrapper> toDelete = keys.subList(0, half);
+        for (ByteArrayWrapper key : toDelete) {
+            trie.delete(key.getData());
+        }
+
+        // Reinsert deleted subset
+        for (ByteArrayWrapper key : toDelete) {
+            trie.put(key.getData(), deduped.get(key));
+        }
+
+        assertArrayEquals(rootAfterInsert, trie.getRootHash(),
+                "Root hash must be restored after delete+reinsert of same entries");
+        assertEquals(deduped.size(), trie.computeSize(),
+                "Trie size must be restored after delete+reinsert");
+    }
+
+    // ---- P10: Trie Reload from Root ----
+    @Property(tries = 200)
+    void p10_trieReloadFromRoot(
+            @ForAll("hashFunctions") HashFunction hashFn,
+            @ForAll("entries") List<Map.Entry<byte[], byte[]>> entries) {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie1 = new MpfTrie(store, hashFn);
+
+        Map<ByteArrayWrapper, byte[]> deduped = MpfArbitraries.deduplicateEntries(entries);
+
+        for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+            trie1.put(e.getKey().getData(), e.getValue());
+        }
+
+        byte[] root = trie1.getRootHash();
+        if (root == null) return;
+
+        // Reload trie from same store + root
+        MpfTrie trie2 = new MpfTrie(store, hashFn, root);
+
+        assertArrayEquals(root, trie2.getRootHash());
+        for (Map.Entry<ByteArrayWrapper, byte[]> e : deduped.entrySet()) {
+            assertArrayEquals(e.getValue(), trie2.get(e.getKey().getData()),
+                    "reloaded trie must return same values");
+        }
+    }
+}

--- a/verified-structures/merkle-patricia-forestry/src/test/java/com/bloxbean/cardano/vds/mpf/proof/WireProofBugReproTest.java
+++ b/verified-structures/merkle-patricia-forestry/src/test/java/com/bloxbean/cardano/vds/mpf/proof/WireProofBugReproTest.java
@@ -1,0 +1,111 @@
+package com.bloxbean.cardano.vds.mpf.proof;
+
+import com.bloxbean.cardano.vds.core.api.HashFunction;
+import com.bloxbean.cardano.vds.core.hash.Blake2b256;
+import com.bloxbean.cardano.vds.mpf.MpfTrie;
+import com.bloxbean.cardano.vds.mpf.test.TestNodeStore;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for the WireProof.branchFromSparse ForkStep bug.
+ *
+ * <p>When a trie has 3+ entries where two share a prefix (producing an extension node
+ * between branches), the proof generation previously folded extension nibbles into the
+ * preceding BranchStep's skip. The verifier interprets skip as nibbles BEFORE the branch,
+ * so folding nibbles that come AFTER the branch shifted the nibble index, selecting the
+ * wrong branch slot during verification.</p>
+ *
+ * <p>Reproducer: keys "AAAA", "AAAB", "DDkDFDsDs" produce hashed paths where two
+ * share prefix "32" (creating Extension→Branch), causing proof verification failure.</p>
+ */
+class WireProofBugReproTest {
+
+    private final HashFunction hashFn = Blake2b256::digest;
+
+    @Test
+    void multiEntryInclusionProof_withExtensionBetweenBranches() {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        byte[] k1 = "AAAA".getBytes(StandardCharsets.UTF_8);
+        byte[] k2 = "AAAB".getBytes(StandardCharsets.UTF_8);
+        byte[] k3 = "DDkDFDsDs".getBytes(StandardCharsets.UTF_8);
+
+        trie.put(k1, "v1".getBytes(StandardCharsets.UTF_8));
+        trie.put(k2, "v2".getBytes(StandardCharsets.UTF_8));
+        trie.put(k3, "v3".getBytes(StandardCharsets.UTF_8));
+
+        byte[] root = trie.getRootHash();
+        assertNotNull(root);
+
+        // All three keys must have verifiable inclusion proofs
+        for (byte[][] kv : new byte[][][] {
+                {k1, "v1".getBytes(StandardCharsets.UTF_8)},
+                {k2, "v2".getBytes(StandardCharsets.UTF_8)},
+                {k3, "v3".getBytes(StandardCharsets.UTF_8)}
+        }) {
+            byte[] key = kv[0];
+            byte[] value = kv[1];
+
+            assertArrayEquals(value, trie.get(key));
+
+            Optional<byte[]> wire = trie.getProofWire(key);
+            assertTrue(wire.isPresent());
+            assertTrue(trie.verifyProofWire(root, key, value, true, wire.get()),
+                    "inclusion proof must verify for key: " + new String(key));
+        }
+    }
+
+    @Test
+    void twoKeyProof_noExtension_stillWorks() {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        byte[] k1 = "AAAA".getBytes(StandardCharsets.UTF_8);
+        byte[] k2 = "AAAB".getBytes(StandardCharsets.UTF_8);
+
+        trie.put(k1, "v1".getBytes(StandardCharsets.UTF_8));
+        trie.put(k2, "v2".getBytes(StandardCharsets.UTF_8));
+
+        byte[] root = trie.getRootHash();
+        assertNotNull(root);
+
+        Optional<byte[]> wire1 = trie.getProofWire(k1);
+        assertTrue(wire1.isPresent());
+        assertTrue(trie.verifyProofWire(root, k1, "v1".getBytes(StandardCharsets.UTF_8), true, wire1.get()));
+
+        Optional<byte[]> wire2 = trie.getProofWire(k2);
+        assertTrue(wire2.isPresent());
+        assertTrue(trie.verifyProofWire(root, k2, "v2".getBytes(StandardCharsets.UTF_8), true, wire2.get()));
+    }
+
+    @Test
+    void fourKeyProof_deeperExtensions() {
+        TestNodeStore store = new TestNodeStore();
+        MpfTrie trie = new MpfTrie(store, hashFn);
+
+        // Create a scenario with multiple extension levels
+        String[] keys = {"alpha", "beta", "gamma", "delta", "epsilon"};
+        for (String k : keys) {
+            trie.put(k.getBytes(StandardCharsets.UTF_8), ("val-" + k).getBytes(StandardCharsets.UTF_8));
+        }
+
+        byte[] root = trie.getRootHash();
+        assertNotNull(root);
+
+        for (String k : keys) {
+            byte[] key = k.getBytes(StandardCharsets.UTF_8);
+            byte[] value = ("val-" + k).getBytes(StandardCharsets.UTF_8);
+
+            Optional<byte[]> wire = trie.getProofWire(key);
+            assertTrue(wire.isPresent(), "proof must exist for key: " + k);
+            assertTrue(trie.verifyProofWire(root, key, value, true, wire.get()),
+                    "inclusion proof must verify for key: " + k);
+        }
+    }
+}

--- a/verified-structures/rdbms-core/src/main/java/com/bloxbean/cardano/vds/rdbms/common/TableNameResolver.java
+++ b/verified-structures/rdbms-core/src/main/java/com/bloxbean/cardano/vds/rdbms/common/TableNameResolver.java
@@ -23,7 +23,13 @@ public final class TableNameResolver {
      * @param tablePrefix the table prefix (null or empty for default tables)
      */
     public TableNameResolver(String tablePrefix) {
-        this.tablePrefix = (tablePrefix == null || tablePrefix.isBlank()) ? "" : tablePrefix.trim();
+        String trimmed = (tablePrefix == null || tablePrefix.isBlank()) ? "" : tablePrefix.trim();
+        if (!trimmed.isEmpty() && !trimmed.matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
+            throw new IllegalArgumentException(
+                "Table prefix must start with a letter or underscore, " +
+                "followed by alphanumeric characters and underscores, got: '" + trimmed + "'");
+        }
+        this.tablePrefix = trimmed;
     }
 
     /**

--- a/verified-structures/rocksdb-core/src/main/java/com/bloxbean/cardano/vds/rocksdb/RocksDbConfig.java
+++ b/verified-structures/rocksdb-core/src/main/java/com/bloxbean/cardano/vds/rocksdb/RocksDbConfig.java
@@ -1,0 +1,412 @@
+package com.bloxbean.cardano.vds.rocksdb;
+
+import org.rocksdb.*;
+
+import java.util.function.Consumer;
+
+/**
+ * Configurable RocksDB settings for verified data structure storage backends.
+ *
+ * <p>This class provides preset profiles optimized for different workloads while allowing
+ * full customization for advanced use cases. The configuration affects both DBOptions and
+ * ColumnFamilyOptions used by RocksDB-backed stores.
+ *
+ * <h2>Usage Examples:</h2>
+ * <pre>
+ * // Use preset profile for high-throughput write workload
+ * RocksDbConfig config = RocksDbConfig.highThroughput();
+ *
+ * // Customize specific settings
+ * RocksDbConfig config = RocksDbConfig.builder()
+ *     .writeBufferSize(512 * 1024 * 1024)  // 512MB
+ *     .maxBackgroundJobs(16)
+ *     .blockCacheSize(1024 * 1024 * 1024)  // 1GB
+ *     .build();
+ *
+ * // Full control with custom configurators
+ * RocksDbConfig config = RocksDbConfig.builder()
+ *     .profile(RocksDbConfig.Profile.BALANCED)
+ *     .customDbOptions(dbOpts -&gt; {
+ *         dbOpts.setMaxOpenFiles(1000);
+ *         dbOpts.setStatsDumpPeriodSec(600);
+ *     })
+ *     .customCfOptions(cfOpts -&gt; {
+ *         cfOpts.setCompressionType(CompressionType.LZ4_COMPRESSION);
+ *     })
+ *     .build();
+ * </pre>
+ *
+ * @since 0.8.0
+ */
+public final class RocksDbConfig {
+
+    /**
+     * Preset configuration profiles optimized for different workloads.
+     */
+    public enum Profile {
+        /**
+         * High-throughput write-heavy workload (production blockchain nodes).
+         *
+         * <p><b>Configuration highlights:</b>
+         * <ul>
+         *   <li>Write buffers: 256MB x 6 memtables = 1.5GB total buffering</li>
+         *   <li>SST files: 256MB L1 files, 1GB L1 total (reduces compaction frequency)</li>
+         *   <li>Compaction: 8 background jobs, 4 subcompactions (parallel processing)</li>
+         *   <li>L0 triggers: Start at 4 files, slowdown at 20, stop at 36</li>
+         *   <li>Write optimization: Concurrent memtable writes, pipelined WAL</li>
+         *   <li>Block cache: 512MB shared cache</li>
+         * </ul>
+         *
+         * <p><b>Use when:</b> High insert/update rate, plenty of RAM available (4GB+ recommended)
+         */
+        HIGH_THROUGHPUT,
+
+        /**
+         * Balanced configuration for general-purpose usage.
+         * - Moderate write buffers (128MB per CF)
+         * - Standard compaction (4 jobs)
+         * - Medium block cache (256MB)
+         * - Good mix of read/write performance
+         *
+         * <p><b>Use when:</b> Mixed workload, moderate resource constraints
+         */
+        BALANCED,
+
+        /**
+         * Memory-constrained environment (development, testing, edge devices).
+         * - Small write buffers (64MB per CF)
+         * - Fewer background jobs (2 jobs)
+         * - Minimal block cache (128MB)
+         * - Trades performance for lower memory footprint
+         *
+         * <p><b>Use when:</b> Limited RAM, development/testing environments
+         */
+        LOW_MEMORY,
+
+        /**
+         * No preset applied - uses RocksDB defaults.
+         * Suitable for custom configuration or minimal overhead.
+         */
+        DEFAULT
+    }
+
+    private final Profile profile;
+    private final Long writeBufferSize;
+    private final Integer maxWriteBufferNumber;
+    private final Integer minWriteBufferNumberToMerge;
+    private final Integer maxBackgroundJobs;
+    private final Integer maxSubcompactions;
+    private final Long blockCacheSize;
+    private final Integer bloomFilterBits;
+    private final Long bytesPerSync;
+    private final Boolean levelCompactionDynamicLevelBytes;
+    private final CompressionType compressionType;
+    private final Consumer<DBOptions> customDbOptions;
+    private final Consumer<ColumnFamilyOptions> customCfOptions;
+
+    private RocksDbConfig(Builder builder) {
+        this.profile = builder.profile;
+        this.writeBufferSize = builder.writeBufferSize;
+        this.maxWriteBufferNumber = builder.maxWriteBufferNumber;
+        this.minWriteBufferNumberToMerge = builder.minWriteBufferNumberToMerge;
+        this.maxBackgroundJobs = builder.maxBackgroundJobs;
+        this.maxSubcompactions = builder.maxSubcompactions;
+        this.blockCacheSize = builder.blockCacheSize;
+        this.bloomFilterBits = builder.bloomFilterBits;
+        this.bytesPerSync = builder.bytesPerSync;
+        this.levelCompactionDynamicLevelBytes = builder.levelCompactionDynamicLevelBytes;
+        this.compressionType = builder.compressionType;
+        this.customDbOptions = builder.customDbOptions;
+        this.customCfOptions = builder.customCfOptions;
+    }
+
+    /**
+     * Creates a HIGH_THROUGHPUT profile configuration.
+     *
+     * @return high-throughput configuration
+     */
+    public static RocksDbConfig highThroughput() {
+        return builder().profile(Profile.HIGH_THROUGHPUT).build();
+    }
+
+    /**
+     * Creates a BALANCED profile configuration.
+     *
+     * @return balanced configuration
+     */
+    public static RocksDbConfig balanced() {
+        return builder().profile(Profile.BALANCED).build();
+    }
+
+    /**
+     * Creates a LOW_MEMORY profile configuration.
+     *
+     * @return low-memory configuration
+     */
+    public static RocksDbConfig lowMemory() {
+        return builder().profile(Profile.LOW_MEMORY).build();
+    }
+
+    /**
+     * Creates a configuration using RocksDB defaults.
+     *
+     * @return default configuration
+     */
+    public static RocksDbConfig defaults() {
+        return builder().profile(Profile.DEFAULT).build();
+    }
+
+    /**
+     * Creates a new builder for custom configuration.
+     *
+     * @return new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Applies this configuration to a DBOptions instance.
+     *
+     * @param dbOptions the DBOptions to configure
+     */
+    public void applyToDbOptions(DBOptions dbOptions) {
+        switch (profile) {
+            case HIGH_THROUGHPUT:
+                dbOptions.setMaxBackgroundJobs(8);
+                dbOptions.setMaxSubcompactions(4);
+                dbOptions.setBytesPerSync(1024 * 1024);
+                dbOptions.setAllowConcurrentMemtableWrite(true);
+                dbOptions.setEnablePipelinedWrite(true);
+                break;
+            case BALANCED:
+                dbOptions.setMaxBackgroundJobs(4);
+                dbOptions.setMaxSubcompactions(2);
+                dbOptions.setBytesPerSync(1024 * 1024);
+                break;
+            case LOW_MEMORY:
+                dbOptions.setMaxBackgroundJobs(2);
+                dbOptions.setMaxSubcompactions(1);
+                dbOptions.setBytesPerSync(512 * 1024);
+                break;
+            case DEFAULT:
+                break;
+        }
+
+        if (maxBackgroundJobs != null) {
+            dbOptions.setMaxBackgroundJobs(maxBackgroundJobs);
+        }
+        if (maxSubcompactions != null) {
+            dbOptions.setMaxSubcompactions(maxSubcompactions);
+        }
+        if (bytesPerSync != null) {
+            dbOptions.setBytesPerSync(bytesPerSync);
+        }
+
+        if (customDbOptions != null) {
+            customDbOptions.accept(dbOptions);
+        }
+    }
+
+    /**
+     * Applies this configuration to a ColumnFamilyOptions instance.
+     *
+     * @param cfOptions  the ColumnFamilyOptions to configure
+     * @param blockCache shared block cache (may be null)
+     * @return configured BlockBasedTableConfig if block cache settings were applied
+     */
+    public BlockBasedTableConfig applyToCfOptions(ColumnFamilyOptions cfOptions, Cache blockCache) {
+        switch (profile) {
+            case HIGH_THROUGHPUT:
+                cfOptions.setWriteBufferSize(256 * 1024 * 1024);
+                cfOptions.setMaxWriteBufferNumber(6);
+                cfOptions.setMinWriteBufferNumberToMerge(2);
+                cfOptions.setTargetFileSizeBase(256 * 1024 * 1024);
+                cfOptions.setMaxBytesForLevelBase(1024 * 1024 * 1024);
+                cfOptions.setTargetFileSizeMultiplier(2);
+                cfOptions.setLevelCompactionDynamicLevelBytes(true);
+                cfOptions.setLevel0FileNumCompactionTrigger(4);
+                cfOptions.setLevel0SlowdownWritesTrigger(20);
+                cfOptions.setLevel0StopWritesTrigger(36);
+                cfOptions.setCompressionType(CompressionType.LZ4_COMPRESSION);
+                break;
+            case BALANCED:
+                cfOptions.setWriteBufferSize(128 * 1024 * 1024);
+                cfOptions.setMaxWriteBufferNumber(3);
+                cfOptions.setMinWriteBufferNumberToMerge(1);
+                cfOptions.setLevelCompactionDynamicLevelBytes(true);
+                break;
+            case LOW_MEMORY:
+                cfOptions.setWriteBufferSize(64 * 1024 * 1024);
+                cfOptions.setMaxWriteBufferNumber(2);
+                cfOptions.setMinWriteBufferNumberToMerge(1);
+                cfOptions.setLevelCompactionDynamicLevelBytes(false);
+                break;
+            case DEFAULT:
+                break;
+        }
+
+        if (writeBufferSize != null) {
+            cfOptions.setWriteBufferSize(writeBufferSize);
+        }
+        if (maxWriteBufferNumber != null) {
+            cfOptions.setMaxWriteBufferNumber(maxWriteBufferNumber);
+        }
+        if (minWriteBufferNumberToMerge != null) {
+            cfOptions.setMinWriteBufferNumberToMerge(minWriteBufferNumberToMerge);
+        }
+        if (levelCompactionDynamicLevelBytes != null) {
+            cfOptions.setLevelCompactionDynamicLevelBytes(levelCompactionDynamicLevelBytes);
+        }
+        if (compressionType != null) {
+            cfOptions.setCompressionType(compressionType);
+        }
+
+        BlockBasedTableConfig tableConfig = null;
+        if (blockCache != null || bloomFilterBits != null) {
+            tableConfig = new BlockBasedTableConfig();
+
+            if (blockCache != null) {
+                tableConfig.setBlockCache(blockCache);
+            }
+
+            if (bloomFilterBits != null) {
+                tableConfig.setFilterPolicy(new BloomFilter(bloomFilterBits));
+            } else if (profile != Profile.DEFAULT) {
+                tableConfig.setFilterPolicy(new BloomFilter(10));
+            }
+
+            cfOptions.setTableFormatConfig(tableConfig);
+        }
+
+        if (customCfOptions != null) {
+            customCfOptions.accept(cfOptions);
+        }
+
+        return tableConfig;
+    }
+
+    /**
+     * Creates a shared block cache based on this configuration.
+     *
+     * @return LRU cache instance, or null if no cache configured
+     */
+    public Cache createBlockCache() {
+        long cacheSize = getBlockCacheSize();
+        return cacheSize > 0 ? new LRUCache(cacheSize) : null;
+    }
+
+    /**
+     * Gets the effective block cache size based on profile and overrides.
+     *
+     * @return cache size in bytes, or 0 if no cache configured
+     */
+    public long getBlockCacheSize() {
+        if (blockCacheSize != null) {
+            return blockCacheSize;
+        }
+
+        switch (profile) {
+            case HIGH_THROUGHPUT:
+                return 512 * 1024 * 1024L;
+            case BALANCED:
+                return 256 * 1024 * 1024L;
+            case LOW_MEMORY:
+                return 128 * 1024 * 1024L;
+            case DEFAULT:
+            default:
+                return 0;
+        }
+    }
+
+    public Profile profile() {
+        return profile;
+    }
+
+    public static final class Builder {
+        private Profile profile = Profile.BALANCED;
+        private Long writeBufferSize;
+        private Integer maxWriteBufferNumber;
+        private Integer minWriteBufferNumberToMerge;
+        private Integer maxBackgroundJobs;
+        private Integer maxSubcompactions;
+        private Long blockCacheSize;
+        private Integer bloomFilterBits;
+        private Long bytesPerSync;
+        private Boolean levelCompactionDynamicLevelBytes;
+        private CompressionType compressionType;
+        private Consumer<DBOptions> customDbOptions;
+        private Consumer<ColumnFamilyOptions> customCfOptions;
+
+        private Builder() {}
+
+        public Builder profile(Profile profile) {
+            this.profile = profile;
+            return this;
+        }
+
+        public Builder writeBufferSize(long writeBufferSize) {
+            this.writeBufferSize = writeBufferSize;
+            return this;
+        }
+
+        public Builder maxWriteBufferNumber(int maxWriteBufferNumber) {
+            this.maxWriteBufferNumber = maxWriteBufferNumber;
+            return this;
+        }
+
+        public Builder minWriteBufferNumberToMerge(int minWriteBufferNumberToMerge) {
+            this.minWriteBufferNumberToMerge = minWriteBufferNumberToMerge;
+            return this;
+        }
+
+        public Builder maxBackgroundJobs(int maxBackgroundJobs) {
+            this.maxBackgroundJobs = maxBackgroundJobs;
+            return this;
+        }
+
+        public Builder maxSubcompactions(int maxSubcompactions) {
+            this.maxSubcompactions = maxSubcompactions;
+            return this;
+        }
+
+        public Builder blockCacheSize(long blockCacheSize) {
+            this.blockCacheSize = blockCacheSize;
+            return this;
+        }
+
+        public Builder bloomFilterBits(int bloomFilterBits) {
+            this.bloomFilterBits = bloomFilterBits;
+            return this;
+        }
+
+        public Builder bytesPerSync(long bytesPerSync) {
+            this.bytesPerSync = bytesPerSync;
+            return this;
+        }
+
+        public Builder levelCompactionDynamicLevelBytes(boolean enabled) {
+            this.levelCompactionDynamicLevelBytes = enabled;
+            return this;
+        }
+
+        public Builder compressionType(CompressionType compressionType) {
+            this.compressionType = compressionType;
+            return this;
+        }
+
+        public Builder customDbOptions(Consumer<DBOptions> customDbOptions) {
+            this.customDbOptions = customDbOptions;
+            return this;
+        }
+
+        public Builder customCfOptions(Consumer<ColumnFamilyOptions> customCfOptions) {
+            this.customCfOptions = customCfOptions;
+            return this;
+        }
+
+        public RocksDbConfig build() {
+            return new RocksDbConfig(this);
+        }
+    }
+}

--- a/verified-structures/rocksdb-core/src/main/java/com/bloxbean/cardano/vds/rocksdb/resources/RocksDbInitializer.java
+++ b/verified-structures/rocksdb-core/src/main/java/com/bloxbean/cardano/vds/rocksdb/resources/RocksDbInitializer.java
@@ -160,8 +160,10 @@ public final class RocksDbInitializer {
                                 .setCreateMissingColumnFamilies(true)));
 
                 // Discover existing column families
-                List<byte[]> existingCfNames = RocksDB.listColumnFamilies(
-                        new Options().setCreateIfMissing(true), databasePath);
+                List<byte[]> existingCfNames;
+                try (Options tempOpts = new Options().setCreateIfMissing(true)) {
+                    existingCfNames = RocksDB.listColumnFamilies(tempOpts, databasePath);
+                }
 
                 // Build column family descriptors
                 List<ColumnFamilyDescriptor> cfDescriptors = new ArrayList<>();


### PR DESCRIPTION
**Should be merged after PR** #619 

 ## Summary

  This PR adds MPF property-based testing infrastructure, fixes MPF/RocksDB edgecases, and consolidates RocksDB configuration into a shared verified-structures core module.

  ## Changes

  - Added a new `test-support` module with jqwik-based test utilities:
    - Generic Cardano arbitraries
    - `ByteArrayWrapper` for stable `byte[]` map/set keys
    - VDS/MPF-specific arbitraries under `com.bloxbean.cardano.client.test.vds`
  - Added property-based MPF test coverage:
    - In-memory MPF trie properties
    - RocksDB-backed MPF persistence, parity, and batch consistency properties
    - Regression coverage for MPF proof verification edge cases
  - Fixed MPF proof verification behavior for branch/extension skip handling.
  - Fixed RocksDB resource-management issues:
    - Properly closes options, handles, caches, and batch resources
    - Adds safer cleanup paths and warning logs for close/rollback failures
  - Introduced shared `verified-structures:rocksdb-core` `RocksDbConfig`.
  - Deprecated the JMT-specific RocksDB config wrapper in favor of the shared config.
  - Added configurable RocksDB tuning support to MPF `RocksDbStateTrees`.
  - Improved MPF RocksDB batch/GC behavior and observability.
  - Added RDBMS table-prefix validation.
  - Updated property-testing documentation and jqwik ignore rules.
  - Kept `verified-structures-core` as `compileOnly` in `test-support` so generic test utilities do not force VDS dependencies onto consumers.
