### PR TITLE
Upgrade Gradle 7.5.1 → 8.14.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ native/*
 
 # Generated files
 .idea/**/contentModel.xml
+**/bin/
+.metals/**
+.bloop/**
 
 # Sensitive or high-churn files
 .idea/**/dataSources/

--- a/annotation-processor/src/test/java/com/bloxbean/cardano/client/metadata/annotation/processor/MetadataAccessorResolverTest.java
+++ b/annotation-processor/src/test/java/com/bloxbean/cardano/client/metadata/annotation/processor/MetadataAccessorResolverTest.java
@@ -48,10 +48,14 @@ class MetadataAccessorResolverTest {
     }
 
     @SupportedAnnotationTypes("com.bloxbean.cardano.client.metadata.annotation.MetadataType")
-    @SupportedSourceVersion(SourceVersion.RELEASE_17)
     static class AccessorCapturingProcessor extends AbstractProcessor {
         MetadataAccessorResolver.AccessorResult result;
         final boolean simulateLombok;
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
 
         AccessorCapturingProcessor(boolean simulateLombok) {
             this.simulateLombok = simulateLombok;

--- a/annotation-processor/src/test/java/com/bloxbean/cardano/client/metadata/annotation/processor/MetadataFieldExtractorTest.java
+++ b/annotation-processor/src/test/java/com/bloxbean/cardano/client/metadata/annotation/processor/MetadataFieldExtractorTest.java
@@ -55,10 +55,14 @@ public class MetadataFieldExtractorTest {
      * instead of generating code.
      */
     @SupportedAnnotationTypes("com.bloxbean.cardano.client.metadata.annotation.MetadataType")
-    @SupportedSourceVersion(SourceVersion.RELEASE_17)
     static class CapturingProcessor extends AbstractProcessor {
         List<MetadataFieldInfo> capturedFields = new ArrayList<>();
         boolean hasLombok;
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
 
         @Override
         public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/annotation-processor/src/test/java/com/bloxbean/cardano/client/metadata/annotation/processor/MetadataFieldValidatorTest.java
+++ b/annotation-processor/src/test/java/com/bloxbean/cardano/client/metadata/annotation/processor/MetadataFieldValidatorTest.java
@@ -40,9 +40,13 @@ class MetadataFieldValidatorTest {
     }
 
     @SupportedAnnotationTypes("com.bloxbean.cardano.client.metadata.annotation.MetadataType")
-    @SupportedSourceVersion(SourceVersion.RELEASE_17)
     static class ValidatorCapturingProcessor extends AbstractProcessor {
         MetadataFieldValidator.MetadataKeyAndEncoding keyEnc;
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
 
         @Override
         public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/annotation-processor/src/test/java/com/bloxbean/cardano/client/metadata/annotation/processor/MetadataTypeDetectorTest.java
+++ b/annotation-processor/src/test/java/com/bloxbean/cardano/client/metadata/annotation/processor/MetadataTypeDetectorTest.java
@@ -50,10 +50,14 @@ class MetadataTypeDetectorTest {
     }
 
     @SupportedAnnotationTypes("com.bloxbean.cardano.client.metadata.annotation.MetadataType")
-    @SupportedSourceVersion(SourceVersion.RELEASE_17)
     static class TypeDetectorCapturingProcessor extends AbstractProcessor {
         MetadataTypeDetector.FieldTypeResult typeResult;
         MetadataTypeDetector.EncoderDecoderResult encoderDecoderResult;
+
+        @Override
+        public SourceVersion getSupportedSourceVersion() {
+            return SourceVersion.latestSupported();
+        }
 
         @Override
         public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/backend-modules/cardano-graphql/build.gradle
+++ b/backend-modules/cardano-graphql/build.gradle
@@ -64,12 +64,12 @@ apollo {
 }
 
 task sourceJar(type: Jar) {
-    classifier "sources"
+    archiveClassifier = "sources"
     from sourceSets.main.allJava
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier "javadoc"
+    archiveClassifier = "javadoc"
     from javadoc.destinationDir
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -125,13 +125,17 @@ subprojects {
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
         testImplementation 'org.junit.jupiter:junit-jupiter-params'
         testImplementation 'org.hamcrest:hamcrest-library:2.2'
-        testImplementation 'org.mockito:mockito-inline:4.6.1'
-        testImplementation 'org.mockito:mockito-junit-jupiter:4.6.1'
+        testImplementation libs.mockito.core
+        testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
         testImplementation('org.assertj:assertj-core:3.23.1')
         testRuntimeOnly 'org.slf4j:slf4j-log4j12:1.7.36'
 
         testCompileOnly libs.lombok
         testAnnotationProcessor libs.lombok
+    }
+
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
     }
 
     compileJava {
@@ -146,13 +150,12 @@ subprojects {
     }
 
     task sourceJar(type: Jar) {
-        classifier "sources"
+        archiveClassifier = "sources"
         from sourceSets.main.allJava
     }
 
     task javadocJar(type: Jar, dependsOn: javadoc) {
-
-        classifier "javadoc"
+        archiveClassifier = "javadoc"
         from javadoc.destinationDir
     }
 
@@ -176,9 +179,6 @@ subprojects {
                     resources {
                         srcDirs = ['src/it/resources']
                     }
-
-                    compileClasspath += sourceSets.main.output + sourceSets.test.output
-                    runtimeClasspath += sourceSets.main.output + sourceSets.test.output
                 }
 
                 tasks.named('processIntegrationTestResources') {
@@ -186,7 +186,8 @@ subprojects {
                 }
 
                 dependencies {
-                    implementation project
+                    implementation project()
+                    implementation sourceSets.test.output
                 }
 
                 targets {
@@ -207,9 +208,6 @@ subprojects {
                     resources {
                         srcDirs = ['src/codegen-test/resources']
                     }
-
-                    compileClasspath += sourceSets.main.output + sourceSets.test.output
-                    runtimeClasspath += sourceSets.main.output + sourceSets.test.output
                 }
 
                 tasks.named('processCodegenTestResources') {
@@ -217,7 +215,8 @@ subprojects {
                 }
 
                 dependencies {
-                    implementation project
+                    implementation project()
+                    implementation sourceSets.test.output
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ subprojects {
         testImplementation 'org.junit.jupiter:junit-jupiter-params'
         testImplementation 'org.hamcrest:hamcrest-library:2.2'
         testImplementation libs.mockito.core
-        testImplementation 'org.mockito:mockito-junit-jupiter:5.12.0'
+        testImplementation libs.mockito.junit.jupiter
         testImplementation('org.assertj:assertj-core:3.23.1')
         testRuntimeOnly 'org.slf4j:slf4j-log4j12:1.7.36'
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ google-auto-service="com.google.auto.service:auto-service:1.1.1"
 javapoet="com.squareup:javapoet:1.13.0"
 google-testing-compile="com.google.testing.compile:compile-testing:0.21.0"
 mockito-core = "org.mockito:mockito-core:5.12.0"
+mockito-junit-jupiter = "org.mockito:mockito-junit-jupiter:5.12.0"
 
 lombok = "org.projectlombok:lombok:1.18.42"
 apache-common-text="org.apache.commons:commons-text:1.15.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/exec/FlowExecutorVirtualThreadTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/exec/FlowExecutorVirtualThreadTest.java
@@ -95,7 +95,7 @@ class FlowExecutorVirtualThreadTest {
 
             // Monitor completion asynchronously
             handle.getResultFuture().whenComplete((result, error) -> {
-                if (error != null) {
+                if (error != null || (result != null && result.isFailed())) {
                     failed.incrementAndGet();
                 } else {
                     completed.incrementAndGet();

--- a/verified-structures/merkle-patricia-forestry/src/test/java/com/bloxbean/cardano/vds/mpf/MpfGoldenVectorsTest.java
+++ b/verified-structures/merkle-patricia-forestry/src/test/java/com/bloxbean/cardano/vds/mpf/MpfGoldenVectorsTest.java
@@ -59,6 +59,7 @@ class MpfGoldenVectorsTest {
 
         // Compute root; we will compare against proofs from the MPF repo
         String rootHex = Bytes.toHex(trie.getRootHash());
+        assertEquals("4acd78f345a686361df77541b2e0b533f53362e36620a1fdd3a13e0b61a3b078", rootHex, "Root hash mismatch with MPF repo");
 
         // Mango proof CBOR (from off-chain Proof.toCBOR test)
         String mangoCborHex = "9fd8799f005f5840c7bfa4472f3a98ebe0421e8f3f03adf0f7c4340dec65b4b92b1c9f0bed209eb45fdf82687b1ab133324cebaf46d99d49f92720c5ded08d5b02f57530f2cc5a5f58401508f13471a031a21277db8817615e62a50a7427d5f8be572746aa5f0d49841758c5e4a29601399a5bd916e5f3b34c38e13253f4de2a3477114f1b2b8f9f2f4dffffd87b9f00582009d23032e6edc0522c00bc9b74edd3af226d1204a079640a367da94c84b69ecc5820c29c35ad67a5a55558084e634ab0d98f7dd1f60070b9ce2a53f9f305fd9d9795ffff";


### PR DESCRIPTION
Hey guys! I realize this is somewhat of a nonstandard first PR, but I was running into issues with this project & Gradle 7 on my local machine & I did the Gradle 8 conversion in my testing. Figured I could leave this here and y'all can decide if you want it.

All tests should be passing.

### build.gradle (root)
- `tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }` - Without this, javac reads source files in the OS default encoding (CP-1252 on Windows), corrupting UTF-8 emoji literals in [MpfGoldenVectorsTest](vscode-file://vscode-app/c:/Users/Sam/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and producing the wrong trie root hash.
- `archiveClassifier` - classifier was removed in Gradle 8.
- Mockito 'mockito-inline:4.6.1' → 'mockito-core:5.12.0' - mockito-inline was merged into [mockito-core](vscode-file://vscode-app/c:/Users/Sam/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in Mockito 5; the old artifact fails on Java 21+.
- Integration test classpath - Gradle 8's JvmTestSuite no longer allows direct compileClasspath += mutation; replaced with implementation project() + implementation sourceSets.test.output.

### build.gradle (graphql)
- archiveClassifier fix - same Gradle 8 removal, applied to this module's local jar tasks.

### Annotation-Processor
Replace @SupportedSourceVersion(RELEASE_17) with getSupportedSourceVersion() returning latestSupported() - prevents processor warnings/errors on Java 21+.


Done in

- MetadataFieldExtractorTest

- MetadataAccessorResolverTest

- MetadataFieldValidatorTest

- MetadataTypeDetectorTest

### FlowExecutorVirtualThreadTest.java (txflow)
Expand failure check to error != null || result.isFailed() - whenComplete only sets error for uncaught exceptions; logical Result.failed() values were previously counted as successes.

### MpfGoldenVectorsTest.java (verified-structures)
Add [assertEquals](vscode-file://vscode-app/c:/Users/Sam/AppData/Local/Programs/Microsoft%20VS%20Code/8b640eef5a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on the computed root hash - the cross-implementation check against the JS reference was computed but never asserted.

### .gitignore
Add **/bin/, .metals/**, .bloop/** - standard IDE/build-tool artifact directories.

Thanks! Got a more normal PR coming soon with CIP-102 support, but I *should* be able to cherry pick that back onto master if you guys decide against using these changes.