### PR TITLE
CIP-102 Implementation

### DIFF
--- a/cip/build.gradle
+++ b/cip/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     api project(':cip:cip30')
     api project(':cip:cip67')
     api project(':cip:cip68')
+    api project(':cip:cip102')
 }
 
 publishing {

--- a/cip/cip102/build.gradle
+++ b/cip/cip102/build.gradle
@@ -1,0 +1,22 @@
+javadoc {
+    // Suppress Lombok-generated constructor warnings (no source-level fix available)
+    options.addBooleanOption('Xdoclint:all,-missing', true)
+}
+
+dependencies {
+    api project(':cip:cip67')
+    api project(':plutus')
+    api project(':address')
+    api project(':transaction-spec')
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Cardano Client CIP102'
+                description = 'Cardano Client Lib - CIP102 Royalty Datum Metadata Implementation'
+            }
+        }
+    }
+}

--- a/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyAddressUtil.java
+++ b/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyAddressUtil.java
@@ -1,0 +1,129 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import com.bloxbean.cardano.client.address.*;
+import com.bloxbean.cardano.client.common.model.Network;
+import com.bloxbean.cardano.client.plutus.spec.*;
+
+import java.math.BigInteger;
+
+/**
+ * Utility class for converting between CCL {@link Address} objects and the Plutus
+ * address representation used in CIP-102 royalty datum fields.
+ *
+ * <h2>Plutus address structure</h2>
+ * <pre>
+ * Address      = Constr(0, [paymentCredential, Option&lt;stakeCredential&gt;])
+ * Credential   = Constr(0, [hash]) -- VerificationKey
+ *              | Constr(1, [hash]) -- Script
+ * StakeOption  = Constr(1, [])                        -- None (enterprise address)
+ *              | Constr(0, [Constr(0, [credential])]) -- Some(Inline(credential))
+ *              | Constr(0, [Constr(1, [slot, tx, cert])]) -- Some(Pointer)
+ * </pre>
+ */
+public class RoyaltyAddressUtil {
+
+    private RoyaltyAddressUtil() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Converts a CCL {@link Address} (bech32 or byte-based) to the Plutus
+     * {@code ConstrPlutusData} representation expected in the royalty datum.
+     *
+     * <p>Supported address types: {@link AddressType#Base}, {@link AddressType#Enterprise},
+     * {@link AddressType#Ptr}.
+     *
+     * @param address the Cardano address to convert
+     * @return {@code Constr(0, [paymentCredential, stakeOption])}
+     * @throws IllegalArgumentException for reward or Byron addresses
+     */
+    public static ConstrPlutusData toPlutusData(Address address) {
+        Credential paymentCred = address.getPaymentCredential()
+                .orElseThrow(() -> new IllegalArgumentException("Address has no payment credential: " + address.getAddressType()));
+
+        ConstrPlutusData paymentData = credentialToPlutusData(paymentCred);
+        PlutusData stakeOption = buildStakeOption(address);
+
+        return ConstrPlutusData.of(0, paymentData, stakeOption);
+    }
+
+    /**
+     * Reconstructs a CCL {@link Address} from the Plutus representation stored in a
+     * CIP-102 datum. The network must be provided since it is not encoded in the
+     * Plutus address.
+     *
+     * <p>Pointer addresses cannot be reconstructed and will throw
+     * {@link UnsupportedOperationException}.
+     *
+     * @param constr  the Plutus address {@code ConstrPlutusData}
+     * @param network the target network (mainnet or testnet)
+     * @return reconstructed {@link Address}
+     * @throws UnsupportedOperationException for pointer stake credentials
+     */
+    public static Address fromPlutusData(ConstrPlutusData constr, Network network) {
+        var list = constr.getData().getPlutusDataList();
+        Credential paymentCred = plutusDataToCredential((ConstrPlutusData) list.get(0));
+
+        ConstrPlutusData stakeOption = (ConstrPlutusData) list.get(1);
+        if (stakeOption.getAlternative() == 1) {
+            // None → enterprise address
+            return AddressProvider.getEntAddress(paymentCred, network);
+        }
+
+        // Some(referencedCredential)
+        ConstrPlutusData referenced = (ConstrPlutusData) stakeOption.getData().getPlutusDataList().get(0);
+        if (referenced.getAlternative() == 0) {
+            // Inline(credential)
+            Credential stakeCred = plutusDataToCredential(
+                    (ConstrPlutusData) referenced.getData().getPlutusDataList().get(0));
+            return AddressProvider.getBaseAddress(paymentCred, stakeCred, network);
+        }
+
+        // Pointer — cannot reconstruct a CCL Address from pointer data alone
+        throw new UnsupportedOperationException("Reconstruction of pointer addresses from Plutus data is not supported");
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private static PlutusData buildStakeOption(Address address) {
+        switch (address.getAddressType()) {
+            case Enterprise:
+                return ConstrPlutusData.of(1); // None
+
+            case Base: {
+                Credential stakeCred = address.getDelegationCredential()
+                        .orElseThrow(() -> new IllegalArgumentException("Base address has no delegation credential"));
+                ConstrPlutusData stakeCredData = credentialToPlutusData(stakeCred);
+                ConstrPlutusData inline = ConstrPlutusData.of(0, stakeCredData); // Inline(cred)
+                return ConstrPlutusData.of(0, inline); // Some(Inline)
+            }
+
+            case Ptr: {
+                PointerAddress ptrAddr = new PointerAddress(address.getBytes());
+                Pointer pointer = ptrAddr.getPointer();
+                ConstrPlutusData pointerData = ConstrPlutusData.of(1,
+                        BigIntPlutusData.of(BigInteger.valueOf(pointer.getSlot())),
+                        BigIntPlutusData.of(BigInteger.valueOf(pointer.getTxIndex())),
+                        BigIntPlutusData.of(BigInteger.valueOf(pointer.getCertIndex())));
+                return ConstrPlutusData.of(0, pointerData); // Some(Pointer)
+            }
+
+            default:
+                throw new IllegalArgumentException("Unsupported address type for CIP-102 royalty datum: " + address.getAddressType());
+        }
+    }
+
+    private static ConstrPlutusData credentialToPlutusData(Credential credential) {
+        int alternative = credential.getType() == CredentialType.Key ? 0 : 1;
+        return ConstrPlutusData.of(alternative, BytesPlutusData.of(credential.getBytes()));
+    }
+
+    private static Credential plutusDataToCredential(ConstrPlutusData constr) {
+        byte[] hash = ((BytesPlutusData) constr.getData().getPlutusDataList().get(0)).getValue();
+        return constr.getAlternative() == 0
+                ? Credential.fromKey(hash)
+                : Credential.fromScript(hash);
+    }
+}

--- a/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyFeeUtil.java
+++ b/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyFeeUtil.java
@@ -1,0 +1,93 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.math.MathContext;
+import java.util.Optional;
+
+/**
+ * Utility class for CIP-102 royalty fee conversions and calculations.
+ *
+ * <h2>On-chain fee encoding</h2>
+ * <p>Fees are stored as integers using the formula:
+ * <pre>  stored_fee = floor(10 / fee_fraction) = floor(1000 / fee_percent)</pre>
+ * where {@code fee_fraction} is the fee as a decimal (e.g. {@code 0.016} for 1.6%) and
+ * {@code fee_percent} is the fee as a percentage (e.g. {@code 1.6} for 1.6%).
+ *
+ * <p>To recover the fee percentage from the stored value:
+ * <pre>  fee_percent ≈ 1000 / stored_fee</pre>
+ *
+ * <h2>Fee calculation</h2>
+ * <p>The royalty amount for a given sale price is:
+ * <pre>  royalty = max(min_fee, min(max_fee, (10 / stored_fee) * sale_price))</pre>
+ * where {@code min_fee} and {@code max_fee} are in the same unit as the sale price.
+ */
+public class RoyaltyFeeUtil {
+
+    private RoyaltyFeeUtil() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    /**
+     * Converts a human-readable fee percentage to the on-chain integer representation.
+     *
+     * <p>Formula: {@code floor(1000 / feePercent)}
+     *
+     * @param feePercent royalty fee as a percentage (e.g. {@code 1.6} for 1.6%),
+     *                   must be in the range [0.1, 100]
+     * @return on-chain fee integer
+     * @throws IllegalArgumentException if feePercent is outside [0.1, 100]
+     */
+    public static BigInteger toChainFee(double feePercent) {
+        if (feePercent < 0.1 || feePercent > 100.0)
+            throw new IllegalArgumentException("Fee percent must be in the range [0.1, 100], got: " + feePercent);
+        return BigInteger.valueOf((long) Math.floor(1000.0 / feePercent));
+    }
+
+    /**
+     * Converts an on-chain fee integer back to a human-readable percentage.
+     *
+     * <p>Formula: {@code ceil(10000 / chainFee) / 10.0}
+     *
+     * @param chainFee on-chain fee integer (must be &gt; 0)
+     * @return fee as a percentage (e.g. {@code 1.6} for 1.6%)
+     * @throws IllegalArgumentException if chainFee is zero or negative
+     */
+    public static double fromChainFee(BigInteger chainFee) {
+        if (chainFee.compareTo(BigInteger.ZERO) <= 0)
+            throw new IllegalArgumentException("Chain fee must be positive, got: " + chainFee);
+        // ceil(10000 / chainFee) / 10.0  — matches the TypeScript reference implementation
+        BigInteger[] divRem = BigInteger.valueOf(10000).divideAndRemainder(chainFee);
+        long ceiled = divRem[0].longValue() + (divRem[1].equals(BigInteger.ZERO) ? 0 : 1);
+        return ceiled / 10.0;
+    }
+
+    /**
+     * Calculates the royalty amount owed for a given sale price, applying min/max caps.
+     *
+     * <p>Formula: {@code max(minFee, min(maxFee, (10 * salePrice) / chainFee))}
+     *
+     * <p>The result is in the same monetary unit as {@code salePrice} (lovelace for ADA sales,
+     * or the base unit of the sale currency for non-ADA sales per version 2).
+     *
+     * @param chainFee  on-chain fee integer from the datum
+     * @param salePrice sale price in the smallest unit of the sale currency
+     * @param minFee    optional absolute minimum royalty (same unit as salePrice)
+     * @param maxFee    optional absolute maximum royalty (same unit as salePrice)
+     * @return royalty amount to pay
+     */
+    public static BigInteger calculateRoyaltyAmount(BigInteger chainFee,
+                                                    BigInteger salePrice,
+                                                    Optional<BigInteger> minFee,
+                                                    Optional<BigInteger> maxFee) {
+        // pct = (10 / chainFee) * salePrice  — integer arithmetic avoids floating point
+        BigInteger pct = BigInteger.TEN.multiply(salePrice).divide(chainFee);
+
+        if (maxFee.isPresent() && pct.compareTo(maxFee.get()) > 0)
+            pct = maxFee.get();
+        if (minFee.isPresent() && pct.compareTo(minFee.get()) < 0)
+            pct = minFee.get();
+
+        return pct;
+    }
+}

--- a/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyFeeUtil.java
+++ b/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyFeeUtil.java
@@ -1,8 +1,6 @@
 package com.bloxbean.cardano.client.cip.cip102;
 
 import java.math.BigInteger;
-import java.math.RoundingMode;
-import java.math.MathContext;
 import java.util.Optional;
 
 /**

--- a/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyInfo.java
+++ b/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyInfo.java
@@ -1,0 +1,114 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import com.bloxbean.cardano.client.exception.CborDeserializationException;
+import com.bloxbean.cardano.client.plutus.spec.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Represents the complete CIP-102 royalty datum.
+ *
+ * <p>CDDL: {@code royalty_info = #6.121([royalty_recipients, version, extra])}
+ *
+ * <p>This datum is stored inline at the UTxO holding the {@code (500)Royalty} token.
+ * Use {@link RoyaltyToken} to construct the asset name and {@link RoyaltyAddressUtil}
+ * to convert recipient addresses.
+ *
+ * <h2>Version semantics</h2>
+ * <ul>
+ *   <li>{@code version = 1} — single {@code (500)Royalty} token per policy ID.</li>
+ *   <li>{@code version = 2} — supports multiple royalty policies via postfixed tokens
+ *       (e.g. {@code (500)Royalty2}). Required when using any {@link RoyaltyToken}
+ *       with a postfix.</li>
+ * </ul>
+ */
+@Getter
+@Builder
+public class RoyaltyInfo {
+
+    /** Datum version for a single royalty token per policy ID. */
+    public static final int VERSION_1 = 1;
+    /** Datum version supporting multiple postfixed royalty tokens per policy ID. */
+    public static final int VERSION_2 = 2;
+
+    @Builder.Default
+    private final List<RoyaltyRecipient> recipients = List.of();
+
+    @Builder.Default
+    private final int version = VERSION_2;
+
+    /** Custom user-defined Plutus data. Defaults to {@code #6.121([])} (unit/void). */
+    @Builder.Default
+    private final PlutusData extra = PlutusData.unit();
+
+    /**
+     * Serializes this royalty info to {@code ConstrPlutusData} suitable for use
+     * as an inline datum.
+     *
+     * @return {@code #6.121([royalty_recipients, version, extra])}
+     */
+    public ConstrPlutusData asPlutusData() {
+        List<PlutusData> recipientDataList = recipients.stream()
+                .map(RoyaltyRecipient::asPlutusData)
+                .collect(Collectors.toList());
+
+        return ConstrPlutusData.of(0,
+                ListPlutusData.of(recipientDataList.toArray(new PlutusData[0])),
+                BigIntPlutusData.of(BigInteger.valueOf(version)),
+                extra);
+    }
+
+    /**
+     * Deserializes a {@code ConstrPlutusData} (read from an inline datum) into
+     * a {@link RoyaltyInfo}.
+     *
+     * @param constr constructor 0 with three fields
+     * @return deserialized royalty info
+     * @throws IllegalArgumentException if the alternative is not 0
+     */
+    public static RoyaltyInfo fromPlutusData(ConstrPlutusData constr) {
+        if (constr.getAlternative() != 0)
+            throw new IllegalArgumentException("Expected constructor alternative 0 for RoyaltyInfo, got: " + constr.getAlternative());
+
+        var outer = constr.getData().getPlutusDataList();
+        ListPlutusData recipientList = (ListPlutusData) outer.get(0);
+        int version = ((BigIntPlutusData) outer.get(1)).getValue().intValue();
+        PlutusData extra = outer.get(2);
+
+        List<RoyaltyRecipient> recipients = recipientList.getPlutusDataList().stream()
+                .map(d -> RoyaltyRecipient.fromPlutusData((ConstrPlutusData) d))
+                .collect(Collectors.toList());
+
+        return RoyaltyInfo.builder()
+                .recipients(recipients)
+                .version(version)
+                .extra(extra)
+                .build();
+    }
+
+    /**
+     * Serializes this royalty info to raw CBOR bytes suitable for use as an inline datum.
+     *
+     * @return CBOR-encoded datum bytes
+     */
+    public byte[] toCbor() {
+        return asPlutusData().serializeToBytes();
+    }
+
+    /**
+     * Convenience method to deserialize from raw CBOR bytes (e.g. from an inline datum
+     * returned by a backend service).
+     *
+     * @param cborBytes raw CBOR-encoded datum bytes
+     * @return deserialized royalty info
+     * @throws CborDeserializationException if the bytes cannot be decoded
+     */
+    public static RoyaltyInfo fromCbor(byte[] cborBytes) throws CborDeserializationException {
+        ConstrPlutusData constr = (ConstrPlutusData) PlutusData.deserialize(cborBytes);
+        return fromPlutusData(constr);
+    }
+}

--- a/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyInfo.java
+++ b/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyInfo.java
@@ -38,6 +38,8 @@ public class RoyaltyInfo {
     @Builder.Default
     private final List<RoyaltyRecipient> recipients = List.of();
 
+    // S1170: cannot be static — @Builder.Default requires an instance field so Lombok generates the builder setter correctly
+    @SuppressWarnings("java:S1170")
     @Builder.Default
     private final int version = VERSION_2;
 

--- a/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyRecipient.java
+++ b/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyRecipient.java
@@ -1,0 +1,101 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import com.bloxbean.cardano.client.plutus.spec.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+/**
+ * Represents a single royalty recipient as defined in the CIP-102 datum specification.
+ *
+ * <p>CDDL: {@code royalty_recipient = #6.121([address, int, optional_big_int, optional_big_int])}
+ * <ul>
+ *   <li>{@code address} — Plutus address (payment + optional stake credential)</li>
+ *   <li>{@code int} — variable fee stored as {@code floor(10 / fee_percent)}</li>
+ *   <li>{@code optional_big_int} — min fee in lovelace, or absent</li>
+ *   <li>{@code optional_big_int} — max fee in lovelace, or absent</li>
+ * </ul>
+ *
+ * <p>Use {@link RoyaltyFeeUtil} to convert between human-readable percentages and the
+ * on-chain fee representation.
+ */
+@Getter
+@Builder
+public class RoyaltyRecipient {
+
+    /** Plutus address as {@code ConstrPlutusData}. Build via {@link RoyaltyAddressUtil#toPlutusData}. */
+    private final ConstrPlutusData address;
+
+    /** Variable fee in on-chain format: {@code floor(10 / fee_percent)}. */
+    private final BigInteger fee;
+
+    /** Minimum royalty fee in lovelace (absolute). Empty means no minimum. */
+    @Builder.Default
+    private final Optional<BigInteger> minFee = Optional.empty();
+
+    /** Maximum royalty fee in lovelace (absolute). Empty means no maximum. */
+    @Builder.Default
+    private final Optional<BigInteger> maxFee = Optional.empty();
+
+    /**
+     * Serializes this recipient to {@code ConstrPlutusData} for inclusion in a royalty datum.
+     *
+     * @return {@code #6.121([address, fee, optional_min_fee, optional_max_fee])}
+     */
+    public ConstrPlutusData asPlutusData() {
+        return ConstrPlutusData.of(0,
+                address,
+                BigIntPlutusData.of(fee),
+                toOptionalBigInt(minFee),
+                toOptionalBigInt(maxFee));
+    }
+
+    /**
+     * Deserializes a {@code ConstrPlutusData} into a {@link RoyaltyRecipient}.
+     *
+     * @param constr constructor 0 with four fields
+     * @return deserialized recipient
+     * @throws IllegalArgumentException if the alternative is not 0
+     */
+    public static RoyaltyRecipient fromPlutusData(ConstrPlutusData constr) {
+        if (constr.getAlternative() != 0)
+            throw new IllegalArgumentException("Expected constructor alternative 0 for RoyaltyRecipient, got: " + constr.getAlternative());
+
+        var list = constr.getData().getPlutusDataList();
+        ConstrPlutusData address = (ConstrPlutusData) list.get(0);
+        BigInteger fee = ((BigIntPlutusData) list.get(1)).getValue();
+        Optional<BigInteger> minFee = fromOptionalBigInt((ConstrPlutusData) list.get(2));
+        Optional<BigInteger> maxFee = fromOptionalBigInt((ConstrPlutusData) list.get(3));
+
+        return RoyaltyRecipient.builder()
+                .address(address)
+                .fee(fee)
+                .minFee(minFee)
+                .maxFee(maxFee)
+                .build();
+    }
+
+    /**
+     * Encodes {@code Optional<BigInteger>} as {@code optional_big_int}:
+     * {@code #6.121([big_int])} for Some, {@code #6.122([])} for None.
+     */
+    private static ConstrPlutusData toOptionalBigInt(Optional<BigInteger> value) {
+        return value
+                .map(v -> ConstrPlutusData.of(0, BigIntPlutusData.of(v)))
+                .orElseGet(() -> ConstrPlutusData.of(1));
+    }
+
+    /**
+     * Decodes {@code optional_big_int} back to {@code Optional<BigInteger>}.
+     * Alternative 0 = Some, alternative 1 = None.
+     */
+    private static Optional<BigInteger> fromOptionalBigInt(ConstrPlutusData constr) {
+        if (constr.getAlternative() == 0) {
+            BigInteger value = ((BigIntPlutusData) constr.getData().getPlutusDataList().get(0)).getValue();
+            return Optional.of(value);
+        }
+        return Optional.empty();
+    }
+}

--- a/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyToken.java
+++ b/cip/cip102/src/main/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyToken.java
@@ -1,0 +1,105 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import com.bloxbean.cardano.client.cip.cip67.CIP67AssetNameUtil;
+import com.bloxbean.cardano.client.crypto.bip32.util.BytesUtil;
+import com.bloxbean.cardano.client.transaction.spec.Asset;
+import com.bloxbean.cardano.client.util.HexUtil;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Represents a CIP-102 Royalty Token — an NFT with the CIP-67 label {@code 500} and
+ * name {@code "Royalty"}, optionally suffixed with a decimal integer.
+ *
+ * <p>Asset name format: {@code <CIP67-prefix-for-500> || "Royalty" || [postfix digits]}
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>{@code (500)Royalty} — no postfix, compatible with version 1 and 2 datums</li>
+ *   <li>{@code (500)Royalty1} — postfix 1, requires {@code version = 2} in the datum</li>
+ *   <li>{@code (500)Royalty2} — postfix 2, requires {@code version = 2} in the datum</li>
+ * </ul>
+ *
+ * <p>The CIP-67 prefix for label 500 encodes to hex {@code 001f4d70} followed by the
+ * UTF-8 bytes of the name.
+ */
+public class RoyaltyToken {
+
+    /** CIP-67 label used for royalty tokens. */
+    public static final int ROYALTY_TOKEN_LABEL = 500;
+    /** Base name component of the royalty token asset name, without any numeric postfix. */
+    public static final String ROYALTY_TOKEN_BASE_NAME = "Royalty";
+
+    private final byte[] nameBytes;
+
+    private RoyaltyToken(byte[] nameBytes) {
+        this.nameBytes = nameBytes;
+    }
+
+    /**
+     * Creates a royalty token with no postfix: {@code (500)Royalty}.
+     * Compatible with both version 1 and version 2 datums.
+     *
+     * @return a {@link RoyaltyToken} with name {@code (500)Royalty}
+     */
+    public static RoyaltyToken create() {
+        return new RoyaltyToken(ROYALTY_TOKEN_BASE_NAME.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Creates a royalty token with the given numeric postfix: {@code (500)Royalty{postfix}}.
+     * The corresponding datum must use {@code version = 2}.
+     *
+     * @param postfix positive integer identifying this royalty policy within the collection
+     * @return a {@link RoyaltyToken} with name {@code (500)Royalty{postfix}}
+     * @throws IllegalArgumentException if postfix is less than 1
+     */
+    public static RoyaltyToken create(int postfix) {
+        if (postfix < 1)
+            throw new IllegalArgumentException("Royalty token postfix must be >= 1");
+        String name = ROYALTY_TOKEN_BASE_NAME + postfix;
+        return new RoyaltyToken(name.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Returns the full asset name as a hex string (CIP-67 label prefix concatenated
+     * with the UTF-8 name bytes), prefixed with {@code "0x"}.
+     *
+     * @return hex-encoded asset name prefixed with {@code "0x"}
+     */
+    public String getAssetNameAsHex() {
+        byte[] prefix = CIP67AssetNameUtil.labelToPrefix(ROYALTY_TOKEN_LABEL);
+        return "0x" + HexUtil.encodeHexString(BytesUtil.merge(prefix, nameBytes));
+    }
+
+    /**
+     * Returns the full asset name as a byte array (CIP-67 label prefix concatenated
+     * with the UTF-8 name bytes).
+     *
+     * @return raw asset name bytes
+     */
+    public byte[] getAssetNameAsBytes() {
+        byte[] prefix = CIP67AssetNameUtil.labelToPrefix(ROYALTY_TOKEN_LABEL);
+        return BytesUtil.merge(prefix, nameBytes);
+    }
+
+    /**
+     * Returns an {@link Asset} representing this royalty token with quantity 1.
+     *
+     * @return asset with this token's name and quantity 1
+     */
+    public Asset getAsset() {
+        return new Asset(getAssetNameAsHex(), BigInteger.ONE);
+    }
+
+    /**
+     * Returns the human-readable asset name, e.g. {@code "(500)Royalty"} or
+     * {@code "(500)Royalty2"}.
+     *
+     * @return friendly asset name in the format {@code "({label}){name}"}
+     */
+    public String getFriendlyName() {
+        return String.format("(%d)%s", ROYALTY_TOKEN_LABEL, new String(nameBytes, StandardCharsets.UTF_8));
+    }
+}

--- a/cip/cip102/src/test/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyAddressUtilTest.java
+++ b/cip/cip102/src/test/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyAddressUtilTest.java
@@ -1,0 +1,61 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import com.bloxbean.cardano.client.address.Address;
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.plutus.spec.ConstrPlutusData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoyaltyAddressUtilTest {
+
+    // Real mainnet addresses for testing
+    private static final String BASE_KEY_KEY =
+            "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+    private static final String ENTERPRISE_KEY =
+            "addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8";
+
+    @Test
+    void testBaseAddress_roundTrip() {
+        Address original = new Address(BASE_KEY_KEY);
+        ConstrPlutusData plutusData = RoyaltyAddressUtil.toPlutusData(original);
+
+        // outer constr is alternative 0
+        assertThat(plutusData.getAlternative()).isEqualTo(0);
+
+        // reconstruct
+        Address reconstructed = RoyaltyAddressUtil.fromPlutusData(plutusData, Networks.mainnet());
+        assertThat(reconstructed.toBech32()).isEqualTo(original.toBech32());
+    }
+
+    @Test
+    void testEnterpriseAddress_roundTrip() {
+        Address original = new Address(ENTERPRISE_KEY);
+        ConstrPlutusData plutusData = RoyaltyAddressUtil.toPlutusData(original);
+
+        // stake option must be None (alternative 1)
+        ConstrPlutusData stakeOption = (ConstrPlutusData) plutusData.getData().getPlutusDataList().get(1);
+        assertThat(stakeOption.getAlternative()).isEqualTo(1);
+
+        Address reconstructed = RoyaltyAddressUtil.fromPlutusData(plutusData, Networks.mainnet());
+        assertThat(reconstructed.toBech32()).isEqualTo(original.toBech32());
+    }
+
+    @Test
+    void testBaseAddress_stakeOptionIsSomeInline() {
+        Address addr = new Address(BASE_KEY_KEY);
+        ConstrPlutusData plutusData = RoyaltyAddressUtil.toPlutusData(addr);
+
+        // stake option = Some(Inline(cred)) = Constr(0, [Constr(0, [cred])])
+        ConstrPlutusData stakeOption = (ConstrPlutusData) plutusData.getData().getPlutusDataList().get(1);
+        assertThat(stakeOption.getAlternative()).isEqualTo(0); // Some
+
+        ConstrPlutusData referencedCred = (ConstrPlutusData) stakeOption.getData().getPlutusDataList().get(0);
+        assertThat(referencedCred.getAlternative()).isEqualTo(0); // Inline
+
+        // inner credential must have alternative 0 (VerificationKey)
+        ConstrPlutusData innerCred = (ConstrPlutusData) referencedCred.getData().getPlutusDataList().get(0);
+        assertThat(innerCred.getAlternative()).isEqualTo(0);
+    }
+}

--- a/cip/cip102/src/test/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyFeeUtilTest.java
+++ b/cip/cip102/src/test/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyFeeUtilTest.java
@@ -1,0 +1,112 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoyaltyFeeUtilTest {
+
+    @ParameterizedTest(name = "{0}% -> chain fee {1}")
+    @CsvSource({
+            "1.6,  625",   // spec example
+            "2.0,  500",
+            "5.0,  200",
+            "10.0, 100",
+            "0.5,  2000",
+            "0.1,  10000",
+            "100.0, 10"
+    })
+    void testToChainFee(double percent, long expected) {
+        assertThat(RoyaltyFeeUtil.toChainFee(percent)).isEqualTo(BigInteger.valueOf(expected));
+    }
+
+    @ParameterizedTest(name = "chain fee {0} -> {1}%")
+    @CsvSource({
+            "625,  1.6",
+            "500,  2.0",
+            "200,  5.0",
+            "100,  10.0",
+            "2000, 0.5",
+            "10,   100.0"
+    })
+    void testFromChainFee(long chainFee, double expectedPercent) {
+        assertThat(RoyaltyFeeUtil.fromChainFee(BigInteger.valueOf(chainFee)))
+                .isEqualTo(expectedPercent);
+    }
+
+    @Test
+    void testToChainFee_belowMinimum_throws() {
+        assertThatThrownBy(() -> RoyaltyFeeUtil.toChainFee(0.09))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testToChainFee_aboveMaximum_throws() {
+        assertThatThrownBy(() -> RoyaltyFeeUtil.toChainFee(100.1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testFromChainFee_zero_throws() {
+        assertThatThrownBy(() -> RoyaltyFeeUtil.fromChainFee(BigInteger.ZERO))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testCalculateRoyaltyAmount_noMinMax() {
+        // 2% of 100 ADA (10_000_000_000 lovelace) = 2 ADA = 2_000_000_000 lovelace
+        BigInteger salePrice = BigInteger.valueOf(100_000_000_000L);
+        BigInteger chainFee = RoyaltyFeeUtil.toChainFee(2.0); // 500
+
+        BigInteger royalty = RoyaltyFeeUtil.calculateRoyaltyAmount(
+                chainFee, salePrice, Optional.empty(), Optional.empty());
+
+        // (10 / 500) * 100_000_000_000 = 0.02 * 100_000_000_000 = 2_000_000_000
+        assertThat(royalty).isEqualTo(BigInteger.valueOf(2_000_000_000L));
+    }
+
+    @Test
+    void testCalculateRoyaltyAmount_cappedByMax() {
+        BigInteger salePrice = BigInteger.valueOf(100_000_000_000L);
+        BigInteger chainFee = RoyaltyFeeUtil.toChainFee(2.0); // 500
+        BigInteger maxFee = BigInteger.valueOf(500_000_000L); // 0.5 ADA cap
+
+        BigInteger royalty = RoyaltyFeeUtil.calculateRoyaltyAmount(
+                chainFee, salePrice, Optional.empty(), Optional.of(maxFee));
+
+        assertThat(royalty).isEqualTo(maxFee);
+    }
+
+    @Test
+    void testCalculateRoyaltyAmount_flooredByMin() {
+        BigInteger salePrice = BigInteger.valueOf(1_000_000L); // cheap NFT: 1 ADA
+        BigInteger chainFee = RoyaltyFeeUtil.toChainFee(2.0); // 500
+        BigInteger minFee = BigInteger.valueOf(500_000L); // 0.5 ADA minimum
+
+        // pct = (10/500) * 1_000_000 = 20_000 lovelace — below minimum
+        BigInteger royalty = RoyaltyFeeUtil.calculateRoyaltyAmount(
+                chainFee, salePrice, Optional.of(minFee), Optional.empty());
+
+        assertThat(royalty).isEqualTo(minFee);
+    }
+
+    @Test
+    void testCalculateRoyaltyAmount_withinMinAndMax() {
+        BigInteger salePrice = BigInteger.valueOf(10_000_000_000L); // 10_000 ADA
+        BigInteger chainFee = RoyaltyFeeUtil.toChainFee(2.0); // 500
+        BigInteger minFee = BigInteger.valueOf(1_000_000L);      // 1 ADA
+        BigInteger maxFee = BigInteger.valueOf(500_000_000_000L); // 500 ADA
+
+        // pct = (10/500) * 10_000_000_000 = 200_000_000 lovelace (200 ADA) — within range
+        BigInteger royalty = RoyaltyFeeUtil.calculateRoyaltyAmount(
+                chainFee, salePrice, Optional.of(minFee), Optional.of(maxFee));
+
+        assertThat(royalty).isEqualTo(BigInteger.valueOf(200_000_000L));
+    }
+}

--- a/cip/cip102/src/test/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyInfoTest.java
+++ b/cip/cip102/src/test/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyInfoTest.java
@@ -1,0 +1,141 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import com.bloxbean.cardano.client.address.Address;
+import com.bloxbean.cardano.client.common.model.Networks;
+import com.bloxbean.cardano.client.plutus.spec.*;
+import com.bloxbean.cardano.client.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RoyaltyInfoTest {
+
+    // A real mainnet base address for testing
+    private static final String TEST_ADDRESS_MAINNET =
+            "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x";
+
+    @Test
+    void testRoundTrip_singleRecipient() throws Exception {
+        Address addr = new Address(TEST_ADDRESS_MAINNET);
+        ConstrPlutusData addressData = RoyaltyAddressUtil.toPlutusData(addr);
+
+        RoyaltyRecipient recipient = RoyaltyRecipient.builder()
+                .address(addressData)
+                .fee(RoyaltyFeeUtil.toChainFee(2.0))  // 2%
+                .minFee(Optional.of(BigInteger.valueOf(1_000_000)))   // 1 ADA
+                .maxFee(Optional.of(BigInteger.valueOf(50_000_000)))  // 50 ADA
+                .build();
+
+        RoyaltyInfo info = RoyaltyInfo.builder()
+                .recipients(List.of(recipient))
+                .version(RoyaltyInfo.VERSION_1)
+                .build();
+
+        ConstrPlutusData serialized = info.asPlutusData();
+        assertThat(serialized.getAlternative()).isEqualTo(0);
+
+        RoyaltyInfo deserialized = RoyaltyInfo.fromPlutusData(serialized);
+
+        assertThat(deserialized.getVersion()).isEqualTo(1);
+        assertThat(deserialized.getRecipients()).hasSize(1);
+
+        RoyaltyRecipient r = deserialized.getRecipients().get(0);
+        assertThat(r.getFee()).isEqualTo(BigInteger.valueOf(500)); // floor(1000/2) = 500
+        assertThat(r.getMinFee()).isEqualTo(Optional.of(BigInteger.valueOf(1_000_000)));
+        assertThat(r.getMaxFee()).isEqualTo(Optional.of(BigInteger.valueOf(50_000_000)));
+    }
+
+    @Test
+    void testRoundTrip_multipleRecipients_noMinMax() throws Exception {
+        Address addr = new Address(TEST_ADDRESS_MAINNET);
+        ConstrPlutusData addressData = RoyaltyAddressUtil.toPlutusData(addr);
+
+        RoyaltyRecipient r1 = RoyaltyRecipient.builder()
+                .address(addressData)
+                .fee(RoyaltyFeeUtil.toChainFee(1.6))
+                .build();
+
+        RoyaltyRecipient r2 = RoyaltyRecipient.builder()
+                .address(addressData)
+                .fee(RoyaltyFeeUtil.toChainFee(3.0))
+                .build();
+
+        RoyaltyInfo info = RoyaltyInfo.builder()
+                .recipients(List.of(r1, r2))
+                .version(RoyaltyInfo.VERSION_1)
+                .build();
+
+        RoyaltyInfo deserialized = RoyaltyInfo.fromPlutusData(info.asPlutusData());
+
+        assertThat(deserialized.getRecipients()).hasSize(2);
+        assertThat(deserialized.getRecipients().get(0).getMinFee()).isEmpty();
+        assertThat(deserialized.getRecipients().get(0).getMaxFee()).isEmpty();
+        assertThat(deserialized.getRecipients().get(1).getFee()).isEqualTo(BigInteger.valueOf(333)); // floor(1000/3)
+    }
+
+    @Test
+    void testRoundTrip_version2_withExtra() throws Exception {
+        Address addr = new Address(TEST_ADDRESS_MAINNET);
+        ConstrPlutusData addressData = RoyaltyAddressUtil.toPlutusData(addr);
+
+        RoyaltyRecipient recipient = RoyaltyRecipient.builder()
+                .address(addressData)
+                .fee(RoyaltyFeeUtil.toChainFee(5.0))
+                .build();
+
+        // extra contains royalty_included = 2 (points to (500)Royalty2)
+        MapPlutusData extraMap = new MapPlutusData();
+        extraMap.put(BytesPlutusData.of("royalty_included"), BigIntPlutusData.of(2));
+
+        RoyaltyInfo info = RoyaltyInfo.builder()
+                .recipients(List.of(recipient))
+                .version(RoyaltyInfo.VERSION_2)
+                .extra(extraMap)
+                .build();
+
+        RoyaltyInfo deserialized = RoyaltyInfo.fromPlutusData(info.asPlutusData());
+
+        assertThat(deserialized.getVersion()).isEqualTo(2);
+        assertThat(deserialized.getExtra()).isInstanceOf(MapPlutusData.class);
+    }
+
+    @Test
+    void testFromCbor_roundTrip() throws Exception {
+        Address addr = new Address(TEST_ADDRESS_MAINNET);
+        ConstrPlutusData addressData = RoyaltyAddressUtil.toPlutusData(addr);
+
+        RoyaltyRecipient recipient = RoyaltyRecipient.builder()
+                .address(addressData)
+                .fee(RoyaltyFeeUtil.toChainFee(2.5))
+                .build();
+
+        RoyaltyInfo info = RoyaltyInfo.builder()
+                .recipients(List.of(recipient))
+                .build();
+
+        byte[] cborBytes = info.toCbor();
+        RoyaltyInfo fromCbor = RoyaltyInfo.fromCbor(cborBytes);
+
+        assertThat(fromCbor.getVersion()).isEqualTo(2);
+        assertThat(fromCbor.getRecipients()).hasSize(1);
+        assertThat(fromCbor.getRecipients().get(0).getFee()).isEqualTo(BigInteger.valueOf(400)); // floor(1000/2.5)
+    }
+
+    @Test
+    void testFromPlutusData_wrongAlternative_throws() {
+        ConstrPlutusData bad = ConstrPlutusData.of(1,
+                ListPlutusData.of(),
+                BigIntPlutusData.of(1),
+                PlutusData.unit());
+
+        assertThatThrownBy(() -> RoyaltyInfo.fromPlutusData(bad))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("alternative 0");
+    }
+}

--- a/cip/cip102/src/test/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyTokenTest.java
+++ b/cip/cip102/src/test/java/com/bloxbean/cardano/client/cip/cip102/RoyaltyTokenTest.java
@@ -1,0 +1,81 @@
+package com.bloxbean.cardano.client.cip.cip102;
+
+import com.bloxbean.cardano.client.cip.cip67.CIP67AssetNameUtil;
+import com.bloxbean.cardano.client.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RoyaltyTokenTest {
+
+    // CIP-67 prefix for label 500 = 001f4d70 (as per the CIP-102 spec)
+    private static final String LABEL_500_PREFIX_HEX = "001f4d70";
+    private static final String ROYALTY_NAME_HEX = HexUtil.encodeHexString(
+            "Royalty".getBytes(StandardCharsets.UTF_8));
+
+    @Test
+    void testCreate_noPostfix_assetName() {
+        RoyaltyToken token = RoyaltyToken.create();
+        // asset name = CIP67 prefix for 500 + "Royalty" in UTF-8
+        String expected = "0x" + LABEL_500_PREFIX_HEX + ROYALTY_NAME_HEX;
+        assertThat(token.getAssetNameAsHex()).isEqualTo(expected);
+    }
+
+    @Test
+    void testCreate_noPostfix_friendlyName() {
+        RoyaltyToken token = RoyaltyToken.create();
+        assertThat(token.getFriendlyName()).isEqualTo("(500)Royalty");
+    }
+
+    @Test
+    void testCreate_withPostfix_assetName() {
+        RoyaltyToken token = RoyaltyToken.create(2);
+        String royalty2NameHex = HexUtil.encodeHexString("Royalty2".getBytes(StandardCharsets.UTF_8));
+        String expected = "0x" + LABEL_500_PREFIX_HEX + royalty2NameHex;
+        assertThat(token.getAssetNameAsHex()).isEqualTo(expected);
+    }
+
+    @Test
+    void testCreate_withPostfix_friendlyName() {
+        assertThat(RoyaltyToken.create(1).getFriendlyName()).isEqualTo("(500)Royalty1");
+        assertThat(RoyaltyToken.create(99).getFriendlyName()).isEqualTo("(500)Royalty99");
+    }
+
+    @Test
+    void testCreate_postfixZero_throws() {
+        assertThatThrownBy(() -> RoyaltyToken.create(0))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testCreate_postfixNegative_throws() {
+        assertThatThrownBy(() -> RoyaltyToken.create(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testGetAsset_quantityIsOne() {
+        RoyaltyToken token = RoyaltyToken.create();
+        assertThat(token.getAsset().getValue()).isEqualByComparingTo(java.math.BigInteger.ONE);
+    }
+
+    @Test
+    void testLabelPrefix_matchesCip67() {
+        // The CIP-67 prefix for label 500 must match what CIP67AssetNameUtil computes
+        byte[] expected = CIP67AssetNameUtil.labelToPrefix(500);
+        byte[] tokenPrefix = new byte[4];
+        System.arraycopy(RoyaltyToken.create().getAssetNameAsBytes(), 0, tokenPrefix, 0, 4);
+        assertThat(tokenPrefix).isEqualTo(expected);
+    }
+
+    @Test
+    void testAssetNameBytes_length() {
+        // 4 bytes CIP67 prefix + 7 bytes "Royalty" = 11 bytes
+        assertThat(RoyaltyToken.create().getAssetNameAsBytes()).hasSize(11);
+        // 4 + 8 ("Royalty1") = 12 bytes
+        assertThat(RoyaltyToken.create(1).getAssetNameAsBytes()).hasSize(12);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,7 @@ include 'cip:cip27'
 include 'cip:cip30'
 include 'cip:cip67'
 include 'cip:cip68'
+include 'cip:cip102'
 
 //Backend modules
 include 'backend'


### PR DESCRIPTION
Implements [CIP-102](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0102) - Royalty Datum Metadata - as a new `cip:cip102` module under the existing CIP module hierarchy.

## New classes

- `RoyaltyInfo` - full royalty datum (`#6.121([recipients, version, extra])`); supports `asPlutusData()`, `toCbor()`, `fromPlutusData()`, `fromCbor()`
- `RoyaltyRecipient` - single recipient with address, fee, and optional min/max fee caps
- **`RoyaltyToken`** - asset name builder for `(500)Royalty[n]` tokens using CIP-67 label 500
- **`RoyaltyFeeUtil`** - fee conversion (`toChainFee` / `fromChainFee`) and royalty amount calculation with min/max clamping
- **`RoyaltyAddressUtil`** - converts CCL `Address` ↔ Plutus `ConstrPlutusData` address representation for use in datum fields. 

RoyaltyAddressUtil could easily be moved elsewhere to be more generally available if desired.
There are 3 similar, but materially different classes that I decided against using: 
- `ConstrPlutusData` (too granular / no reusable abstraction)
- `AddressEncoderDecoderUtil` (handles bech32/byte encoding, not Plutus data representation)
- `plutus-aiken`'s `Address` type (identical logic, but operates on its own `Credential` types with no bridge to CCL's `Address`, and would pull Aiken blueprint tooling into a simple CIP module).

The current implementation keeps the dependency surface minimal and puts the encoding in one place scoped to CIP-102, since this is apparently the only place this functionality is needed currently.

## Test coverage

37 unit tests across 4 test classes covering round-trips, CBOR serialization, fee edge cases, and address encoding.

## Build wiring

- Added `include 'cip:cip102'` to `settings.gradle`
- Added `api project(':cip:cip102')` to `cip/build.gradle`