### PR TITLE
 fix: prefer raw cost models for protocol params

### DIFF
--- a/backend-modules/koios/src/it/java/com/bloxbean/cardano/client/backend/koios/it/KoiosEpochServiceIT.java
+++ b/backend-modules/koios/src/it/java/com/bloxbean/cardano/client/backend/koios/it/KoiosEpochServiceIT.java
@@ -106,8 +106,8 @@ class KoiosEpochServiceIT extends KoiosBaseTest {
         assertThat(protocolParams.getDrepActivity(), greaterThan(0));
         assertThat(protocolParams.getMinFeeRefScriptCostPerByte(), greaterThan(BigDecimal.ZERO));
 
-        assertThat(protocolParams.getCostModels().get("PlutusV1").size(), is(166));
-        assertThat(protocolParams.getCostModels().get("PlutusV2").size(), is(175));
-        assertThat(protocolParams.getCostModels().get("PlutusV3").size(), greaterThan(251));
+        assertThat(protocolParams.getCostModels().get("PlutusV1").size(), greaterThanOrEqualTo(166));
+        assertThat(protocolParams.getCostModels().get("PlutusV2").size(), greaterThanOrEqualTo(175));
+        assertThat(protocolParams.getCostModels().get("PlutusV3").size(), greaterThanOrEqualTo(251));
     }
 }

--- a/backend-modules/koios/src/main/java/com/bloxbean/cardano/client/backend/koios/KoiosEpochService.java
+++ b/backend-modules/koios/src/main/java/com/bloxbean/cardano/client/backend/koios/KoiosEpochService.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import rest.koios.client.backend.api.epoch.model.EpochInfo;
 import rest.koios.client.backend.api.epoch.model.EpochParams;
 
@@ -21,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Koios Epoch Service
  */
+@Slf4j
 public class KoiosEpochService implements EpochService {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -174,6 +176,7 @@ public class KoiosEpochService implements EpochService {
             protocolParams.setMaxCollateralInputs(epochParams.getMaxCollateralInputs());
         }
         if (epochParams.getCostModels() != null) {
+            protocolParams.setCostModelsRaw(convertToCostModelsRaw(epochParams.getCostModels()));
             protocolParams.setCostModels(convertToCostModels(epochParams.getCostModels()));
         }
         if (epochParams.getCoinsPerUtxoSize() != null) {
@@ -213,6 +216,20 @@ public class KoiosEpochService implements EpochService {
         protocolParams.setMinFeeRefScriptCostPerByte(epochParams.getMinFeeRefScriptCostPerByte());
 
         return Result.success("OK").withValue(protocolParams).code(200);
+    }
+
+    private LinkedHashMap<String, List<Long>> convertToCostModelsRaw(JsonNode costModelsJsonNode) {
+        if (costModelsJsonNode == null || costModelsJsonNode.isNull()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return objectMapper.convertValue(
+                    costModelsJsonNode,
+                    new TypeReference<LinkedHashMap<String, List<Long>>>() {});
+        } catch (IllegalArgumentException e) {
+            log.warn("Failed to convert cost models", e);
+            return new LinkedHashMap<>();
+        }
     }
 
     private LinkedHashMap<String, LinkedHashMap<String, Long>> convertToCostModels(JsonNode costModelsJsonNode) {

--- a/backend-modules/ogmios/src/main/java/com/bloxbean/cardano/client/backend/ogmios/websocket/Ogmios5EpochService.java
+++ b/backend-modules/ogmios/src/main/java/com/bloxbean/cardano/client/backend/ogmios/websocket/Ogmios5EpochService.java
@@ -9,7 +9,9 @@ import io.adabox.model.query.response.CurrentProtocolParameters;
 import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 @Slf4j
 public class Ogmios5EpochService implements EpochService {
@@ -72,9 +74,17 @@ public class Ogmios5EpochService implements EpochService {
 
         LinkedHashMap<String, Long> plutusV1CostModel = (LinkedHashMap<String, Long>)currentProtocolParameters.getProtocolParameters().getCostModels().get("plutus:v1");
         LinkedHashMap<String, Long> plutusV2CostModel = (LinkedHashMap<String, Long>)currentProtocolParameters.getProtocolParameters().getCostModels().get("plutus:v2");
+        LinkedHashMap<String, Long> plutusV3CostModel = (LinkedHashMap<String, Long>)currentProtocolParameters.getProtocolParameters().getCostModels().get("plutus:v3");
+        LinkedHashMap<String, List<Long>> costModelsRaw = new LinkedHashMap<>();
+        costModelsRaw.put("PlutusV1", new ArrayList<>(plutusV1CostModel.values()));
+        costModelsRaw.put("PlutusV2", new ArrayList<>(plutusV2CostModel.values()));
+        costModelsRaw.put("PlutusV3", new ArrayList<>(plutusV3CostModel.values()));
+        protocolParams.setCostModelsRaw(costModelsRaw);
+
         LinkedHashMap<String, LinkedHashMap<String, Long>> costModels = new LinkedHashMap<>();
         costModels.put("PlutusV1", plutusV1CostModel);
         costModels.put("PlutusV2", plutusV2CostModel);
+        costModels.put("PlutusV3", plutusV3CostModel);
         protocolParams.setCostModels(costModels);
 
         protocolParams.setPriceMem(stringToDecimal(currentProtocolParameters.getProtocolParameters().getPrices().getMemory()));

--- a/core-api/src/main/java/com/bloxbean/cardano/client/api/model/ProtocolParams.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/client/api/model/ProtocolParams.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 @Data
 @Builder
@@ -43,7 +44,13 @@ public class ProtocolParams {
     private String nonce;
 
     //Alonzo changes
+    @Deprecated
+    /**
+     * Use costModelsRaw instead of costModels. costModelsRaw is a list of costs in the order of the language's built-in functions.
+     */
     private LinkedHashMap<String, LinkedHashMap<String, Long>> costModels;
+    @JsonProperty("cost_models_raw")
+    private LinkedHashMap<String, List<Long>> costModelsRaw;
     private BigDecimal priceMem;
     private BigDecimal priceStep;
     private String maxTxExMem;

--- a/core-api/src/main/java/com/bloxbean/cardano/client/api/util/CostModelUtil.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/client/api/util/CostModelUtil.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.plutus.spec.Language;
 
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -647,6 +648,17 @@ public class CostModelUtil {
             languageKey = "PlutusV2";
         } else if (language == Language.PLUTUS_V3) {
             languageKey = "PlutusV3";
+        }
+
+        if (protocolParams.getCostModelsRaw() != null) {
+            List<Long> raw = protocolParams.getCostModelsRaw().get(languageKey);
+            if (raw != null && !raw.isEmpty()) {
+                long[] costModel = raw.stream()
+                        .mapToLong(Long::longValue)
+                        .toArray();
+
+                return Optional.of(new CostModel(language, costModel));
+            }
         }
 
         if (protocolParams.getCostModels() == null)

--- a/core-api/src/test/java/com/bloxbean/cardano/client/api/util/CostModelUtilTest.java
+++ b/core-api/src/test/java/com/bloxbean/cardano/client/api/util/CostModelUtilTest.java
@@ -5,7 +5,9 @@ import com.bloxbean.cardano.client.plutus.spec.CostModel;
 import com.bloxbean.cardano.client.plutus.spec.Language;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,23 +16,12 @@ class CostModelUtilTest {
 
     @Test
     void getCostModelFromProtocolParams() {
-        LinkedHashMap<String, Long> costModel1 = new LinkedHashMap<>();
-        costModel1.put("verifyEd25519Signature-cpu-arguments-slope", 1021L);
-        costModel1.put("addInteger-cpu-arguments-intercept", 205665L);
-        costModel1.put("verifyEd25519Signature-memory-arguments", 10L);
-        costModel1.put("unBData-cpu-arguments", 31220L);
+        LinkedHashMap<String, List<Long>> costModelsRaw = new LinkedHashMap<>();
+        costModelsRaw.put("PlutusV1", Arrays.asList(1021L, 205665L, 10L, 31220L));
+        costModelsRaw.put("PlutusV2", Arrays.asList(812L, 205665L, 10L, 1000L));
 
-        LinkedHashMap<String, Long> costModel2 = new LinkedHashMap<>();
-        costModel2.put("addInteger-cpu-arguments-slope", 812L);
-        costModel2.put("addInteger-cpu-arguments-intercept", 205665L);
-        costModel2.put("verifyEd25519Signature-memory-arguments", 10L);
-        costModel2.put("bData-cpu-arguments", 1000L);
-
-        LinkedHashMap<String, LinkedHashMap<String, Long>> costModels = new LinkedHashMap<>();
-        costModels.put("PlutusV1", costModel1);
-        costModels.put("PlutusV2", costModel2);
         ProtocolParams protocolParams = new ProtocolParams();
-        protocolParams.setCostModels(costModels);
+        protocolParams.setCostModelsRaw(costModelsRaw);
 
         Optional<CostModel> v1CostModel = CostModelUtil.getCostModelFromProtocolParams(protocolParams, Language.PLUTUS_V1);
         Optional<CostModel> v2CostModel = CostModelUtil.getCostModelFromProtocolParams(protocolParams, Language.PLUTUS_V2);
@@ -41,20 +32,32 @@ class CostModelUtilTest {
 
     @Test
     void getCostModelFromProtocolParams_whenNotExists_returnsNull() {
-        LinkedHashMap<String, Long> costModel1 = new LinkedHashMap<>();
-        costModel1.put("verifyEd25519Signature-cpu-arguments-slope", 1021L);
-                costModel1.put("addInteger-cpu-arguments-intercept", 205665L);
-                costModel1.put("verifyEd25519Signature-memory-arguments", 10L);
-                costModel1.put("unBData-cpu-arguments", 31220L);
+        LinkedHashMap<String, List<Long>> costModelsRaw = new LinkedHashMap<>();
+        costModelsRaw.put("PlutusV1", Arrays.asList(1021L, 205665L, 10L, 31220L));
 
-        LinkedHashMap<String, LinkedHashMap<String, Long>> costModels = new LinkedHashMap<>();
-        costModels.put("PlutusV1", costModel1);
         ProtocolParams protocolParams = new ProtocolParams();
-        protocolParams.setCostModels(costModels);
+        protocolParams.setCostModelsRaw(costModelsRaw);
 
         Optional<CostModel> v2CostModel = CostModelUtil.getCostModelFromProtocolParams(protocolParams, Language.PLUTUS_V2);
 
         assertThat(v2CostModel).isEmpty();
+    }
+
+    @Test
+    void getCostModelFromProtocolParams_whenOnlyNamedCostModelExists_returnsNamed() {
+        LinkedHashMap<String, Long> namedV1 = new LinkedHashMap<>();
+        namedV1.put("addInteger-cpu-arguments-intercept", 1L);
+        namedV1.put("addInteger-cpu-arguments-slope", 2L);
+
+        LinkedHashMap<String, LinkedHashMap<String, Long>> costModels = new LinkedHashMap<>();
+        costModels.put("PlutusV1", namedV1);
+
+        ProtocolParams protocolParams = new ProtocolParams();
+        protocolParams.setCostModels(costModels);
+
+        Optional<CostModel> v1CostModel = CostModelUtil.getCostModelFromProtocolParams(protocolParams, Language.PLUTUS_V1);
+
+        assertThat(v1CostModel.get().getCosts()).isEqualTo(new long[]{1L, 2L});
     }
 
     @Test
@@ -63,6 +66,48 @@ class CostModelUtilTest {
         Optional<CostModel> v2CostModel = CostModelUtil.getCostModelFromProtocolParams(protocolParams, Language.PLUTUS_V2);
 
         assertThat(v2CostModel).isEmpty();
+    }
+
+    @Test
+    void getCostModelFromProtocolParams_whenRawV3Exists_prefersRaw() {
+        LinkedHashMap<String, Long> namedV3 = new LinkedHashMap<>();
+        namedV3.put("addInteger-cpu-arguments-intercept", 1L);
+        namedV3.put("addInteger-cpu-arguments-slope", 2L);
+
+        LinkedHashMap<String, LinkedHashMap<String, Long>> costModels = new LinkedHashMap<>();
+        costModels.put("PlutusV3", namedV3);
+
+        LinkedHashMap<String, List<Long>> costModelsRaw = new LinkedHashMap<>();
+        costModelsRaw.put("PlutusV3", Arrays.asList(10L, 20L, 30L));
+
+        ProtocolParams protocolParams = new ProtocolParams();
+        protocolParams.setCostModels(costModels);
+        protocolParams.setCostModelsRaw(costModelsRaw);
+
+        Optional<CostModel> v3CostModel = CostModelUtil.getCostModelFromProtocolParams(protocolParams, Language.PLUTUS_V3);
+
+        assertThat(v3CostModel.get().getCosts()).isEqualTo(new long[]{10L, 20L, 30L});
+    }
+
+    @Test
+    void getCostModelFromProtocolParams_whenRawV1Exists_prefersRaw() {
+        LinkedHashMap<String, Long> namedV1 = new LinkedHashMap<>();
+        namedV1.put("addInteger-cpu-arguments-intercept", 1L);
+        namedV1.put("addInteger-cpu-arguments-slope", 2L);
+
+        LinkedHashMap<String, LinkedHashMap<String, Long>> costModels = new LinkedHashMap<>();
+        costModels.put("PlutusV1", namedV1);
+
+        LinkedHashMap<String, List<Long>> costModelsRaw = new LinkedHashMap<>();
+        costModelsRaw.put("PlutusV1", Arrays.asList(10L, 20L, 30L));
+
+        ProtocolParams protocolParams = new ProtocolParams();
+        protocolParams.setCostModels(costModels);
+        protocolParams.setCostModelsRaw(costModelsRaw);
+
+        Optional<CostModel> v1CostModel = CostModelUtil.getCostModelFromProtocolParams(protocolParams, Language.PLUTUS_V1);
+
+        assertThat(v1CostModel.get().getCosts()).isEqualTo(new long[]{10L, 20L, 30L});
     }
 
     @Test

--- a/core/src/main/java/com/bloxbean/cardano/client/transaction/util/CostModelUtil.java
+++ b/core/src/main/java/com/bloxbean/cardano/client/transaction/util/CostModelUtil.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.plutus.spec.Language;
 
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -651,6 +652,17 @@ public class CostModelUtil {
             languageKey = "PlutusV2";
         } else if (language == Language.PLUTUS_V3) {
             languageKey = "PlutusV3";
+        }
+
+        if (protocolParams.getCostModelsRaw() != null) {
+            List<Long> raw = protocolParams.getCostModelsRaw().get(languageKey);
+            if (raw != null && !raw.isEmpty()) {
+                long[] costModel = raw.stream()
+                        .mapToLong(Long::longValue)
+                        .toArray();
+
+                return Optional.of(new CostModel(language, costModel));
+            }
         }
 
         if (protocolParams.getCostModels() == null)

--- a/supplier/ogmios-supplier/src/main/java/com/bloxbean/cardano/client/supplier/ogmios/dto/ProtocolParametersDto.java
+++ b/supplier/ogmios-supplier/src/main/java/com/bloxbean/cardano/client/supplier/ogmios/dto/ProtocolParametersDto.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,12 @@ public class ProtocolParametersDto {
         protocolParams.setMinUtxo(String.valueOf(minUtxoDepositCoefficient));
         protocolParams.setMinPoolCost(minStakePoolCost.get("ada").get("lovelace").toString());
 //        protocolParams.setNonce(currentProtocolParameters.getProtocolParameters().getNonce()); // Not there
+
+        LinkedHashMap<String, List<Long>> costModelsRaw = new LinkedHashMap<>();
+        costModelsRaw.put("PlutusV1", Arrays.asList(plutusCostModels.get("plutus:v1")));
+        costModelsRaw.put("PlutusV2", Arrays.asList(plutusCostModels.get("plutus:v2")));
+        costModelsRaw.put("PlutusV3", Arrays.asList(plutusCostModels.get("plutus:v3")));
+        protocolParams.setCostModelsRaw(costModelsRaw);
 
         LinkedHashMap<String, LinkedHashMap<String, Long>> costModels = new LinkedHashMap<>();
         costModels.put("PlutusV1",


### PR DESCRIPTION
 To fix #622 
 
 ## Summary

  Fix protocol parameter cost model handling to prefer canonical raw cost model arrays when available.

  Blockfrost’s named `cost_models` can be truncated/reordered for Conway/Plomin cost models, which can produce an incorrect script integrity hash. This change adds `costModelsRaw` support and updates cost model extraction to use raw arrays first.

  ## Changes

  - Add `costModelsRaw` to `ProtocolParams` for `cost_models_raw`
  - Prefer `costModelsRaw` in `CostModelUtil`
  - Keep existing `costModels` fallback for Blockfrost-compatible APIs that do not expose raw cost models yet, such as current Yaci Store/Yaci DevKit
  - Populate raw cost models in Koios and Ogmios providers
  - Add tests covering raw preference and named fallback behavior