### PR TITLE
feat: add TxFlow flow-level execution context

### DIFF
--- a/quicktx/adr/policy-references-for-minting.md
+++ b/quicktx/adr/policy-references-for-minting.md
@@ -1,0 +1,225 @@
+# Policy References for Minting
+
+**Status**: Proposed
+**Date**: 2026-06-17
+**Issue**: https://github.com/bloxbean/cardano-client-lib/issues/630
+**Modules**: `quicktx`, `transaction-spec`
+
+## 1. Context
+
+QuickTx supports URI-style references through `SignerRegistry` so YAML documents can refer to runtime-held accounts, wallets, and policies without embedding secrets:
+
+```java
+SignerRegistry registry = new DefaultSignerRegistry()
+    .addAccount("account://alice", alice)
+    .addPolicy("policy://nft", policy);
+```
+
+The account and wallet references are usable from TxPlan YAML through fields such as `from_ref`, `fee_payer_ref`, `collateral_payer_ref`, and `context.signers`.
+
+Policy references are only partially usable today. A policy binding can create a policy signer through `signerFor("policy")`, but minting intents cannot use the same reference to obtain the native policy script or policy id. Native minting YAML must still embed `script_hex` and `script_type`, then separately add a policy signer ref in `context.signers`.
+
+Current behavior:
+
+- `MintingIntent` requires a runtime `Script` or YAML fields `script_hex` plus `script_type`.
+- `ScriptMintingIntent` carries `policyId`, assets, redeemer, and optional receiver/output datum. If not using a reference script path, the mint validator must be attached separately through `ScriptValidatorAttachmentIntent`.
+- `DefaultSignerRegistry.addPolicy(...)` stores a `Policy`, but `SignerBinding` exposes only `signerFor(...)`, `asWallet()`, and `preferredAddress()`.
+
+This makes minting asymmetric with the clean ref-based payment flow. A YAML tool can keep payment keys out of YAML, but native minting still needs policy script bytes duplicated in the document even when runtime already registered `policy://nft`.
+
+## 2. Decision
+
+Add `policy_ref` support to native `MintingIntent`.
+
+```yaml
+version: "1.0"
+transaction:
+  - tx:
+      from_ref: account://minter
+      intents:
+        - type: minting
+          policy_ref: policy://nft
+          assets:
+            - name: ExampleToken
+              value: 1
+          receiver: addr_test1...
+```
+
+When `QuickTxBuilder` composes a `TxPlan` with a `SignerRegistry`, `policy_ref` resolves to a registered `Policy`. The resolved policy supplies:
+
+- the native policy script used by `MintingIntent`;
+- the policy id derived from that script;
+- the policy signer added to the transaction context using `SignerScopes.POLICY`.
+
+YAML authors should not need to repeat:
+
+```yaml
+context:
+  signers:
+    - ref: policy://nft
+      scope: policy
+```
+
+for the common native minting case. Explicit signer refs remain allowed, and duplicate policy signers should be de-duplicated or otherwise harmless.
+
+## 3. API Changes
+
+Extend `SignerBinding` with a backward-compatible default method:
+
+```java
+default Optional<Policy> asPolicy() {
+    return Optional.empty();
+}
+```
+
+`BasicSignerBinding.fromPolicy(policy)` returns the registered policy from `asPolicy()`.
+
+This avoids a second registry abstraction for the immediate native-policy use case and does not break custom `SignerBinding` implementations. A custom registry that wants to support `policy_ref` must return a binding whose `asPolicy()` is present and whose `signerFor(SignerScopes.POLICY)` returns the policy signer.
+
+Add `policyRef` to `MintingIntent`:
+
+```java
+@JsonProperty("policy_ref")
+private String policyRef;
+```
+
+Add fluent Java helpers, for example:
+
+```java
+Tx mintAssetRef(String policyRef, Asset asset, String receiver)
+Tx mintAssetRef(String policyRef, List<Asset> assets, String receiver)
+```
+
+Exact overload naming can follow local API style, but it should be clear that the policy is resolved at composition/build time.
+
+## 4. Resolution Flow
+
+Resolution should happen in `QuickTxBuilder.TxContext._build()` after the effective `SignerRegistry` is known and before `tx.verifyData()` / `tx.complete()` applies intents.
+
+For each `MintingIntent` with `policy_ref`:
+
+1. Resolve `${...}` variables in `policy_ref` through the normal TxPlan variable path.
+2. Require a configured `SignerRegistry`; otherwise throw `TxBuildException`.
+3. Resolve the ref; missing refs throw `TxBuildException`.
+4. Require `binding.asPolicy()`; bindings without policy material throw `TxBuildException`.
+5. Set the intent's runtime script from `policy.getPolicyScript()`.
+6. Add `binding.signerFor(SignerScopes.POLICY)` to the TxContext signer set once per unique policy ref.
+
+The resolver should not parse or require the registry during `TxPlan.from(yaml)`. Loading YAML should remain a pure document operation; missing runtime refs should fail only when the transaction is built.
+
+## 5. Validation Rules
+
+For native `MintingIntent`, exactly one policy source should be used:
+
+- runtime `script`;
+- `script_hex` plus `script_type`;
+- `policy_ref`.
+
+If `policy_ref` appears together with `script_hex`, `script_type`, or a runtime script, fail fast with a clear ambiguity error.
+
+`policy_ref` must not be blank after variable resolution.
+
+If a policy ref resolves to a binding that can sign as `policy` but cannot expose `asPolicy()`, fail with a message that the policy script is unavailable. A signer alone is not enough for native minting because the native script must be present in the transaction witness set.
+
+## 6. Serialization Rules
+
+When an intent was created with a `policy_ref`, `toYaml()` should preserve `policy_ref` and should not emit derived `script_hex` / `script_type`.
+
+When an intent was created from a runtime `Script` without a ref, keep existing behavior and emit `script_hex` / `script_type`.
+
+When an intent was created from YAML with `script_hex` / `script_type`, keep existing behavior and round-trip those fields.
+
+Do not serialize policy keys. `policy_ref` is intentionally a runtime binding, not a secret-export mechanism.
+
+## 7. ScriptMintingIntent Scope
+
+Do not add `policy_ref` to `ScriptMintingIntent` in the first implementation.
+
+Reasoning:
+
+- `DefaultSignerRegistry.addPolicy(...)` stores `transaction.spec.Policy`, which is a native-script policy object.
+- Plutus minting uses a `PlutusScript`, redeemer, execution units, and possibly reference inputs. A native `Policy` binding cannot supply those semantics.
+- Existing `ScriptMintingIntent` supports a policy-id/reference-script path, and non-reference-script usage already needs a separate validator attachment intent.
+
+A future ADR can introduce a generalized script reference model, such as `validator_ref`, `mint_validator_ref`, or a `ScriptRegistry`, for Plutus minting. That design should cover witness attachment, reference-script inputs, redeemer/ex-unit defaults, and script versioning explicitly instead of overloading native `policy_ref`.
+
+## 8. Alternatives Considered
+
+### Require `context.signers` Plus `script_hex`
+
+This is the current behavior. It works, but it duplicates public policy script bytes in YAML and forces tools to know how to serialize native scripts even when runtime already has the `Policy`.
+
+Decision: reject as the only option. Keep it for backward compatibility.
+
+### Add A Separate `PolicyRegistry`
+
+A dedicated registry would avoid expanding `SignerBinding`, but it would force applications to wire two registries for one concept: the same `policy://nft` reference must provide both script material and signing capability.
+
+Decision: reject for native policy refs. Add `SignerBinding.asPolicy()` as the minimal compatible extension.
+
+### Add `policy_ref` To Both Minting Intent Types Now
+
+This would satisfy the broadest reading of the issue, but it hides important differences between native policy minting and Plutus minting. For Plutus scripts, the policy id alone is not enough, and a `Policy` object is the wrong carrier.
+
+Decision: reject for the initial change. Native minting gets `policy_ref`; Plutus script references require a separate design.
+
+## 9. Implementation Plan
+
+1. Extend `SignerBinding`.
+   - Add default `asPolicy()`.
+   - Return `Optional.of(policy)` from `BasicSignerBinding` when backed by a `Policy`.
+
+2. Extend `MintingIntent`.
+   - Add `policyRef` with YAML property `policy_ref`.
+   - Accept `policy_ref` in validation as a valid policy source.
+   - Reject ambiguous combinations with script fields.
+   - Resolve variables for `policy_ref`.
+   - Preserve `policy_ref` in serialization.
+
+3. Resolve refs in `QuickTxBuilder`.
+   - Detect `MintingIntent` instances with `policyRef`.
+   - Resolve through the effective registry.
+   - Inject `policy.getPolicyScript()` into the intent before `tx.complete()`.
+   - Add the policy signer once per unique ref.
+   - Fail clearly when registry, binding, policy, script, or signer is missing.
+
+4. Add Java API helpers.
+   - Add fluent methods on `Tx` for policy-ref native minting.
+   - Keep `ScriptTx` deprecated; do not expand deprecated APIs unless needed for binary/source compatibility.
+
+5. Add tests.
+   - YAML parse of native minting with `policy_ref` and no `script_hex`.
+   - TxPlan round-trip preserves `policy_ref`.
+   - Build with registry resolves policy script and signer.
+   - Build without registry fails.
+   - Unknown policy ref fails.
+   - Binding with signer but no `asPolicy()` fails.
+   - `policy_ref` plus `script_hex` / `script_type` fails.
+   - Variable resolution in `policy_ref`.
+   - Duplicate refs do not add duplicate signers or produce duplicate witness issues.
+
+6. Update docs.
+   - Add a TxPlan YAML example for native minting with `policy_ref`.
+   - Explain that `policy_ref` is for native `Policy`-backed minting.
+   - Point Plutus minting users to validator attachment or reference-script workflows until a script-reference ADR exists.
+
+## 10. Consequences
+
+Positive:
+
+- Native minting YAML can stay secret-free and avoid embedded policy script hex.
+- `DefaultSignerRegistry.addPolicy(...)` becomes useful for complete YAML minting, not only signer lookup.
+- YAML tools can express "mint under `policy://nft`" end to end.
+- Existing `script_hex` / `script_type` YAML remains valid.
+
+Tradeoffs:
+
+- `SignerBinding` gains one policy-specific method.
+- `QuickTxBuilder` must resolve intent-level refs, not only context-level refs.
+- Native and Plutus minting ref support will be intentionally asymmetric until the Plutus script-reference design is added.
+
+Out of scope:
+
+- Plutus `ScriptMintingIntent` policy/script references.
+- Exporting or serializing policy keys.
+- Changing existing `context.signers` behavior.

--- a/txflow/adr/0001-flow-level-execution-context.md
+++ b/txflow/adr/0001-flow-level-execution-context.md
@@ -1,0 +1,303 @@
+# ADR 0001: TxFlow Flow-Level Execution Context in YAML
+
+**Status**: Proposed
+**Date**: 2026-06-17
+**Issue**: https://github.com/bloxbean/cardano-client-lib/issues/630
+**Modules**: `txflow`, `quicktx`
+
+## Context
+
+TxFlow YAML currently describes flow identity, variables, steps, dependencies, per-step retry policy, and each step's transaction plan. It does not describe execution behavior for the flow itself.
+
+The runtime execution settings live only on `FlowExecutor` fluent methods:
+
+- `withChainingMode(ChainingMode)`
+- `withConfirmationConfig(ConfirmationConfig)`
+- `withRollbackStrategy(RollbackStrategy)`
+- `withDefaultRetryPolicy(RetryPolicy)`
+
+This means a flow loaded with `TxFlow.fromYaml(...)` cannot declare that it should run in `BATCH` mode, use a devnet confirmation preset, or rebuild the whole flow after rollback. Those settings are also lost when a flow is serialized with `TxFlow.toYaml()`.
+
+TxPlan already has a top-level `context:` block for transaction composition settings such as fee payer, collateral payer, signer refs, validity range, and deposit behavior. TxFlow has a per-step `context:` that maps to this transaction context, but there is no flow-level context for executor behavior. This causes downstream YAML tooling, such as Yaci DevKit scenario files, to carry custom directives outside the TxFlow schema and strip them before calling `TxFlow.fromYaml(...)`.
+
+## Scope
+
+In scope:
+
+- a top-level TxFlow execution `context:` section;
+- a public `FlowExecutionSettings` model carried by `TxFlow`;
+- YAML round-trip support for execution settings;
+- executor precedence and per-execution effective settings;
+- strict parsing and validation for execution settings.
+
+Out of scope:
+
+- changing the TxPlan transaction context schema;
+- implementing minting `policy_ref` (covered by `quicktx/adr/policy-references-for-minting.md`);
+- adding a mandatory YAML schema discriminator;
+- implementing a generic extension namespace.
+
+Follow-up:
+
+- public YAML format detection helpers;
+- an explicit `extensions:` map for layered tools if more extension points are needed after flow-level context lands;
+- a Plutus script-reference design for minting and validator attachment.
+
+## Decision
+
+Add an optional top-level TxFlow `context:` section as a sibling of `flow:`. This section is the flow execution context. It is distinct from the per-step `context:`, which remains the transaction composition context for a step.
+
+```yaml
+version: "1.0"
+context:
+  chaining_mode: BATCH
+  confirmation: devnet
+  rollback_strategy: REBUILD_ENTIRE_FLOW
+  retry:
+    max_attempts: 3
+    backoff: exponential
+    initial_delay: 1s
+    max_delay: 30s
+flow:
+  id: fund-and-forward
+  steps:
+    - step:
+        id: fund
+        tx:
+          # transaction content
+        context:
+          signers:
+            - ref: account://acc0
+              scope: payment
+```
+
+The flow-level `context:` will be carried on the `TxFlow` domain model through a new immutable domain object named `FlowExecutionSettings`. Do not call the new type `TxFlowContext`, and do not reuse `txflow.exec.FlowExecutionContext`; that class tracks step outputs and execution state during a run.
+
+The domain model must preserve whether a setting was explicitly provided in YAML. Convenience getters may expose effective defaults, but the executor needs presence information to apply precedence correctly.
+
+`FlowExecutionSettings` should not introduce a model-to-`txflow.exec` package dependency. The implementation should either move public execution config types such as `ConfirmationConfig` and `RollbackStrategy` into the public `txflow` API package during the preview window, or introduce base-package setting types that are mapped to executor internals at the boundary.
+
+## Context Fields
+
+The initial schema should support these fields:
+
+| YAML field | Java target | Default when absent |
+|------------|-------------|---------------------|
+| `chaining_mode` | `ChainingMode` | `SEQUENTIAL` |
+| `confirmation` | `ConfirmationConfig` preset or inline config | no deep confirmation tracking |
+| `rollback_strategy` | `RollbackStrategy` | `FAIL_IMMEDIATELY` |
+| `retry` | `RetryPolicy` default for steps | no default retry |
+
+`chaining_mode` and `rollback_strategy` should parse enum names case-insensitively. Serialization should emit canonical enum names.
+
+`confirmation` may be either a preset string or an object:
+
+```yaml
+context:
+  confirmation: devnet
+```
+
+```yaml
+context:
+  confirmation:
+    preset: devnet
+    min_confirmations: 3
+    check_interval: 1s
+    timeout: 5m
+    max_rollback_retries: 3
+    wait_for_backend_after_rollback: true
+    post_rollback_wait_attempts: 30
+    post_rollback_utxo_sync_delay: 3s
+```
+
+Preset names are `defaults`, `devnet`, `testnet`, and `quick`. Inline fields override the preset when both are present. A confirmation object without a `preset` starts from `ConfirmationConfig.defaults()` and then applies the inline fields; it does not imply the `devnet` or `quick` preset. Duration fields should use the same compact format as TxFlow retry YAML (`ms`, `s`, `m`) and may later add ISO-8601 duration support if needed.
+
+`max_rollback_retries` belongs to `ConfirmationConfig`, so the schema must place it under the `confirmation` object. Do not accept a root-level `context.max_rollback_retries` alias; the flow-level context schema is new, and accepting a non-round-tripping alias would create needless long-term asymmetry.
+
+YAML DTOs must use boxed nullable fields such as `Integer` and `Boolean`, not primitives. Preset merging and precedence depend on distinguishing absent values from explicit values such as `false` or `0`.
+
+## Execution Precedence
+
+For each execution setting:
+
+1. An explicit `FlowExecutor.with...(...)` call wins.
+2. A value from `TxFlow.context` is used when the executor did not explicitly configure that setting.
+3. The existing library default is used when neither executor nor flow provides a value.
+
+For retry policy specifically, step-level retry stays strongest for the step:
+
+1. `FlowStep.retry`
+2. explicit `FlowExecutor.withDefaultRetryPolicy(...)`
+3. `TxFlow.context.retry`
+4. no retry
+
+This precedence requires the executor to distinguish "explicitly set to the default value" from "not set". `FlowExecutor` currently initializes fields such as `chainingMode` and `rollbackStrategy` to defaults, and its setters preserve public null-to-default behavior (`withChainingMode(null)` means `SEQUENTIAL`; `withRollbackStrategy(null)` means `FAIL_IMMEDIATELY`). Therefore the implementation must add explicit override tracking flags rather than changing those configured fields to nullable values.
+
+`confirmation` precedence is whole-object precedence. An explicit `FlowExecutor.withConfirmationConfig(...)` wins over the whole YAML confirmation object. There is no cross-source field merge such as "executor check interval plus YAML timeout". Field-level merging happens only inside YAML when a `confirmation.preset` is combined with inline confirmation fields.
+
+## Executor Implementation Constraint
+
+Flow context must not be applied by mutating shared `FlowExecutor` fields before running a flow.
+
+`FlowExecutor` can run async flows and may be reused across flows. Mutating executor fields to apply one flow's YAML context would cause cross-flow races when two flows with different contexts execute concurrently.
+
+Implementation should compute an immutable per-execution effective settings object, for example `EffectiveFlowExecutionSettings`, and pass it through validation, chaining-mode dispatch, retry selection, confirmation tracking, and rollback handling.
+
+`withConfirmationConfig(...)` currently has an eager side effect: it creates a `ConfirmationTracker` and stores it on the executor instance. That shared tracker is part of the concurrency hazard. The refactor should remove the shared `confirmationTracker` as the authoritative runtime tracker, or leave it only as a compatibility detail that is not used by execution. Confirmation trackers should be created from the effective per-execution confirmation config and scoped to that execution.
+
+## Validation Rules
+
+- A non-default `rollback_strategy` still requires confirmation tracking. If neither the executor nor the flow context provides `confirmation`, fail with a clear message before execution.
+- This validation must run against the computed effective settings, not the executor's shared fields. The existing programmatic behavior already fails for `withRollbackStrategy(REBUILD_...)` without confirmation tracking; the refactor must preserve the same rule for both Java and YAML paths.
+- `confirmation` absent means keep current simple confirmation behavior, not `ConfirmationConfig.defaults()`.
+- `confirmation: defaults` explicitly enables deep confirmation tracking with `ConfirmationConfig.defaults()`.
+- A bare `confirmation:` with no value, `confirmation: null`, or an empty `confirmation: {}` object is invalid. Use absence for simple confirmation behavior or `confirmation: defaults` for explicit default deep tracking.
+- Invalid enum names or invalid duration values must fail fast for execution-context fields.
+- The same `retry:` shape must not be strict at flow level but lenient at step level. This implementation migrates step retry parsing to the same strict enum, duration, and bounds validation used by flow-level retry.
+- Dependency `strategy:` parsing should also fail fast for unknown values. A misspelled dependency strategy can silently change UTXO-selection semantics, so it should not default to `ALL`.
+- Existing TxFlow YAML without `context:` remains valid.
+
+Compatibility note: TxFlow YAML that previously relied on lenient fallback for typoed step retry values or dependency strategies will now fail during parsing. Fix the YAML to use valid enum names instead of relying on logged defaults.
+
+## YAML Compatibility And Extensions
+
+The current `FlowDocument` and `TransactionDocument` root classes use Jackson's default unknown-property behavior. Many intent classes ignore unknown fields, but root-level or flow-level unknown fields fail parsing.
+
+Do not globally disable unknown-property failures for all YAML. That would hide misspelled transaction fields such as `chianing_mode` or `fee_pyayer_ref`.
+
+This ADR does not add a generic extension mechanism. The new top-level execution context addresses the immediate Yaci DevKit use case that motivated custom directives. If future tooling still needs extension data, prefer one explicit `extensions:` map at relevant scopes instead of supporting both magic `x_*` prefixes and maps.
+
+## Related Gaps From Issue 630
+
+### Policy References For Minting
+
+`DefaultSignerRegistry.addPolicy("policy://...", policy)` can provide policy signing, but minting YAML cannot use that reference as the source of minting policy material.
+
+Current state:
+
+- `MintingIntent` requires a runtime `Script` or `script_hex` plus `script_type`.
+- `ScriptMintingIntent` carries a `policyId`, assets, redeemer, and optional receiver/datum.
+- `SignerBinding` exposes `signerFor(...)`, `asWallet()`, and `preferredAddress()`, but does not expose a `Policy`, `Script`, or policy id.
+
+This should be handled as a follow-up QuickTx design item, not folded into the TxFlow execution-context change. A likely approach is a backward-compatible default method on `SignerBinding`, such as `Optional<Policy> asPolicy()`, or a separate policy resolver interface. Then `policy_ref` can be added to minting intents and resolved during composition.
+
+This follow-up is now documented separately in `quicktx/adr/policy-references-for-minting.md`.
+
+### YAML Format Detection
+
+Consumers currently infer TxPlan vs TxFlow by checking for `transaction:` or `flow:`. Add public helpers rather than requiring every consumer to duplicate this logic:
+
+- `TxFlow.isTxFlowYaml(String yaml)`
+- `TxPlan.isTxPlanYaml(String yaml)`
+- or a shared `YamlDocumentType.detect(String yaml)`
+
+A mandatory discriminator field is not part of this ADR because it would require a broader schema-version decision.
+
+### Documentation Drift
+
+While reviewing the issue, the TxFlow guide was found to mention APIs that are not present in the current code, including `TxFlow.Builder.withVersion(...)`, `FlowExecutor.withConfirmationTimeout(...)`, and `FlowExecutor.withCheckInterval(...)`. Documentation should be updated during implementation so YAML examples, builder APIs, and executor options match.
+
+The new YAML `confirmation:` block is the declarative replacement for the phantom `withConfirmationTimeout(...)` and `withCheckInterval(...)` examples. Do not add those executor methods only to satisfy stale documentation unless there is a separate API need.
+
+## Alternatives Considered
+
+### Put Execution Context Under `flow:`
+
+```yaml
+flow:
+  id: example
+  context:
+    chaining_mode: BATCH
+```
+
+This avoids a second top-level `context`, but it diverges from TxPlan's top-level context pattern and makes execution metadata look like part of the flow definition rather than document-level runtime semantics.
+
+Decision: reject. Use top-level `context:` for consistency with TxPlan.
+
+### Use `execution:` Instead Of `context:`
+
+```yaml
+execution:
+  chaining_mode: BATCH
+```
+
+This is less ambiguous, but it creates a new naming convention and weakens the TxPlan/TxFlow parallel. The ambiguity is manageable because the scopes differ: document-level `context` means execution context; step-level `context` means transaction context.
+
+Decision: reject for now. Use `context:` and document the scope difference clearly.
+
+### Apply Flow Context By Mutating `FlowExecutor`
+
+This is the smallest implementation mechanically, but it is unsafe for concurrent async flows and shared executors.
+
+Decision: reject. Use per-execution effective settings.
+
+## Implementation Plan
+
+1. Add a TxFlow execution-context model.
+   - Add `FlowExecutionSettings` in the public TxFlow model/API package.
+   - Avoid model dependencies on `txflow.exec` types; resolve package ownership for `ConfirmationConfig` and `RollbackStrategy` before wiring the model.
+   - Add builder methods on `TxFlow.Builder` such as `withContext(...)`, `withChainingMode(...)`, and optional focused helpers if they match local style.
+   - Preserve explicit presence of settings.
+
+2. Extend `FlowDocument`.
+   - Add top-level `context`.
+   - Add YAML DTOs for confirmation, retry, and enum values using boxed nullable fields.
+   - Convert domain context to and from YAML.
+   - Round-trip context in `TxFlow.toYaml()` and `TxFlow.fromYaml()`.
+   - Reject root-level `context.max_rollback_retries`; only accept the canonical nested confirmation field.
+   - Define `confirmation:`, `confirmation: null`, and `confirmation: {}` as invalid.
+
+3. Refactor `FlowExecutor` effective settings.
+   - Track explicit executor overrides for chaining mode, confirmation config, rollback strategy, and default retry policy.
+   - Build immutable effective settings for each `execute`, `executeSync`, `resume`, and `resumeSync` invocation.
+   - Validate effective settings before execution.
+   - Use effective settings for mode dispatch, retry fallback, confirmation timeout/check interval, rollback retry limit, post-rollback waits, and confirmation tracker creation.
+   - Move confirmation tracker creation to the per-execution settings path; the shared executor tracker must not drive execution.
+
+4. Add tests.
+   - YAML parse of top-level `context.chaining_mode`.
+   - YAML round-trip of all context fields.
+   - Stable `toYaml()` ordering with top-level `context` as a sibling of `flow`.
+   - Case-insensitive enum parsing.
+   - `confirmation` preset and inline configuration parsing.
+   - `confirmation` absent vs `confirmation: defaults` vs invalid empty confirmation.
+   - Executor precedence: explicit executor setting overrides YAML context.
+   - Whole-object confirmation precedence with no executor/YAML field merge.
+   - Flow context controls execution when executor setting is absent.
+   - Step retry overrides flow default retry.
+   - Strict parsing for flow retry, step retry, and dependency strategy.
+   - Non-default rollback strategy without confirmation fails before execution.
+   - Concurrent async flows with different contexts do not contaminate each other.
+
+5. Update docs.
+   - Add TxFlow YAML examples with flow-level `context:`.
+   - Explain top-level execution context vs per-step transaction context.
+   - Document precedence.
+   - Remove or fix stale API references found during review.
+
+6. Open follow-up work.
+   - QuickTx `policy_ref` for minting intents (see `quicktx/adr/policy-references-for-minting.md`).
+   - Public YAML format detection helper.
+   - Optional `extensions:` map support for layered tools if needed after this schema change.
+
+## Consequences
+
+Positive:
+
+- TxFlow YAML becomes self-contained for execution behavior.
+- `BATCH` and `PIPELINED` flows can be expressed declaratively.
+- Yaci DevKit and similar tools no longer need custom top-level directives for TxFlow execution settings.
+- Round-tripping a YAML-loaded flow preserves its execution intent.
+
+Tradeoffs:
+
+- `context:` now has different meanings at different scopes. Documentation and examples must be explicit.
+- `FlowExecutor` needs a scoped settings refactor rather than a simple parser change.
+- Confirmation tracking and rollback settings become part of YAML, so validation errors must be precise and early.
+
+Out of scope:
+
+- Changing the TxPlan transaction context schema.
+- Implementing minting `policy_ref`.
+- Adding a mandatory schema discriminator.
+- Adding a generic extension namespace.

--- a/txflow/src/it/java/com/bloxbean/cardano/client/txflow/TxFlowYamlIntegrationTest.java
+++ b/txflow/src/it/java/com/bloxbean/cardano/client/txflow/TxFlowYamlIntegrationTest.java
@@ -561,12 +561,81 @@ public class TxFlowYamlIntegrationTest {
         System.out.println("\n=== Test 9 completed successfully! ===\n");
     }
 
+    @Test
+    @Order(10)
+    void yamlString_flowExecutionContextBatchMode_success() throws Exception {
+        System.out.println("=== Test 10: YAML String - Flow Execution Context BATCH Mode ===");
+
+        String yaml = """
+                version: "1.0"
+                context:
+                  chaining_mode: BATCH
+                  confirmation: quick
+                flow:
+                  id: yaml-context-batch
+                  description: BATCH mode and confirmation configured from YAML context
+                  steps:
+                    - step:
+                        id: step1
+                        description: Sender to Receiver
+                        tx:
+                          from_ref: account://sender
+                          intents:
+                            - type: payment
+                              address: %s
+                              amounts:
+                                - unit: lovelace
+                                  quantity: 2500000
+                        context:
+                          signers:
+                            - ref: account://sender
+                              scope: payment
+                    - step:
+                        id: step2
+                        description: Receiver to Relay
+                        depends_on:
+                          - from_step: step1
+                            strategy: all
+                        tx:
+                          from_ref: account://receiver
+                          intents:
+                            - type: payment
+                              address: %s
+                              amounts:
+                                - unit: lovelace
+                                  quantity: 1200000
+                        context:
+                          signers:
+                            - ref: account://receiver
+                              scope: payment
+                """.formatted(receiverAccount.baseAddress(), relayAccount.baseAddress());
+
+        TxFlow flow = TxFlow.fromYaml(yaml);
+
+        assertEquals(ChainingMode.BATCH, flow.getExecutionSettings().getChainingMode());
+        assertNotNull(flow.getExecutionSettings().getConfirmationConfig());
+        assertEquals(1, flow.getExecutionSettings().getConfirmationConfig().getMinConfirmations());
+
+        FlowResult result = FlowExecutor.create(backendService)
+                .withSignerRegistry(signerRegistry)
+                .withListener(new LoggingFlowListener())
+                .executeSync(flow);
+
+        assertTrue(result.isSuccessful(), "YAML context BATCH flow should succeed: " +
+                (result.getError() != null ? result.getError().getMessage() : "no error"));
+        assertEquals(2, result.getCompletedStepCount());
+        assertEquals(2, result.getTransactionHashes().size());
+
+        System.out.println("Tx hashes: " + result.getTransactionHashes());
+        System.out.println("\n=== Test 10 completed successfully! ===\n");
+    }
+
     // ==================== Category 5: YAML Resource Files ====================
 
     @Test
-    @Order(10)
+    @Order(11)
     void yamlResourceFile_loadAndExecute_success() throws Exception {
-        System.out.println("=== Test 10: YAML Resource File - Load and Execute ===");
+        System.out.println("=== Test 11: YAML Resource File - Load and Execute ===");
 
         // Load YAML from classpath resource
         String yaml = loadResource("/flows/two-step-chain.yaml");
@@ -597,15 +666,15 @@ public class TxFlowYamlIntegrationTest {
         assertEquals(2, result.getTransactionHashes().size());
 
         System.out.println("Tx hashes: " + result.getTransactionHashes());
-        System.out.println("\n=== Test 10 completed successfully! ===\n");
+        System.out.println("\n=== Test 11 completed successfully! ===\n");
     }
 
     // ==================== Category 6: UTXO Selection DSL ====================
 
     @Test
-    @Order(11)
+    @Order(12)
     void txPlan_indexedUtxoSelection_success() throws Exception {
-        System.out.println("=== Test 11: TxPlan - Indexed UTXO Selection ===");
+        System.out.println("=== Test 12: TxPlan - Indexed UTXO Selection ===");
 
         // Step 1: Sender sends two separate payments to Receiver (3 ADA + 2 ADA)
         // This creates two distinct outputs at the receiver address
@@ -649,13 +718,13 @@ public class TxFlowYamlIntegrationTest {
         assertEquals(2, result.getTransactionHashes().size());
 
         System.out.println("Tx hashes: " + result.getTransactionHashes());
-        System.out.println("\n=== Test 11 completed successfully! ===\n");
+        System.out.println("\n=== Test 12 completed successfully! ===\n");
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     void yamlString_indexedUtxoSelection_success() throws Exception {
-        System.out.println("=== Test 12: YAML String - Indexed UTXO Selection ===");
+        System.out.println("=== Test 13: YAML String - Indexed UTXO Selection ===");
 
         String yaml = """
                 version: "1.0"
@@ -725,13 +794,13 @@ public class TxFlowYamlIntegrationTest {
         assertEquals(2, result.getTransactionHashes().size());
 
         System.out.println("Tx hashes: " + result.getTransactionHashes());
-        System.out.println("\n=== Test 12 completed successfully! ===\n");
+        System.out.println("\n=== Test 13 completed successfully! ===\n");
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void yamlString_changeOutputDependency_success() throws Exception {
-        System.out.println("=== Test 13: YAML String - Change Output Dependency ===");
+        System.out.println("=== Test 14: YAML String - Change Output Dependency ===");
 
         // Step 1: Sender sends 2 ADA to Receiver. This creates a change output back to Sender.
         // Step 2: Sender sends 1 ADA to Relay. With strategy: all, step1's change output
@@ -797,7 +866,7 @@ public class TxFlowYamlIntegrationTest {
         assertEquals(2, result.getTransactionHashes().size());
 
         System.out.println("Tx hashes: " + result.getTransactionHashes());
-        System.out.println("\n=== Test 13 completed successfully! ===\n");
+        System.out.println("\n=== Test 14 completed successfully! ===\n");
     }
 
     // ==================== Helpers ====================

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/FlowExecutionSettings.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/FlowExecutionSettings.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.client.txflow;
+
+import com.bloxbean.cardano.client.txflow.exec.ConfirmationConfig;
+import com.bloxbean.cardano.client.txflow.exec.RollbackStrategy;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Optional flow-level execution settings carried by a {@link TxFlow}.
+ * <p>
+ * These settings describe how a flow should be executed when the executor has
+ * not provided an explicit override. Null fields mean the setting was not
+ * provided by the flow.
+ */
+@Getter
+@Builder(toBuilder = true)
+public class FlowExecutionSettings {
+
+    private static final FlowExecutionSettings EMPTY = FlowExecutionSettings.builder().build();
+
+    private final ChainingMode chainingMode;
+    private final ConfirmationConfig confirmationConfig;
+    private final RollbackStrategy rollbackStrategy;
+    private final RetryPolicy retryPolicy;
+
+    public static FlowExecutionSettings empty() {
+        return EMPTY;
+    }
+
+    public boolean hasAnySetting() {
+        return chainingMode != null
+                || confirmationConfig != null
+                || rollbackStrategy != null
+                || retryPolicy != null;
+    }
+}

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/TxFlow.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/TxFlow.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.client.txflow;
 
 import com.bloxbean.cardano.client.txflow.yaml.FlowDocument;
+import com.bloxbean.cardano.client.txflow.exec.ConfirmationConfig;
+import com.bloxbean.cardano.client.txflow.exec.RollbackStrategy;
 import lombok.Getter;
 
 import java.util.*;
@@ -46,12 +48,16 @@ public class TxFlow {
     private final String description;
     private final Map<String, Object> variables;
     private final List<FlowStep> steps;
+    private final FlowExecutionSettings executionSettings;
 
     private TxFlow(Builder builder) {
         this.id = builder.id;
         this.description = builder.description;
         this.variables = Collections.unmodifiableMap(new HashMap<>(builder.variables));
         this.steps = Collections.unmodifiableList(new ArrayList<>(builder.steps));
+        this.executionSettings = builder.executionSettings != null
+                ? builder.executionSettings
+                : FlowExecutionSettings.empty();
     }
 
     /**
@@ -261,6 +267,7 @@ public class TxFlow {
         private String description;
         private final Map<String, Object> variables = new HashMap<>();
         private final List<FlowStep> steps = new ArrayList<>();
+        private FlowExecutionSettings executionSettings = FlowExecutionSettings.empty();
 
         private Builder(String id) {
             if (id == null || id.isEmpty()) {
@@ -303,6 +310,81 @@ public class TxFlow {
             if (variables != null) {
                 this.variables.putAll(variables);
             }
+            return this;
+        }
+
+        /**
+         * Set flow-level execution settings.
+         *
+         * @param executionSettings execution settings for this flow
+         * @return this builder
+         */
+        public Builder withExecutionSettings(FlowExecutionSettings executionSettings) {
+            this.executionSettings = executionSettings != null
+                    ? executionSettings
+                    : FlowExecutionSettings.empty();
+            return this;
+        }
+
+        /**
+         * Alias for {@link #withExecutionSettings(FlowExecutionSettings)} for YAML context parity.
+         *
+         * @param executionSettings execution settings for this flow
+         * @return this builder
+         */
+        public Builder withContext(FlowExecutionSettings executionSettings) {
+            return withExecutionSettings(executionSettings);
+        }
+
+        /**
+         * Set the flow-level chaining mode.
+         *
+         * @param chainingMode chaining mode
+         * @return this builder
+         */
+        public Builder withChainingMode(ChainingMode chainingMode) {
+            this.executionSettings = this.executionSettings.toBuilder()
+                    .chainingMode(chainingMode)
+                    .build();
+            return this;
+        }
+
+        /**
+         * Set the flow-level confirmation configuration.
+         *
+         * @param confirmationConfig confirmation configuration
+         * @return this builder
+         */
+        public Builder withConfirmationConfig(ConfirmationConfig confirmationConfig) {
+            this.executionSettings = this.executionSettings.toBuilder()
+                    .confirmationConfig(confirmationConfig)
+                    .build();
+            return this;
+        }
+
+        /**
+         * Set the flow-level rollback strategy.
+         *
+         * @param rollbackStrategy rollback strategy
+         * @return this builder
+         */
+        public Builder withRollbackStrategy(RollbackStrategy rollbackStrategy) {
+            this.executionSettings = this.executionSettings.toBuilder()
+                    .rollbackStrategy(rollbackStrategy)
+                    .build();
+            return this;
+        }
+
+        /**
+         * Set the flow-level default retry policy for steps that do not define one.
+         *
+         * @param retryPolicy default retry policy
+         * @return this builder
+         */
+        public Builder withDefaultRetryPolicy(RetryPolicy retryPolicy) {
+            this.executionSettings = this.executionSettings.toBuilder()
+                    .retryPolicy(retryPolicy)
+                    .build();
             return this;
         }
 

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/exec/FlowExecutor.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/exec/FlowExecutor.java
@@ -19,6 +19,7 @@ import com.bloxbean.cardano.client.quicktx.signing.SignerRegistry;
 import com.bloxbean.cardano.client.transaction.spec.*;
 import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
 import com.bloxbean.cardano.client.txflow.ChainingMode;
+import com.bloxbean.cardano.client.txflow.FlowExecutionSettings;
 import com.bloxbean.cardano.client.txflow.FlowStep;
 import com.bloxbean.cardano.client.txflow.RetryPolicy;
 import com.bloxbean.cardano.client.txflow.TxFlow;
@@ -66,6 +67,9 @@ import java.util.function.Consumer;
  * FlowHandle handle = executor.execute(flow);
  * FlowResult result = handle.await();
  * }</pre>
+ * Configure an executor before starting flows. Each execution snapshots the effective
+ * settings for that flow, but mutating executor configuration while flows are in flight
+ * is not an atomic reconfiguration operation.
  */
 @Slf4j
 public class FlowExecutor implements AutoCloseable {
@@ -103,8 +107,11 @@ public class FlowExecutor implements AutoCloseable {
     private volatile ChainingMode chainingMode = ChainingMode.SEQUENTIAL;
     private volatile RetryPolicy defaultRetryPolicy;
     private volatile ConfirmationConfig confirmationConfig;
-    private volatile ConfirmationTracker confirmationTracker;
     private volatile RollbackStrategy rollbackStrategy = RollbackStrategy.FAIL_IMMEDIATELY;
+    private volatile boolean chainingModeConfigured;
+    private volatile boolean defaultRetryPolicyConfigured;
+    private volatile boolean confirmationConfigConfigured;
+    private volatile boolean rollbackStrategyConfigured;
     private volatile FlowRegistry flowRegistry;
     private volatile FlowStateStore flowStateStore;
     private final Set<String> activeFlowIds = ConcurrentHashMap.newKeySet();
@@ -245,12 +252,16 @@ public class FlowExecutor implements AutoCloseable {
      *         for confirmations between steps. Transactions can potentially land in the
      *         same block, providing faster execution.</li>
      * </ul>
+     * Calling this setter marks the chaining mode as explicitly configured, even when
+     * {@code mode} is null. A null value explicitly selects {@link ChainingMode#SEQUENTIAL}
+     * and suppresses any flow-level chaining mode.
      *
      * @param mode the chaining mode
      * @return this executor
      */
     public FlowExecutor withChainingMode(ChainingMode mode) {
         this.chainingMode = mode != null ? mode : ChainingMode.SEQUENTIAL;
+        this.chainingModeConfigured = true;
         return this;
     }
 
@@ -259,12 +270,16 @@ public class FlowExecutor implements AutoCloseable {
      * <p>
      * This policy will be used for any step that doesn't have its own step-level retry policy.
      * If not set, no retries will be performed by default.
+     * Calling this setter marks the default retry policy as explicitly configured, even when
+     * {@code retryPolicy} is null. A null value explicitly disables the executor default
+     * retry policy and suppresses any flow-level default retry policy.
      *
      * @param retryPolicy the default retry policy
      * @return this executor
      */
     public FlowExecutor withDefaultRetryPolicy(RetryPolicy retryPolicy) {
         this.defaultRetryPolicy = retryPolicy;
+        this.defaultRetryPolicyConfigured = true;
         return this;
     }
 
@@ -279,15 +294,16 @@ public class FlowExecutor implements AutoCloseable {
      * </ul>
      * <p>
      * If not set, the executor uses simple confirmation checking (transaction exists = confirmed).
+     * Calling this setter marks confirmation as explicitly configured, even when
+     * {@code config} is null. A null value explicitly selects simple confirmation mode
+     * and suppresses any flow-level confirmation config.
      *
      * @param config the confirmation configuration
      * @return this executor
      */
     public FlowExecutor withConfirmationConfig(ConfirmationConfig config) {
         this.confirmationConfig = config;
-        if (config != null) {
-            this.confirmationTracker = new ConfirmationTracker(chainDataSupplier, config);
-        }
+        this.confirmationConfigConfigured = true;
         return this;
     }
 
@@ -305,14 +321,18 @@ public class FlowExecutor implements AutoCloseable {
      * For REBUILD_FROM_FAILED and REBUILD_ENTIRE_FLOW strategies, the maximum number of
      * rebuild attempts is controlled by the {@code maxRollbackRetries} setting in {@link ConfirmationConfig}.
      * <p>
-     * Note: This only takes effect when {@link #withConfirmationConfig(ConfirmationConfig)}
-     * has been set, as rollback detection requires confirmation tracking.
+     * Note: Non-default rollback strategies only take effect when confirmation tracking
+     * is configured either on the executor or in the flow-level execution settings.
+     * Calling this setter marks the rollback strategy as explicitly configured, even when
+     * {@code strategy} is null. A null value explicitly selects
+     * {@link RollbackStrategy#FAIL_IMMEDIATELY} and suppresses any flow-level rollback strategy.
      *
      * @param strategy the rollback strategy
      * @return this executor
      */
     public FlowExecutor withRollbackStrategy(RollbackStrategy strategy) {
         this.rollbackStrategy = strategy != null ? strategy : RollbackStrategy.FAIL_IMMEDIATELY;
+        this.rollbackStrategyConfigured = true;
         return this;
     }
 
@@ -435,6 +455,53 @@ public class FlowExecutor implements AutoCloseable {
         };
     }
 
+    @Getter
+    @AllArgsConstructor
+    static class EffectiveFlowExecutionSettings {
+        private final ChainingMode chainingMode;
+        private final RetryPolicy defaultRetryPolicy;
+        private final ConfirmationConfig confirmationConfig;
+        private final ConfirmationTracker confirmationTracker;
+        private final RollbackStrategy rollbackStrategy;
+    }
+
+    EffectiveFlowExecutionSettings effectiveSettings(TxFlow flow) {
+        FlowExecutionSettings flowSettings = flow.getExecutionSettings() != null
+                ? flow.getExecutionSettings()
+                : FlowExecutionSettings.empty();
+
+        ChainingMode effectiveChainingMode = chainingModeConfigured
+                ? chainingMode
+                : flowSettings.getChainingMode() != null
+                        ? flowSettings.getChainingMode()
+                        : ChainingMode.SEQUENTIAL;
+
+        RetryPolicy effectiveDefaultRetryPolicy = defaultRetryPolicyConfigured
+                ? defaultRetryPolicy
+                : flowSettings.getRetryPolicy();
+
+        ConfirmationConfig effectiveConfirmationConfig = confirmationConfigConfigured
+                ? confirmationConfig
+                : flowSettings.getConfirmationConfig();
+
+        RollbackStrategy effectiveRollbackStrategy = rollbackStrategyConfigured
+                ? rollbackStrategy
+                : flowSettings.getRollbackStrategy() != null
+                        ? flowSettings.getRollbackStrategy()
+                        : RollbackStrategy.FAIL_IMMEDIATELY;
+
+        ConfirmationTracker effectiveConfirmationTracker = effectiveConfirmationConfig != null
+                ? new ConfirmationTracker(chainDataSupplier, effectiveConfirmationConfig)
+                : null;
+
+        return new EffectiveFlowExecutionSettings(
+                effectiveChainingMode,
+                effectiveDefaultRetryPolicy,
+                effectiveConfirmationConfig,
+                effectiveConfirmationTracker,
+                effectiveRollbackStrategy);
+    }
+
     // ==================== Public Execution Methods ====================
 
     /**
@@ -445,11 +512,12 @@ public class FlowExecutor implements AutoCloseable {
      *
      * @throws IllegalStateException if configuration is invalid
      */
-    private void validateConfiguration() {
-        if (rollbackStrategy != RollbackStrategy.FAIL_IMMEDIATELY && confirmationTracker == null) {
+    private void validateConfiguration(EffectiveFlowExecutionSettings settings) {
+        if (settings.getRollbackStrategy() != RollbackStrategy.FAIL_IMMEDIATELY
+                && settings.getConfirmationConfig() == null) {
             throw new IllegalStateException(
-                    "Rollback strategy " + rollbackStrategy + " requires confirmation tracking. " +
-                    "Call withConfirmationConfig() before execute().");
+                    "Rollback strategy " + settings.getRollbackStrategy() + " requires confirmation tracking. " +
+                    "Call withConfirmationConfig() or set context.confirmation before execute().");
         }
     }
 
@@ -479,7 +547,8 @@ public class FlowExecutor implements AutoCloseable {
      * @throws FlowExecutionException if flow validation fails
      */
     public FlowResult resumeSync(TxFlow flow, FlowResult previousResult) {
-        validateConfiguration();
+        EffectiveFlowExecutionSettings settings = effectiveSettings(flow);
+        validateConfiguration(settings);
 
         TxFlow.ValidationResult validation = flow.validate();
         if (!validation.isValid()) {
@@ -495,14 +564,14 @@ public class FlowExecutor implements AutoCloseable {
         }
 
         try {
-            switch (chainingMode) {
+            switch (settings.getChainingMode()) {
                 case PIPELINED:
-                    return doExecutePipelinedWithResume(flow, syncHooks(flow), confirmedSteps);
+                    return doExecutePipelinedWithResume(flow, syncHooks(flow), confirmedSteps, settings);
                 case BATCH:
-                    return doExecuteBatchWithResume(flow, syncHooks(flow), confirmedSteps);
+                    return doExecuteBatchWithResume(flow, syncHooks(flow), confirmedSteps, settings);
                 case SEQUENTIAL:
                 default:
-                    return doExecuteSequentialWithResume(flow, syncHooks(flow), confirmedSteps);
+                    return doExecuteSequentialWithResume(flow, syncHooks(flow), confirmedSteps, settings);
             }
         } finally {
             activeFlowIds.remove(flow.getId());
@@ -523,7 +592,8 @@ public class FlowExecutor implements AutoCloseable {
      * @throws IllegalStateException if the flow is already executing
      */
     public FlowHandle resume(TxFlow flow, FlowResult previousResult) {
-        validateConfiguration();
+        EffectiveFlowExecutionSettings settings = effectiveSettings(flow);
+        validateConfiguration(settings);
 
         TxFlow.ValidationResult validation = flow.validate();
         if (!validation.isValid()) {
@@ -551,16 +621,16 @@ public class FlowExecutor implements AutoCloseable {
             try {
                 handle.updateStatus(FlowStatus.IN_PROGRESS);
                 FlowResult result;
-                switch (chainingMode) {
+                switch (settings.getChainingMode()) {
                     case PIPELINED:
-                        result = doExecutePipelinedWithResume(flow, handleHooks(flow, handle), confirmedSteps);
+                        result = doExecutePipelinedWithResume(flow, handleHooks(flow, handle), confirmedSteps, settings);
                         break;
                     case BATCH:
-                        result = doExecuteBatchWithResume(flow, handleHooks(flow, handle), confirmedSteps);
+                        result = doExecuteBatchWithResume(flow, handleHooks(flow, handle), confirmedSteps, settings);
                         break;
                     case SEQUENTIAL:
                     default:
-                        result = doExecuteSequentialWithResume(flow, handleHooks(flow, handle), confirmedSteps);
+                        result = doExecuteSequentialWithResume(flow, handleHooks(flow, handle), confirmedSteps, settings);
                         break;
                 }
                 activeFlowIds.remove(flow.getId());
@@ -587,7 +657,8 @@ public class FlowExecutor implements AutoCloseable {
      * @return the flow result
      */
     public FlowResult executeSync(TxFlow flow) {
-        validateConfiguration();
+        EffectiveFlowExecutionSettings settings = effectiveSettings(flow);
+        validateConfiguration(settings);
 
         // Validate the flow
         TxFlow.ValidationResult validation = flow.validate();
@@ -600,14 +671,14 @@ public class FlowExecutor implements AutoCloseable {
         }
 
         try {
-            switch (chainingMode) {
+            switch (settings.getChainingMode()) {
                 case PIPELINED:
-                    return executePipelined(flow);
+                    return executePipelined(flow, settings);
                 case BATCH:
-                    return executeBatch(flow);
+                    return executeBatch(flow, settings);
                 case SEQUENTIAL:
                 default:
-                    return executeSequential(flow);
+                    return executeSequential(flow, settings);
             }
         } finally {
             activeFlowIds.remove(flow.getId());
@@ -617,8 +688,8 @@ public class FlowExecutor implements AutoCloseable {
     /**
      * Thin wrapper: synchronous SEQUENTIAL execution.
      */
-    private FlowResult executeSequential(TxFlow flow) {
-        return doExecuteSequential(flow, syncHooks(flow));
+    private FlowResult executeSequential(TxFlow flow, EffectiveFlowExecutionSettings settings) {
+        return doExecuteSequential(flow, syncHooks(flow), settings);
     }
 
     /**
@@ -630,8 +701,9 @@ public class FlowExecutor implements AutoCloseable {
      *     <li>REBUILD_ENTIRE_FLOW: Restarts the entire flow from step 1</li>
      * </ul>
      */
-    private FlowResult doExecuteSequential(TxFlow flow, ExecutionHooks hooks) {
-        int maxRollbackRetries = getMaxRollbackRetries();
+    private FlowResult doExecuteSequential(TxFlow flow, ExecutionHooks hooks,
+                                           EffectiveFlowExecutionSettings settings) {
+        int maxRollbackRetries = getMaxRollbackRetries(settings);
         int flowRestartAttempts = 0;
         Map<String, Integer> stepRollbackAttempts = new ConcurrentHashMap<>();
         List<String> flowTxHashes = new ArrayList<>();
@@ -667,7 +739,7 @@ public class FlowExecutor implements AutoCloseable {
 
                     FlowStepResult stepResult = executeStepWithRollbackHandling(
                             step, context, flow.getVariables(), false,
-                            stepRollbackAttempts, maxRollbackRetries, steps, cancelCheck);
+                            stepRollbackAttempts, maxRollbackRetries, steps, cancelCheck, settings);
                     resultBuilder.addStepResult(stepResult);
 
                     if (stepResult.isSuccessful()) {
@@ -678,7 +750,7 @@ public class FlowExecutor implements AutoCloseable {
                         listener.onStepCompleted(step, stepResult);
 
                         // Get confirmation details - tx is already confirmed from completeAndWait()
-                        Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck);
+                        Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck, settings);
                         hooks.onTransactionConfirmed(flow, step, txHash, confirmResult.orElse(null));
                     } else {
                         listener.onStepFailed(step, stepResult);
@@ -693,9 +765,9 @@ public class FlowExecutor implements AutoCloseable {
                 }
 
                 // Cleanup tracked transactions to prevent memory leak
-                if (confirmationTracker != null) {
+                if (settings.getConfirmationTracker() != null) {
                     for (String hash : flowTxHashes) {
-                        confirmationTracker.stopTracking(hash);
+                        settings.getConfirmationTracker().stopTracking(hash);
                     }
                 }
 
@@ -726,7 +798,8 @@ public class FlowExecutor implements AutoCloseable {
                             flowRestartAttempts, maxRollbackRetries, e.getStep().getId());
                     listener.onFlowRestarting(flow, flowRestartAttempts, maxRollbackRetries,
                             "Rollback detected at step '" + e.getStep().getId() + "'");
-                    waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck);
+                    waitForBackendReadyAfterRollback(rollbackCleanupHashes(flowTxHashes, e.getTxHash()),
+                            cancelCheck, settings);
                     stepRollbackAttempts.clear();
                     hooks.onFlowRestarting();
                     continue;
@@ -764,22 +837,22 @@ public class FlowExecutor implements AutoCloseable {
     /**
      * Get the maximum rollback retries from configuration.
      */
-    private int getMaxRollbackRetries() {
-        return confirmationConfig != null ? confirmationConfig.getMaxRollbackRetries() : 3;
+    private int getMaxRollbackRetries(EffectiveFlowExecutionSettings settings) {
+        return settings.getConfirmationConfig() != null ? settings.getConfirmationConfig().getMaxRollbackRetries() : 3;
     }
 
     /**
      * Get the confirmation timeout from configuration or use default.
      */
-    private Duration getConfirmationTimeout() {
-        return confirmationConfig != null ? confirmationConfig.getTimeout() : DEFAULT_CONFIRMATION_TIMEOUT;
+    private Duration getConfirmationTimeout(EffectiveFlowExecutionSettings settings) {
+        return settings.getConfirmationConfig() != null ? settings.getConfirmationConfig().getTimeout() : DEFAULT_CONFIRMATION_TIMEOUT;
     }
 
     /**
      * Get the check interval from configuration or use default.
      */
-    private Duration getCheckInterval() {
-        return confirmationConfig != null ? confirmationConfig.getCheckInterval() : DEFAULT_CHECK_INTERVAL;
+    private Duration getCheckInterval(EffectiveFlowExecutionSettings settings) {
+        return settings.getConfirmationConfig() != null ? settings.getConfirmationConfig().getCheckInterval() : DEFAULT_CHECK_INTERVAL;
     }
 
     /**
@@ -801,14 +874,15 @@ public class FlowExecutor implements AutoCloseable {
                                                             Map<String, Integer> stepRollbackAttempts,
                                                             int maxRollbackRetries,
                                                             List<FlowStep> allSteps,
-                                                            BooleanSupplier cancelCheck) {
+                                                            BooleanSupplier cancelCheck,
+                                                            EffectiveFlowExecutionSettings settings) {
         while (true) {
             if (cancelCheck.getAsBoolean()) {
                 return FlowStepResult.failure(step.getId(), new RuntimeException("Flow cancelled"));
             }
 
             try {
-                return executeStepWithRetry(step, context, variables, pipelined, cancelCheck);
+                return executeStepWithRetry(step, context, variables, pipelined, cancelCheck, settings);
             } catch (RollbackException e) {
                 if (e.isRequiresFlowRestart()) {
                     // REBUILD_ENTIRE_FLOW: propagate exception to flow level
@@ -837,7 +911,7 @@ public class FlowExecutor implements AutoCloseable {
                 listener.onStepRebuilding(step, currentAttempts, maxRollbackRetries,
                         "Transaction " + e.getTxHash() + " rolled back");
 
-                waitForBackendReadyAfterRollback(List.of(e.getTxHash()), cancelCheck); // Wait for backend to sync after rollback
+                waitForBackendReadyAfterRollback(List.of(e.getTxHash()), cancelCheck, settings); // Wait for backend to sync after rollback
 
                 // Clear the step result so it can be rebuilt
                 context.clearStepResult(step.getId());
@@ -867,8 +941,8 @@ public class FlowExecutor implements AutoCloseable {
     /**
      * Thin wrapper: synchronous PIPELINED execution.
      */
-    private FlowResult executePipelined(TxFlow flow) {
-        return doExecutePipelined(flow, syncHooks(flow));
+    private FlowResult executePipelined(TxFlow flow, EffectiveFlowExecutionSettings settings) {
+        return doExecutePipelined(flow, syncHooks(flow), settings);
     }
 
     /**
@@ -879,8 +953,9 @@ public class FlowExecutor implements AutoCloseable {
      * On restart after rollback, steps whose transactions are still confirmed on-chain
      * are skipped to avoid unnecessary rebuilding.
      */
-    private FlowResult doExecutePipelined(TxFlow flow, ExecutionHooks hooks) {
-        int maxRollbackRetries = getMaxRollbackRetries();
+    private FlowResult doExecutePipelined(TxFlow flow, ExecutionHooks hooks,
+                                          EffectiveFlowExecutionSettings settings) {
+        int maxRollbackRetries = getMaxRollbackRetries(settings);
         int flowRestartAttempts = 0;
         Map<Integer, FlowStepResult> previousConfirmedSteps = new HashMap<>();
         List<String> flowTxHashes = new ArrayList<>();
@@ -937,7 +1012,8 @@ public class FlowExecutor implements AutoCloseable {
                         continue;
                     }
 
-                    FlowStepResult stepResult = executeStepWithRetry(step, context, flow.getVariables(), true, cancelCheck);
+                    FlowStepResult stepResult = executeStepWithRetry(step, context, flow.getVariables(), true,
+                            cancelCheck, settings);
                     stepResults.add(stepResult);
                     resultBuilder.addStepResult(stepResult);
 
@@ -973,7 +1049,7 @@ public class FlowExecutor implements AutoCloseable {
                         continue;
                     }
 
-                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck);
+                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck, settings);
                     if (confirmResult.isPresent()) {
                         ConfirmationResult result = confirmResult.get();
                         hooks.onStepCompleted(step, stepResults.get(i));
@@ -997,9 +1073,9 @@ public class FlowExecutor implements AutoCloseable {
                 }
 
                 // Cleanup tracked transactions to prevent memory leak
-                if (confirmationTracker != null) {
+                if (settings.getConfirmationTracker() != null) {
                     for (String hash : flowTxHashes) {
-                        confirmationTracker.stopTracking(hash);
+                        settings.getConfirmationTracker().stopTracking(hash);
                     }
                 }
 
@@ -1033,7 +1109,7 @@ public class FlowExecutor implements AutoCloseable {
                 // Find steps that are still confirmed before clearing tracker
                 previousConfirmedSteps = findStillConfirmedSteps(steps, submittedTxHashes, stepResults);
 
-                waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck);
+                waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck, settings);
                 hooks.onFlowRestarting();
                 continue;
 
@@ -1120,10 +1196,6 @@ public class FlowExecutor implements AutoCloseable {
      * @param txHash the transaction hash to wait for
      * @return Optional containing ConfirmationResult if confirmed, empty if timeout or failure
      */
-    private Optional<ConfirmationResult> waitForConfirmation(String txHash) {
-        return waitForConfirmation(txHash, null, () -> false);
-    }
-
     /**
      * Wait for a transaction to be confirmed on-chain with enhanced tracking.
      * <p>
@@ -1139,16 +1211,17 @@ public class FlowExecutor implements AutoCloseable {
      * @return Optional containing ConfirmationResult if confirmed, empty if timeout or rollback
      */
     private Optional<ConfirmationResult> waitForConfirmation(String txHash, FlowStep step,
-                                                               BooleanSupplier cancelCheck) {
+                                                               BooleanSupplier cancelCheck,
+                                                               EffectiveFlowExecutionSettings settings) {
         // Use enhanced confirmation tracking if configured
-        if (confirmationTracker != null) {
-            return waitForConfirmationWithTracking(txHash, step, cancelCheck);
+        if (settings.getConfirmationTracker() != null) {
+            return waitForConfirmationWithTracking(txHash, step, cancelCheck, settings);
         }
 
         // Fall back to simple confirmation checking
         long startTime = System.currentTimeMillis();
-        long timeoutMs = getConfirmationTimeout().toMillis();
-        long intervalMs = getCheckInterval().toMillis();
+        long timeoutMs = getConfirmationTimeout(settings).toMillis();
+        long intervalMs = getCheckInterval(settings).toMillis();
 
         while (System.currentTimeMillis() - startTime < timeoutMs) {
             if (cancelCheck.getAsBoolean() || Thread.currentThread().isInterrupted()) {
@@ -1201,7 +1274,8 @@ public class FlowExecutor implements AutoCloseable {
      * @throws RollbackException when using REBUILD_FROM_FAILED or REBUILD_ENTIRE_FLOW strategies
      */
     private Optional<ConfirmationResult> waitForConfirmationWithTracking(String txHash, FlowStep step,
-                                                                          BooleanSupplier cancelCheck) {
+                                                                          BooleanSupplier cancelCheck,
+                                                                          EffectiveFlowExecutionSettings settings) {
         ConfirmationStatus targetStatus = ConfirmationStatus.CONFIRMED;
 
         // Track the last known status for detecting transitions
@@ -1213,7 +1287,7 @@ public class FlowExecutor implements AutoCloseable {
             if (cancelCheck.getAsBoolean() || Thread.currentThread().isInterrupted()) {
                 return Optional.empty();
             }
-            ConfirmationResult result = confirmationTracker.waitForConfirmation(txHash, targetStatus,
+            ConfirmationResult result = settings.getConfirmationTracker().waitForConfirmation(txHash, targetStatus,
                     (hash, confirmResult) -> {
                         if (step == null) return;
 
@@ -1245,22 +1319,23 @@ public class FlowExecutor implements AutoCloseable {
                     listener.onTransactionRolledBack(step, txHash, prevHeight);
                 }
 
-                switch (rollbackStrategy) {
+                switch (settings.getRollbackStrategy()) {
                     case FAIL_IMMEDIATELY:
                         log.warn("Transaction {} rolled back, failing flow (FAIL_IMMEDIATELY strategy)", txHash);
                         return Optional.empty();
 
                     case NOTIFY_ONLY:
                         notifyOnlyRepolls++;
-                        if (notifyOnlyRepolls > getMaxRollbackRetries()) {
-                            log.warn("NOTIFY_ONLY re-poll limit ({}) reached for tx {}", getMaxRollbackRetries(), txHash);
+                        if (notifyOnlyRepolls > getMaxRollbackRetries(settings)) {
+                            log.warn("NOTIFY_ONLY re-poll limit ({}) reached for tx {}",
+                                    getMaxRollbackRetries(settings), txHash);
                             return Optional.empty();
                         }
                         // Clear stale tracker state and re-enter polling
                         // The tx may be re-included from mempool after new blocks are mined
                         log.warn("Transaction {} rolled back, re-entering confirmation polling (NOTIFY_ONLY strategy, attempt {}/{})",
-                                txHash, notifyOnlyRepolls, getMaxRollbackRetries());
-                        confirmationTracker.stopTracking(txHash);
+                                txHash, notifyOnlyRepolls, getMaxRollbackRetries(settings));
+                        settings.getConfirmationTracker().stopTracking(txHash);
                         firstBlockHeight[0] = null;
                         lastStatus[0] = null;
                         continue;  // re-enter the while loop to poll again
@@ -1331,6 +1406,14 @@ public class FlowExecutor implements AutoCloseable {
         log.warn("Backend may not be fully ready after {} attempts", maxAttempts);
     }
 
+    private List<String> rollbackCleanupHashes(List<String> flowTxHashes, String rollbackTxHash) {
+        List<String> hashes = new ArrayList<>(flowTxHashes);
+        if (rollbackTxHash != null && !hashes.contains(rollbackTxHash)) {
+            hashes.add(rollbackTxHash);
+        }
+        return hashes;
+    }
+
     /**
      * Wait for backend to be ready after a rollback.
      * <p>
@@ -1345,31 +1428,32 @@ public class FlowExecutor implements AutoCloseable {
      *         Waits for backend ready and optional UTXO sync delay.</li>
      * </ul>
      */
-    private void waitForBackendReadyAfterRollback(List<String> flowTxHashes, BooleanSupplier cancelCheck) {
+    private void waitForBackendReadyAfterRollback(List<String> flowTxHashes, BooleanSupplier cancelCheck,
+                                                   EffectiveFlowExecutionSettings settings) {
         // Clear only this flow's tracked transactions (scoped, not global)
-        if (confirmationTracker != null) {
+        if (settings.getConfirmationTracker() != null) {
             log.debug("Clearing confirmation tracker state for {} flow transactions after rollback", flowTxHashes.size());
             for (String txHash : flowTxHashes) {
-                confirmationTracker.stopTracking(txHash);
+                settings.getConfirmationTracker().stopTracking(txHash);
             }
         }
 
         // Skip wait logic if not configured (production default)
-        if (confirmationConfig == null || !confirmationConfig.isWaitForBackendAfterRollback()) {
+        if (settings.getConfirmationConfig() == null || !settings.getConfirmationConfig().isWaitForBackendAfterRollback()) {
             log.debug("Skipping backend wait (not configured for post-rollback wait)");
             return;
         }
 
         // Wait for backend ready (for test scenarios like Yaci DevKit)
-        long retryDelayMs = confirmationConfig.getCheckInterval().toMillis();
-        int maxAttempts = confirmationConfig.getPostRollbackWaitAttempts();
+        long retryDelayMs = settings.getConfirmationConfig().getCheckInterval().toMillis();
+        int maxAttempts = settings.getConfirmationConfig().getPostRollbackWaitAttempts();
         waitForBackendReady(maxAttempts, retryDelayMs, cancelCheck);
 
         // Optional additional delay for UTXO indexer sync
         if (cancelCheck.getAsBoolean()) {
             return;
         }
-        Duration utxoSyncDelay = confirmationConfig.getPostRollbackUtxoSyncDelay();
+        Duration utxoSyncDelay = settings.getConfirmationConfig().getPostRollbackUtxoSyncDelay();
         if (utxoSyncDelay != null && !utxoSyncDelay.isZero()) {
             try {
                 log.debug("Waiting {}ms for UTXO indexer to sync", utxoSyncDelay.toMillis());
@@ -1390,7 +1474,8 @@ public class FlowExecutor implements AutoCloseable {
      * @return a handle for monitoring the execution
      */
     public FlowHandle execute(TxFlow flow) {
-        validateConfiguration();
+        EffectiveFlowExecutionSettings settings = effectiveSettings(flow);
+        validateConfiguration(settings);
 
         if (!activeFlowIds.add(flow.getId())) {
             throw new IllegalStateException("Flow '" + flow.getId() + "' is already executing");
@@ -1408,7 +1493,7 @@ public class FlowExecutor implements AutoCloseable {
         Runnable task = () -> {
             try {
                 handle.updateStatus(FlowStatus.IN_PROGRESS);
-                FlowResult result = executeWithHandle(flow, handle);
+                FlowResult result = executeWithHandle(flow, handle, settings);
                 // Clean up BEFORE completing the future so callers unblocked by
                 // await() can immediately re-execute the same flow ID.
                 activeFlowIds.remove(flow.getId());
@@ -1428,36 +1513,39 @@ public class FlowExecutor implements AutoCloseable {
         return handle;
     }
 
-    private FlowResult executeWithHandle(TxFlow flow, FlowHandle handle) {
+    private FlowResult executeWithHandle(TxFlow flow, FlowHandle handle,
+                                         EffectiveFlowExecutionSettings settings) {
         // Validate the flow
         TxFlow.ValidationResult validation = flow.validate();
         if (!validation.isValid()) {
             throw new FlowExecutionException("Flow validation failed: " + validation.getErrors());
         }
 
-        switch (chainingMode) {
+        switch (settings.getChainingMode()) {
             case PIPELINED:
-                return executeWithHandlePipelined(flow, handle);
+                return executeWithHandlePipelined(flow, handle, settings);
             case BATCH:
-                return executeWithHandleBatch(flow, handle);
+                return executeWithHandleBatch(flow, handle, settings);
             case SEQUENTIAL:
             default:
-                return executeWithHandleSequential(flow, handle);
+                return executeWithHandleSequential(flow, handle, settings);
         }
     }
 
     /**
      * Thin wrapper: async SEQUENTIAL execution with FlowHandle.
      */
-    private FlowResult executeWithHandleSequential(TxFlow flow, FlowHandle handle) {
-        return doExecuteSequential(flow, handleHooks(flow, handle));
+    private FlowResult executeWithHandleSequential(TxFlow flow, FlowHandle handle,
+                                                   EffectiveFlowExecutionSettings settings) {
+        return doExecuteSequential(flow, handleHooks(flow, handle), settings);
     }
 
     /**
      * Thin wrapper: async PIPELINED execution with FlowHandle.
      */
-    private FlowResult executeWithHandlePipelined(TxFlow flow, FlowHandle handle) {
-        return doExecutePipelined(flow, handleHooks(flow, handle));
+    private FlowResult executeWithHandlePipelined(TxFlow flow, FlowHandle handle,
+                                                  EffectiveFlowExecutionSettings settings) {
+        return doExecutePipelined(flow, handleHooks(flow, handle), settings);
     }
 
     /**
@@ -1475,9 +1563,10 @@ public class FlowExecutor implements AutoCloseable {
      */
     private FlowStepResult executeStepWithRetry(FlowStep step, FlowExecutionContext context,
                                                  java.util.Map<String, Object> variables, boolean pipelined,
-                                                 BooleanSupplier cancelCheck) {
+                                                 BooleanSupplier cancelCheck,
+                                                 EffectiveFlowExecutionSettings settings) {
         // Determine retry policy (step-level overrides default)
-        RetryPolicy policy = step.hasRetryPolicy() ? step.getRetryPolicy() : defaultRetryPolicy;
+        RetryPolicy policy = step.hasRetryPolicy() ? step.getRetryPolicy() : settings.getDefaultRetryPolicy();
         int maxAttempts = (policy != null) ? policy.getMaxAttempts() : 1;
 
         Throwable lastError = null;
@@ -1486,7 +1575,7 @@ public class FlowExecutor implements AutoCloseable {
             try {
                 FlowStepResult result = pipelined
                         ? executeStepPipelined(step, context, variables)
-                        : executeStepSequential(step, context, variables, cancelCheck);
+                        : executeStepSequential(step, context, variables, cancelCheck, settings);
 
                 if (result.isSuccessful()) {
                     return result;  // Success!
@@ -1531,7 +1620,8 @@ public class FlowExecutor implements AutoCloseable {
      */
     private FlowStepResult executeStepSequential(FlowStep step, FlowExecutionContext context,
                                                   java.util.Map<String, Object> variables,
-                                                  BooleanSupplier cancelCheck) {
+                                                  BooleanSupplier cancelCheck,
+                                                  EffectiveFlowExecutionSettings settings) {
         String stepId = step.getId();
         log.debug("Executing step '{}'", stepId);
 
@@ -1575,7 +1665,7 @@ public class FlowExecutor implements AutoCloseable {
             });
 
             // Execute and wait for confirmation
-            TxResult result = txContext.completeAndWait(getConfirmationTimeout(), getCheckInterval(),
+            TxResult result = txContext.completeAndWait(getConfirmationTimeout(settings), getCheckInterval(settings),
                     msg -> log.debug("[{}] {}", stepId, msg));
 
             if (result.isSuccessful()) {
@@ -1588,8 +1678,8 @@ public class FlowExecutor implements AutoCloseable {
 
                 // If confirmation tracking is configured, wait for deeper confirmation
                 // This enables rollback detection in SEQUENTIAL mode
-                if (confirmationTracker != null) {
-                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck);
+                if (settings.getConfirmationTracker() != null) {
+                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck, settings);
                     if (confirmResult.isEmpty()) {
                         // waitForConfirmation handles RollbackException for REBUILD strategies
                         // For FAIL_IMMEDIATELY/NOTIFY_ONLY, it returns empty
@@ -1812,15 +1902,16 @@ public class FlowExecutor implements AutoCloseable {
     /**
      * Thin wrapper: synchronous BATCH execution.
      */
-    private FlowResult executeBatch(TxFlow flow) {
-        return doExecuteBatch(flow, syncHooks(flow));
+    private FlowResult executeBatch(TxFlow flow, EffectiveFlowExecutionSettings settings) {
+        return doExecuteBatch(flow, syncHooks(flow), settings);
     }
 
     /**
      * Thin wrapper: async BATCH execution with FlowHandle.
      */
-    private FlowResult executeWithHandleBatch(TxFlow flow, FlowHandle handle) {
-        return doExecuteBatch(flow, handleHooks(flow, handle));
+    private FlowResult executeWithHandleBatch(TxFlow flow, FlowHandle handle,
+                                              EffectiveFlowExecutionSettings settings) {
+        return doExecuteBatch(flow, handleHooks(flow, handle), settings);
     }
 
     /**
@@ -1835,8 +1926,9 @@ public class FlowExecutor implements AutoCloseable {
      * <p>
      * Supports rollback retry loop: on rollback, the entire flow is rebuilt and resubmitted.
      */
-    private FlowResult doExecuteBatch(TxFlow flow, ExecutionHooks hooks) {
-        int maxRollbackRetries = getMaxRollbackRetries();
+    private FlowResult doExecuteBatch(TxFlow flow, ExecutionHooks hooks,
+                                      EffectiveFlowExecutionSettings settings) {
+        int maxRollbackRetries = getMaxRollbackRetries(settings);
         int flowRestartAttempts = 0;
         Map<Integer, FlowStepResult> previousConfirmedSteps = new HashMap<>();
         List<String> flowTxHashes = new ArrayList<>();
@@ -1985,7 +2077,7 @@ public class FlowExecutor implements AutoCloseable {
                         continue;
                     }
 
-                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck);
+                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck, settings);
                     if (confirmResult.isPresent()) {
                         ConfirmationResult cr = confirmResult.get();
                         hooks.onStepCompleted(step, stepResults.get(i));
@@ -2007,9 +2099,9 @@ public class FlowExecutor implements AutoCloseable {
                 }
 
                 // Cleanup tracked transactions to prevent memory leak
-                if (confirmationTracker != null) {
+                if (settings.getConfirmationTracker() != null) {
                     for (String hash : flowTxHashes) {
-                        confirmationTracker.stopTracking(hash);
+                        settings.getConfirmationTracker().stopTracking(hash);
                     }
                 }
 
@@ -2043,7 +2135,7 @@ public class FlowExecutor implements AutoCloseable {
                 // Find steps that are still confirmed before clearing tracker
                 previousConfirmedSteps = findStillConfirmedSteps(steps, precomputedTxHashes, stepResults);
 
-                waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck);
+                waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck, settings);
                 hooks.onFlowRestarting();
                 continue;
 
@@ -2323,8 +2415,9 @@ public class FlowExecutor implements AutoCloseable {
      * Execute SEQUENTIAL mode with resume support — skips verified steps from a previous run.
      */
     private FlowResult doExecuteSequentialWithResume(TxFlow flow, ExecutionHooks hooks,
-                                                      Map<Integer, FlowStepResult> confirmedSteps) {
-        int maxRollbackRetries = getMaxRollbackRetries();
+                                                      Map<Integer, FlowStepResult> confirmedSteps,
+                                                      EffectiveFlowExecutionSettings settings) {
+        int maxRollbackRetries = getMaxRollbackRetries(settings);
         int flowRestartAttempts = 0;
         Map<String, Integer> stepRollbackAttempts = new ConcurrentHashMap<>();
         List<String> flowTxHashes = new ArrayList<>();
@@ -2382,7 +2475,7 @@ public class FlowExecutor implements AutoCloseable {
 
                     FlowStepResult stepResult = executeStepWithRollbackHandling(
                             step, context, flow.getVariables(), false,
-                            stepRollbackAttempts, maxRollbackRetries, steps, cancelCheck);
+                            stepRollbackAttempts, maxRollbackRetries, steps, cancelCheck, settings);
                     resultBuilder.addStepResult(stepResult);
 
                     if (stepResult.isSuccessful()) {
@@ -2392,7 +2485,7 @@ public class FlowExecutor implements AutoCloseable {
                         hooks.onStepCompleted(step, stepResult);
                         listener.onStepCompleted(step, stepResult);
 
-                        Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck);
+                        Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck, settings);
                         hooks.onTransactionConfirmed(flow, step, txHash, confirmResult.orElse(null));
                     } else {
                         listener.onStepFailed(step, stepResult);
@@ -2406,9 +2499,9 @@ public class FlowExecutor implements AutoCloseable {
                     }
                 }
 
-                if (confirmationTracker != null) {
+                if (settings.getConfirmationTracker() != null) {
                     for (String hash : flowTxHashes) {
-                        confirmationTracker.stopTracking(hash);
+                        settings.getConfirmationTracker().stopTracking(hash);
                     }
                 }
 
@@ -2439,7 +2532,8 @@ public class FlowExecutor implements AutoCloseable {
                             flowRestartAttempts, maxRollbackRetries, e.getStep().getId());
                     listener.onFlowRestarting(flow, flowRestartAttempts, maxRollbackRetries,
                             "Rollback detected at step '" + e.getStep().getId() + "'");
-                    waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck);
+                    waitForBackendReadyAfterRollback(rollbackCleanupHashes(flowTxHashes, e.getTxHash()),
+                            cancelCheck, settings);
                     // On restart, clear confirmed steps — verifyAndPrepareSkippedSteps will re-check
                     confirmedSteps = new HashMap<>(confirmedSteps);
                     stepRollbackAttempts.clear();
@@ -2479,7 +2573,8 @@ public class FlowExecutor implements AutoCloseable {
      * Execute PIPELINED mode with resume support — seeds confirmed steps from a previous run.
      */
     private FlowResult doExecutePipelinedWithResume(TxFlow flow, ExecutionHooks hooks,
-                                                     Map<Integer, FlowStepResult> confirmedSteps) {
+                                                     Map<Integer, FlowStepResult> confirmedSteps,
+                                                     EffectiveFlowExecutionSettings settings) {
         // The existing doExecutePipelined already supports previousConfirmedSteps via its
         // rollback retry loop. We just need to seed it by injecting our verified steps
         // into the first iteration. We achieve this by temporarily modifying the internal
@@ -2498,7 +2593,7 @@ public class FlowExecutor implements AutoCloseable {
 
         // For PIPELINED resume, we reuse the exact same logic as doExecutePipelined
         // but start with previousConfirmedSteps pre-seeded.
-        int maxRollbackRetries = getMaxRollbackRetries();
+        int maxRollbackRetries = getMaxRollbackRetries(settings);
         int flowRestartAttempts = 0;
         Map<Integer, FlowStepResult> previousConfirmedSteps = new HashMap<>(confirmedSteps);
         List<String> flowTxHashes = new ArrayList<>();
@@ -2551,7 +2646,8 @@ public class FlowExecutor implements AutoCloseable {
                         continue;
                     }
 
-                    FlowStepResult stepResult = executeStepWithRetry(step, context, flow.getVariables(), true, cancelCheck);
+                    FlowStepResult stepResult = executeStepWithRetry(step, context, flow.getVariables(), true,
+                            cancelCheck, settings);
                     stepResults.add(stepResult);
                     resultBuilder.addStepResult(stepResult);
 
@@ -2584,7 +2680,7 @@ public class FlowExecutor implements AutoCloseable {
                         continue;
                     }
 
-                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck);
+                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck, settings);
                     if (confirmResult.isPresent()) {
                         ConfirmationResult result = confirmResult.get();
                         hooks.onStepCompleted(step, stepResults.get(i));
@@ -2605,9 +2701,9 @@ public class FlowExecutor implements AutoCloseable {
                     }
                 }
 
-                if (confirmationTracker != null) {
+                if (settings.getConfirmationTracker() != null) {
                     for (String hash : flowTxHashes) {
-                        confirmationTracker.stopTracking(hash);
+                        settings.getConfirmationTracker().stopTracking(hash);
                     }
                 }
 
@@ -2632,7 +2728,7 @@ public class FlowExecutor implements AutoCloseable {
                 }
 
                 previousConfirmedSteps = findStillConfirmedSteps(steps, submittedTxHashes, stepResults);
-                waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck);
+                waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck, settings);
                 hooks.onFlowRestarting();
                 continue;
 
@@ -2662,8 +2758,9 @@ public class FlowExecutor implements AutoCloseable {
      * Execute BATCH mode with resume support — seeds confirmed steps from a previous run.
      */
     private FlowResult doExecuteBatchWithResume(TxFlow flow, ExecutionHooks hooks,
-                                                 Map<Integer, FlowStepResult> confirmedSteps) {
-        int maxRollbackRetries = getMaxRollbackRetries();
+                                                 Map<Integer, FlowStepResult> confirmedSteps,
+                                                 EffectiveFlowExecutionSettings settings) {
+        int maxRollbackRetries = getMaxRollbackRetries(settings);
         int flowRestartAttempts = 0;
         Map<Integer, FlowStepResult> previousConfirmedSteps = new HashMap<>(confirmedSteps);
         List<String> flowTxHashes = new ArrayList<>();
@@ -2801,7 +2898,7 @@ public class FlowExecutor implements AutoCloseable {
                         continue;
                     }
 
-                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck);
+                    Optional<ConfirmationResult> confirmResult = waitForConfirmation(txHash, step, cancelCheck, settings);
                     if (confirmResult.isPresent()) {
                         ConfirmationResult cr = confirmResult.get();
                         hooks.onStepCompleted(step, stepResults.get(i));
@@ -2822,9 +2919,9 @@ public class FlowExecutor implements AutoCloseable {
                     }
                 }
 
-                if (confirmationTracker != null) {
+                if (settings.getConfirmationTracker() != null) {
                     for (String hash : flowTxHashes) {
-                        confirmationTracker.stopTracking(hash);
+                        settings.getConfirmationTracker().stopTracking(hash);
                     }
                 }
 
@@ -2849,7 +2946,7 @@ public class FlowExecutor implements AutoCloseable {
                 }
 
                 previousConfirmedSteps = findStillConfirmedSteps(steps, precomputedTxHashes, stepResults);
-                waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck);
+                waitForBackendReadyAfterRollback(flowTxHashes, cancelCheck, settings);
                 hooks.onFlowRestarting();
                 continue;
 
@@ -2876,7 +2973,7 @@ public class FlowExecutor implements AutoCloseable {
     /**
      * Close this executor and release associated resources.
      * <p>
-     * Cancels all running flows, clears active flow tracking and confirmation tracker state.
+     * Cancels all running flows and clears active flow tracking.
      */
     @Override
     public void close() {
@@ -2885,8 +2982,5 @@ public class FlowExecutor implements AutoCloseable {
         }
         activeHandles.clear();
         activeFlowIds.clear();
-        if (confirmationTracker != null) {
-            confirmationTracker.clearTracking();
-        }
     }
 }

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/yaml/FlowDocument.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/yaml/FlowDocument.java
@@ -4,13 +4,18 @@ import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
 import com.bloxbean.cardano.client.quicktx.serialization.TransactionDocument;
 import com.bloxbean.cardano.client.quicktx.serialization.VariableResolver;
 import com.bloxbean.cardano.client.txflow.BackoffStrategy;
+import com.bloxbean.cardano.client.txflow.ChainingMode;
+import com.bloxbean.cardano.client.txflow.FlowExecutionSettings;
 import com.bloxbean.cardano.client.txflow.FlowStep;
 import com.bloxbean.cardano.client.txflow.RetryPolicy;
 import com.bloxbean.cardano.client.txflow.SelectionStrategy;
 import com.bloxbean.cardano.client.txflow.StepDependency;
 import com.bloxbean.cardano.client.txflow.TxFlow;
+import com.bloxbean.cardano.client.txflow.exec.ConfirmationConfig;
+import com.bloxbean.cardano.client.txflow.exec.RollbackStrategy;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -58,6 +63,7 @@ import java.util.*;
 @Data
 @NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"version", "context", "flow"})
 @Slf4j
 public class FlowDocument {
 
@@ -76,8 +82,32 @@ public class FlowDocument {
     @JsonProperty("version")
     private String version = "1.0";
 
+    @JsonProperty("context")
+    private ExecutionContext context;
+
     @JsonProperty("flow")
     private FlowContent flow;
+
+    /**
+     * Flow-level execution context.
+     */
+    @Data
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({"chaining_mode", "confirmation", "rollback_strategy", "retry"})
+    public static class ExecutionContext {
+        @JsonProperty("chaining_mode")
+        private String chainingMode;
+
+        @JsonProperty("confirmation")
+        private JsonNode confirmation;
+
+        @JsonProperty("rollback_strategy")
+        private String rollbackStrategy;
+
+        @JsonProperty("retry")
+        private RetryEntry retry;
+    }
 
     /**
      * Flow content with steps and variables.
@@ -193,6 +223,49 @@ public class FlowDocument {
     }
 
     /**
+     * Flow-level confirmation configuration.
+     */
+    @Data
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ConfirmationEntry {
+        @JsonProperty("preset")
+        private String preset;
+
+        @JsonProperty("min_confirmations")
+        private Integer minConfirmations;
+
+        @JsonProperty("check_interval")
+        private String checkInterval;
+
+        @JsonProperty("timeout")
+        private String timeout;
+
+        @JsonProperty("max_rollback_retries")
+        private Integer maxRollbackRetries;
+
+        @JsonProperty("wait_for_backend_after_rollback")
+        private Boolean waitForBackendAfterRollback;
+
+        @JsonProperty("post_rollback_wait_attempts")
+        private Integer postRollbackWaitAttempts;
+
+        @JsonProperty("post_rollback_utxo_sync_delay")
+        private String postRollbackUtxoSyncDelay;
+
+        boolean isEmpty() {
+            return preset == null
+                    && minConfirmations == null
+                    && checkInterval == null
+                    && timeout == null
+                    && maxRollbackRetries == null
+                    && waitForBackendAfterRollback == null
+                    && postRollbackWaitAttempts == null
+                    && postRollbackUtxoSyncDelay == null;
+        }
+    }
+
+    /**
      * Create a FlowDocument from a TxFlow.
      *
      * @param flow the TxFlow to convert
@@ -200,6 +273,9 @@ public class FlowDocument {
      */
     public static FlowDocument fromFlow(TxFlow flow) {
         FlowDocument doc = new FlowDocument();
+        if (flow.getExecutionSettings() != null && flow.getExecutionSettings().hasAnySetting()) {
+            doc.setContext(toExecutionContext(flow.getExecutionSettings()));
+        }
 
         FlowContent content = new FlowContent();
         content.setId(flow.getId());
@@ -234,19 +310,7 @@ public class FlowDocument {
 
             // Convert retry policy
             if (step.hasRetryPolicy()) {
-                RetryPolicy policy = step.getRetryPolicy();
-                RetryEntry retryEntry = new RetryEntry();
-                retryEntry.setMaxAttempts(policy.getMaxAttempts());
-                retryEntry.setBackoff(policy.getBackoffStrategy().name().toLowerCase());
-                retryEntry.setInitialDelay(formatDuration(policy.getInitialDelay()));
-                retryEntry.setMaxDelay(formatDuration(policy.getMaxDelay()));
-                if (!policy.isRetryOnTimeout()) {
-                    retryEntry.setRetryOnTimeout(false);
-                }
-                if (!policy.isRetryOnNetworkError()) {
-                    retryEntry.setRetryOnNetworkError(false);
-                }
-                stepContent.setRetry(retryEntry);
+                stepContent.setRetry(toRetryEntry(step.getRetryPolicy()));
             }
 
             // Convert transaction - only TxPlan can be serialized to YAML
@@ -269,6 +333,50 @@ public class FlowDocument {
         doc.setFlow(content);
 
         return doc;
+    }
+
+    private static ExecutionContext toExecutionContext(FlowExecutionSettings settings) {
+        ExecutionContext context = new ExecutionContext();
+        if (settings.getChainingMode() != null) {
+            context.setChainingMode(settings.getChainingMode().name());
+        }
+        if (settings.getConfirmationConfig() != null) {
+            context.setConfirmation(YAML_MAPPER.valueToTree(toConfirmationEntry(settings.getConfirmationConfig())));
+        }
+        if (settings.getRollbackStrategy() != null) {
+            context.setRollbackStrategy(settings.getRollbackStrategy().name());
+        }
+        if (settings.getRetryPolicy() != null) {
+            context.setRetry(toRetryEntry(settings.getRetryPolicy()));
+        }
+        return context;
+    }
+
+    private static RetryEntry toRetryEntry(RetryPolicy policy) {
+        RetryEntry retryEntry = new RetryEntry();
+        retryEntry.setMaxAttempts(policy.getMaxAttempts());
+        retryEntry.setBackoff(policy.getBackoffStrategy().name().toLowerCase(Locale.ROOT));
+        retryEntry.setInitialDelay(formatDuration(policy.getInitialDelay()));
+        retryEntry.setMaxDelay(formatDuration(policy.getMaxDelay()));
+        if (!policy.isRetryOnTimeout()) {
+            retryEntry.setRetryOnTimeout(false);
+        }
+        if (!policy.isRetryOnNetworkError()) {
+            retryEntry.setRetryOnNetworkError(false);
+        }
+        return retryEntry;
+    }
+
+    private static ConfirmationEntry toConfirmationEntry(ConfirmationConfig config) {
+        ConfirmationEntry entry = new ConfirmationEntry();
+        entry.setMinConfirmations(config.getMinConfirmations());
+        entry.setCheckInterval(formatDuration(config.getCheckInterval()));
+        entry.setTimeout(formatDuration(config.getTimeout()));
+        entry.setMaxRollbackRetries(config.getMaxRollbackRetries());
+        entry.setWaitForBackendAfterRollback(config.isWaitForBackendAfterRollback());
+        entry.setPostRollbackWaitAttempts(config.getPostRollbackWaitAttempts());
+        entry.setPostRollbackUtxoSyncDelay(formatDuration(config.getPostRollbackUtxoSyncDelay()));
+        return entry;
     }
 
     /**
@@ -307,6 +415,10 @@ public class FlowDocument {
 
         TxFlow.Builder builder = TxFlow.builder(flow.getId())
                 .withDescription(flow.getDescription());
+
+        if (context != null) {
+            builder.withExecutionSettings(parseExecutionSettings(context));
+        }
 
         if (flow.getVariables() != null) {
             builder.withVariables(flow.getVariables());
@@ -357,15 +469,10 @@ public class FlowDocument {
      * Parse a selection strategy string to enum.
      */
     private SelectionStrategy parseStrategy(String strategy) {
-        if (strategy == null || strategy.isEmpty()) {
+        if (strategy == null || strategy.trim().isEmpty()) {
             return SelectionStrategy.ALL;
         }
-        try {
-            return SelectionStrategy.valueOf(strategy.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            log.warn("Unknown selection strategy: {}, defaulting to ALL", strategy);
-            return SelectionStrategy.ALL;
-        }
+        return parseEnumStrict(SelectionStrategy.class, strategy, "strategy");
     }
 
     /**
@@ -375,16 +482,19 @@ public class FlowDocument {
         RetryPolicy.RetryPolicyBuilder builder = RetryPolicy.builder();
 
         if (entry.getMaxAttempts() != null) {
+            requirePositive(entry.getMaxAttempts(), "max_attempts");
             builder.maxAttempts(entry.getMaxAttempts());
         }
         if (entry.getBackoff() != null) {
-            builder.backoffStrategy(parseBackoffStrategy(entry.getBackoff()));
+            builder.backoffStrategy(parseBackoffStrategyStrict(entry.getBackoff()));
         }
         if (entry.getInitialDelay() != null) {
-            builder.initialDelay(parseDuration(entry.getInitialDelay()));
+            builder.initialDelay(requireNonNegative(
+                    parseDurationStrict(entry.getInitialDelay(), "initial_delay"), "initial_delay"));
         }
         if (entry.getMaxDelay() != null) {
-            builder.maxDelay(parseDuration(entry.getMaxDelay()));
+            builder.maxDelay(requireNonNegative(
+                    parseDurationStrict(entry.getMaxDelay(), "max_delay"), "max_delay"));
         }
         if (entry.getRetryOnTimeout() != null) {
             builder.retryOnTimeout(entry.getRetryOnTimeout());
@@ -396,30 +506,166 @@ public class FlowDocument {
         return builder.build();
     }
 
+    private FlowExecutionSettings parseExecutionSettings(ExecutionContext context) {
+        FlowExecutionSettings.FlowExecutionSettingsBuilder builder = FlowExecutionSettings.builder();
+
+        if (context.getChainingMode() != null) {
+            builder.chainingMode(parseEnumStrict(ChainingMode.class, context.getChainingMode(), "chaining_mode"));
+        }
+        if (context.getConfirmation() != null) {
+            builder.confirmationConfig(parseConfirmationConfig(context.getConfirmation()));
+        }
+        if (context.getRollbackStrategy() != null) {
+            builder.rollbackStrategy(parseEnumStrict(RollbackStrategy.class, context.getRollbackStrategy(), "rollback_strategy"));
+        }
+        if (context.getRetry() != null) {
+            builder.retryPolicy(parseRetryPolicy(context.getRetry()));
+        }
+
+        return builder.build();
+    }
+
+    private ConfirmationConfig parseConfirmationConfig(JsonNode node) {
+        if (node == null || node.isNull()) {
+            throw new IllegalArgumentException("context.confirmation cannot be null. Omit it for simple confirmation mode.");
+        }
+
+        if (node.isTextual()) {
+            String preset = node.asText();
+            if (preset == null || preset.trim().isEmpty()) {
+                throw new IllegalArgumentException("context.confirmation preset cannot be blank");
+            }
+            return confirmationPreset(preset);
+        }
+
+        if (!node.isObject()) {
+            throw new IllegalArgumentException("context.confirmation must be a preset string or an object");
+        }
+
+        ConfirmationEntry entry = YAML_MAPPER.convertValue(node, ConfirmationEntry.class);
+        if (entry.isEmpty()) {
+            throw new IllegalArgumentException("context.confirmation object cannot be empty");
+        }
+
+        ConfirmationConfig base = entry.getPreset() != null
+                ? confirmationPreset(entry.getPreset())
+                : ConfirmationConfig.defaults();
+
+        ConfirmationConfig.ConfirmationConfigBuilder builder = ConfirmationConfig.builder()
+                .minConfirmations(base.getMinConfirmations())
+                .checkInterval(base.getCheckInterval())
+                .timeout(base.getTimeout())
+                .maxRollbackRetries(base.getMaxRollbackRetries())
+                .waitForBackendAfterRollback(base.isWaitForBackendAfterRollback())
+                .postRollbackWaitAttempts(base.getPostRollbackWaitAttempts())
+                .postRollbackUtxoSyncDelay(base.getPostRollbackUtxoSyncDelay());
+
+        if (entry.getMinConfirmations() != null) {
+            requireNonNegative(entry.getMinConfirmations(), "min_confirmations");
+            builder.minConfirmations(entry.getMinConfirmations());
+        }
+        if (entry.getCheckInterval() != null) {
+            builder.checkInterval(requirePositive(
+                    parseDurationStrict(entry.getCheckInterval(), "check_interval"), "check_interval"));
+        }
+        if (entry.getTimeout() != null) {
+            builder.timeout(requirePositive(
+                    parseDurationStrict(entry.getTimeout(), "timeout"), "timeout"));
+        }
+        if (entry.getMaxRollbackRetries() != null) {
+            requireNonNegative(entry.getMaxRollbackRetries(), "max_rollback_retries");
+            builder.maxRollbackRetries(entry.getMaxRollbackRetries());
+        }
+        if (entry.getWaitForBackendAfterRollback() != null) {
+            builder.waitForBackendAfterRollback(entry.getWaitForBackendAfterRollback());
+        }
+        if (entry.getPostRollbackWaitAttempts() != null) {
+            requirePositive(entry.getPostRollbackWaitAttempts(), "post_rollback_wait_attempts");
+            builder.postRollbackWaitAttempts(entry.getPostRollbackWaitAttempts());
+        }
+        if (entry.getPostRollbackUtxoSyncDelay() != null) {
+            builder.postRollbackUtxoSyncDelay(requireNonNegative(parseDurationStrict(
+                    entry.getPostRollbackUtxoSyncDelay(), "post_rollback_utxo_sync_delay"),
+                    "post_rollback_utxo_sync_delay"));
+        }
+
+        return builder.build();
+    }
+
+    private ConfirmationConfig confirmationPreset(String preset) {
+        if (preset == null || preset.trim().isEmpty()) {
+            throw new IllegalArgumentException("confirmation preset cannot be blank");
+        }
+
+        switch (preset.trim().toLowerCase(Locale.ROOT)) {
+            case "defaults":
+                return ConfirmationConfig.defaults();
+            case "devnet":
+                return ConfirmationConfig.devnet();
+            case "testnet":
+                return ConfirmationConfig.testnet();
+            case "quick":
+                return ConfirmationConfig.quick();
+            default:
+                throw new IllegalArgumentException("Unknown confirmation preset: " + preset);
+        }
+    }
+
     /**
      * Parse a backoff strategy string to enum.
      */
-    private BackoffStrategy parseBackoffStrategy(String strategy) {
-        if (strategy == null || strategy.isEmpty()) {
-            return BackoffStrategy.EXPONENTIAL;
+    private BackoffStrategy parseBackoffStrategyStrict(String strategy) {
+        return parseEnumStrict(BackoffStrategy.class, strategy, "backoff");
+    }
+
+    private <E extends Enum<E>> E parseEnumStrict(Class<E> enumType, String value, String fieldName) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
         }
         try {
-            return BackoffStrategy.valueOf(strategy.toUpperCase());
+            return Enum.valueOf(enumType, value.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            log.warn("Unknown backoff strategy: {}, defaulting to EXPONENTIAL", strategy);
-            return BackoffStrategy.EXPONENTIAL;
+            throw new IllegalArgumentException("Unknown " + fieldName + ": " + value, e);
         }
+    }
+
+    private int requirePositive(int value, String fieldName) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(fieldName + " must be positive");
+        }
+        return value;
+    }
+
+    private int requireNonNegative(int value, String fieldName) {
+        if (value < 0) {
+            throw new IllegalArgumentException(fieldName + " cannot be negative");
+        }
+        return value;
+    }
+
+    private Duration requirePositive(Duration duration, String fieldName) {
+        if (duration.isZero() || duration.isNegative()) {
+            throw new IllegalArgumentException(fieldName + " must be positive");
+        }
+        return duration;
+    }
+
+    private Duration requireNonNegative(Duration duration, String fieldName) {
+        if (duration.isNegative()) {
+            throw new IllegalArgumentException(fieldName + " cannot be negative");
+        }
+        return duration;
     }
 
     /**
      * Parse a duration string (e.g., "1s", "500ms", "2m") to Duration.
      */
-    private Duration parseDuration(String durationStr) {
-        if (durationStr == null || durationStr.isEmpty()) {
-            return Duration.ofSeconds(1);
+    private Duration parseDurationStrict(String durationStr, String fieldName) {
+        if (durationStr == null || durationStr.trim().isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " cannot be blank");
         }
 
-        durationStr = durationStr.trim().toLowerCase();
+        durationStr = durationStr.trim().toLowerCase(Locale.ROOT);
 
         try {
             if (durationStr.endsWith("ms")) {
@@ -437,8 +683,7 @@ public class FlowDocument {
                 return Duration.ofSeconds(s);
             }
         } catch (NumberFormatException e) {
-            log.warn("Invalid duration format: {}, defaulting to 1s", durationStr);
-            return Duration.ofSeconds(1);
+            throw new IllegalArgumentException("Invalid duration for " + fieldName + ": " + durationStr, e);
         }
     }
 

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/exec/FlowExecutorTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/exec/FlowExecutorTest.java
@@ -4,7 +4,12 @@ import com.bloxbean.cardano.client.api.ChainDataSupplier;
 import com.bloxbean.cardano.client.api.ProtocolParamsSupplier;
 import com.bloxbean.cardano.client.api.TransactionProcessor;
 import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.quicktx.QuickTxBuilder;
 import com.bloxbean.cardano.client.quicktx.Tx;
+import com.bloxbean.cardano.client.quicktx.TxResult;
+import com.bloxbean.cardano.client.txflow.ChainingMode;
+import com.bloxbean.cardano.client.txflow.BackoffStrategy;
 import com.bloxbean.cardano.client.txflow.FlowStep;
 import com.bloxbean.cardano.client.txflow.RetryPolicy;
 import com.bloxbean.cardano.client.txflow.TxFlow;
@@ -23,8 +28,11 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -54,6 +62,30 @@ class FlowExecutorTest {
                         .withTxContext(builder -> builder.compose(new Tx().from("addr1")))
                         .build())
                 .build();
+    }
+
+    private QuickTxBuilder.TxContext failingTxContext(String message) {
+        QuickTxBuilder.TxContext txContext = mock(QuickTxBuilder.TxContext.class);
+        when(txContext.withTxInspector(any())).thenReturn(txContext);
+        when(txContext.completeAndWait(any(Duration.class), any(Duration.class), any()))
+                .thenReturn(TxResult.fromResult(Result.error(message)));
+        return txContext;
+    }
+
+    private Function<QuickTxBuilder, QuickTxBuilder.TxContext> blockingFactory(
+            QuickTxBuilder.TxContext txContext, CountDownLatch started, CountDownLatch release) {
+        return builder -> {
+            started.countDown();
+            try {
+                if (!release.await(5, TimeUnit.SECONDS)) {
+                    throw new RuntimeException("Timed out waiting to release test flow");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            return txContext;
+        };
     }
 
     // ==================== HIGH-3: Validate rollback strategy requires ConfirmationConfig ====================
@@ -94,6 +126,186 @@ class FlowExecutorTest {
         // Should not throw — FAIL_IMMEDIATELY doesn't require ConfirmationConfig
         // It will fail later during execution, but the validation should pass
         assertDoesNotThrow(() -> executor.execute(flow));
+    }
+
+    @Test
+    void testExecuteSync_flowRollbackStrategy_withoutConfirmationConfig_throwsIllegalState() {
+        TxFlow flow = TxFlow.builder("flow-context-no-confirmation")
+                .withRollbackStrategy(RollbackStrategy.REBUILD_ENTIRE_FLOW)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(builder -> builder.compose(new Tx().from("addr1")))
+                        .build())
+                .build();
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> executor.executeSync(flow));
+        assertTrue(ex.getMessage().contains("REBUILD_ENTIRE_FLOW"));
+        assertTrue(ex.getMessage().contains("context.confirmation"));
+    }
+
+    @Test
+    void testExecuteSync_flowRollbackStrategy_withFlowConfirmation_passesValidation() {
+        TxFlow flow = TxFlow.builder("flow-context-confirmation")
+                .withConfirmationConfig(ConfirmationConfig.quick())
+                .withRollbackStrategy(RollbackStrategy.REBUILD_ENTIRE_FLOW)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(builder -> builder.compose(new Tx().from("addr1")))
+                        .build())
+                .build();
+
+        assertDoesNotThrow(() -> executor.executeSync(flow));
+    }
+
+    @Test
+    void testExecuteSync_explicitExecutorRollbackDefault_overridesFlowRollbackStrategy() {
+        executor.withRollbackStrategy(null);
+
+        TxFlow flow = TxFlow.builder("executor-rollback-default")
+                .withRollbackStrategy(RollbackStrategy.REBUILD_ENTIRE_FLOW)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(builder -> builder.compose(new Tx().from("addr1")))
+                        .build())
+                .build();
+
+        assertDoesNotThrow(() -> executor.executeSync(flow));
+    }
+
+    @Test
+    void testExecuteSync_explicitNullConfirmation_overridesFlowConfirmation() {
+        executor.withConfirmationConfig(null);
+
+        TxFlow flow = TxFlow.builder("executor-null-confirmation")
+                .withConfirmationConfig(ConfirmationConfig.quick())
+                .withRollbackStrategy(RollbackStrategy.REBUILD_ENTIRE_FLOW)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(builder -> builder.compose(new Tx().from("addr1")))
+                        .build())
+                .build();
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> executor.executeSync(flow));
+        assertTrue(ex.getMessage().contains("REBUILD_ENTIRE_FLOW"));
+        assertTrue(ex.getMessage().contains("context.confirmation"));
+    }
+
+    @Test
+    void testEffectiveChainingMode_flowContextAppliesWhenExecutorUnset() throws Exception {
+        TxFlow flow = TxFlow.builder("flow-chaining")
+                .withChainingMode(ChainingMode.BATCH)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(builder -> builder.compose(new Tx().from("addr1")))
+                        .build())
+                .build();
+
+        assertEquals(ChainingMode.BATCH, executor.effectiveSettings(flow).getChainingMode());
+    }
+
+    @Test
+    void testEffectiveChainingMode_explicitExecutorDefaultOverridesFlowContext() throws Exception {
+        executor.withChainingMode(null);
+
+        TxFlow flow = TxFlow.builder("executor-chaining-default")
+                .withChainingMode(ChainingMode.BATCH)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(builder -> builder.compose(new Tx().from("addr1")))
+                        .build())
+                .build();
+
+        assertEquals(ChainingMode.SEQUENTIAL, executor.effectiveSettings(flow).getChainingMode());
+    }
+
+    @Test
+    void testExecute_concurrentFlowsWithDifferentContexts_doNotContaminateChainingMode() throws Exception {
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        CountDownLatch started = new CountDownLatch(2);
+        CountDownLatch release = new CountDownLatch(1);
+        executor.withExecutor(pool);
+
+        QuickTxBuilder.TxContext sequentialContext = failingTxContext("sequential connection timeout");
+        QuickTxBuilder.TxContext batchContext = failingTxContext("batch connection timeout");
+
+        TxFlow sequentialFlow = TxFlow.builder("concurrent-sequential")
+                .withChainingMode(ChainingMode.SEQUENTIAL)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(blockingFactory(sequentialContext, started, release))
+                        .build())
+                .build();
+
+        TxFlow batchFlow = TxFlow.builder("concurrent-batch")
+                .withChainingMode(ChainingMode.BATCH)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(blockingFactory(batchContext, started, release))
+                        .build())
+                .build();
+
+        try {
+            FlowHandle sequentialHandle = executor.execute(sequentialFlow);
+            FlowHandle batchHandle = executor.execute(batchFlow);
+
+            assertTrue(started.await(5, TimeUnit.SECONDS), "Both flows should start before release");
+            release.countDown();
+
+            sequentialHandle.await(Duration.ofSeconds(5));
+            batchHandle.await(Duration.ofSeconds(5));
+
+            verify(sequentialContext, atLeastOnce())
+                    .completeAndWait(any(Duration.class), any(Duration.class), any());
+            verify(sequentialContext, never()).buildAndSign();
+            verify(batchContext, atLeastOnce()).buildAndSign();
+            verify(batchContext, never())
+                    .completeAndWait(any(Duration.class), any(Duration.class), any());
+        } finally {
+            release.countDown();
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void testExecuteSync_stepRetryPolicyOverridesFlowDefaultRetryPolicy() {
+        QuickTxBuilder.TxContext txContext = failingTxContext("connection timeout");
+        RetryPolicy flowRetry = RetryPolicy.builder()
+                .maxAttempts(3)
+                .backoffStrategy(BackoffStrategy.FIXED)
+                .initialDelay(Duration.ZERO)
+                .maxDelay(Duration.ZERO)
+                .build();
+        RetryPolicy stepRetry = RetryPolicy.noRetry();
+
+        TxFlow flow = TxFlow.builder("step-retry-wins")
+                .withDefaultRetryPolicy(flowRetry)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(builder -> txContext)
+                        .withRetryPolicy(stepRetry)
+                        .build())
+                .build();
+
+        FlowResult result = executor.executeSync(flow);
+
+        assertTrue(result.isFailed());
+        verify(txContext, times(1))
+                .completeAndWait(any(Duration.class), any(Duration.class), any());
+    }
+
+    @Test
+    void testExecuteSync_flowDefaultRetryPolicyAppliesWhenStepHasNoRetryPolicy() {
+        QuickTxBuilder.TxContext txContext = failingTxContext("connection timeout");
+        RetryPolicy flowRetry = RetryPolicy.builder()
+                .maxAttempts(2)
+                .backoffStrategy(BackoffStrategy.FIXED)
+                .initialDelay(Duration.ZERO)
+                .maxDelay(Duration.ZERO)
+                .build();
+
+        TxFlow flow = TxFlow.builder("flow-retry-default")
+                .withDefaultRetryPolicy(flowRetry)
+                .addStep(FlowStep.builder("step1")
+                        .withTxContext(builder -> txContext)
+                        .build())
+                .build();
+
+        FlowResult result = executor.executeSync(flow);
+
+        assertTrue(result.isFailed());
+        verify(txContext, times(2))
+                .completeAndWait(any(Duration.class), any(Duration.class), any());
     }
 
     // ==================== HIGH-5: Reject duplicate flow ID execution ====================

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/yaml/FlowYamlSerializationTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/yaml/FlowYamlSerializationTest.java
@@ -4,15 +4,19 @@ import com.bloxbean.cardano.client.api.model.Amount;
 import com.bloxbean.cardano.client.quicktx.Tx;
 import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
 import com.bloxbean.cardano.client.txflow.BackoffStrategy;
+import com.bloxbean.cardano.client.txflow.ChainingMode;
 import com.bloxbean.cardano.client.txflow.FlowStep;
 import com.bloxbean.cardano.client.txflow.RetryPolicy;
 import com.bloxbean.cardano.client.txflow.SelectionStrategy;
 import com.bloxbean.cardano.client.txflow.TxFlow;
+import com.bloxbean.cardano.client.txflow.exec.ConfirmationConfig;
+import com.bloxbean.cardano.client.txflow.exec.RollbackStrategy;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for TxFlow YAML serialization.
@@ -350,5 +354,303 @@ class FlowYamlSerializationTest {
         RetryPolicy policy = step1.get().getRetryPolicy();
         assertThat(policy.getInitialDelay()).isEqualTo(Duration.ofMillis(500));
         assertThat(policy.getMaxDelay()).isEqualTo(Duration.ofMinutes(2));
+    }
+
+    @Test
+    void fromYaml_shouldParseFlowExecutionContext() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "context:\n" +
+                "  chaining_mode: batch\n" +
+                "  confirmation:\n" +
+                "    preset: quick\n" +
+                "    min_confirmations: 0\n" +
+                "    check_interval: 250ms\n" +
+                "    timeout: 7s\n" +
+                "    max_rollback_retries: 0\n" +
+                "    wait_for_backend_after_rollback: false\n" +
+                "    post_rollback_wait_attempts: 2\n" +
+                "    post_rollback_utxo_sync_delay: 500ms\n" +
+                "  rollback_strategy: notify_only\n" +
+                "  retry:\n" +
+                "    max_attempts: 4\n" +
+                "    backoff: fixed\n" +
+                "    initial_delay: 250ms\n" +
+                "    retry_on_timeout: false\n" +
+                "flow:\n" +
+                "  id: context-flow\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1_sender\n" +
+                "          intents:\n" +
+                "            - type: payment\n" +
+                "              receiver: addr1_receiver\n" +
+                "              amount:\n" +
+                "                lovelace: 1000000\n";
+
+        // When
+        TxFlow flow = TxFlow.fromYaml(yaml);
+
+        // Then
+        assertThat(flow.getExecutionSettings().getChainingMode()).isEqualTo(ChainingMode.BATCH);
+        assertThat(flow.getExecutionSettings().getRollbackStrategy()).isEqualTo(RollbackStrategy.NOTIFY_ONLY);
+
+        ConfirmationConfig confirmationConfig = flow.getExecutionSettings().getConfirmationConfig();
+        assertThat(confirmationConfig).isNotNull();
+        assertThat(confirmationConfig.getMinConfirmations()).isZero();
+        assertThat(confirmationConfig.getMaxRollbackRetries()).isZero();
+        assertThat(confirmationConfig.isWaitForBackendAfterRollback()).isFalse();
+        assertThat(confirmationConfig.getCheckInterval()).isEqualTo(Duration.ofMillis(250));
+        assertThat(confirmationConfig.getTimeout()).isEqualTo(Duration.ofSeconds(7));
+        assertThat(confirmationConfig.getPostRollbackWaitAttempts()).isEqualTo(2);
+        assertThat(confirmationConfig.getPostRollbackUtxoSyncDelay()).isEqualTo(Duration.ofMillis(500));
+
+        RetryPolicy retryPolicy = flow.getExecutionSettings().getRetryPolicy();
+        assertThat(retryPolicy).isNotNull();
+        assertThat(retryPolicy.getMaxAttempts()).isEqualTo(4);
+        assertThat(retryPolicy.getBackoffStrategy()).isEqualTo(BackoffStrategy.FIXED);
+        assertThat(retryPolicy.getInitialDelay()).isEqualTo(Duration.ofMillis(250));
+        assertThat(retryPolicy.isRetryOnTimeout()).isFalse();
+    }
+
+    @Test
+    void toYaml_shouldSerializeFlowExecutionContextWithStableRootOrder() {
+        // Given
+        TxPlan plan = TxPlan.from(new Tx()
+                .from("addr1_sender")
+                .payToAddress("addr1_receiver", Amount.ada(1)));
+
+        ConfirmationConfig confirmationConfig = ConfirmationConfig.builder()
+                .minConfirmations(0)
+                .checkInterval(Duration.ofMillis(500))
+                .timeout(Duration.ofSeconds(45))
+                .maxRollbackRetries(0)
+                .waitForBackendAfterRollback(false)
+                .postRollbackWaitAttempts(2)
+                .postRollbackUtxoSyncDelay(Duration.ofMillis(250))
+                .build();
+
+        TxFlow flow = TxFlow.builder("context-roundtrip-flow")
+                .withChainingMode(ChainingMode.BATCH)
+                .withConfirmationConfig(confirmationConfig)
+                .withRollbackStrategy(RollbackStrategy.NOTIFY_ONLY)
+                .withDefaultRetryPolicy(RetryPolicy.builder()
+                        .maxAttempts(2)
+                        .backoffStrategy(BackoffStrategy.LINEAR)
+                        .initialDelay(Duration.ofSeconds(2))
+                        .maxDelay(Duration.ofSeconds(6))
+                        .build())
+                .addStep(FlowStep.builder("step1")
+                        .withTxPlan(plan)
+                        .build())
+                .build();
+
+        // When
+        String yaml = flow.toYaml();
+        TxFlow restored = TxFlow.fromYaml(yaml);
+
+        // Then
+        assertThat(yaml.indexOf("context:")).isLessThan(yaml.indexOf("flow:"));
+        assertThat(yaml).contains("chaining_mode: BATCH");
+        assertThat(yaml).contains("rollback_strategy: NOTIFY_ONLY");
+        assertThat(yaml).contains("max_rollback_retries: 0");
+        assertThat(yaml).contains("wait_for_backend_after_rollback: false");
+        assertThat(yaml).contains("post_rollback_utxo_sync_delay: 250ms");
+        assertThat(restored.getExecutionSettings().getChainingMode()).isEqualTo(ChainingMode.BATCH);
+        assertThat(restored.getExecutionSettings().getRollbackStrategy()).isEqualTo(RollbackStrategy.NOTIFY_ONLY);
+        assertThat(restored.getExecutionSettings().getConfirmationConfig().getMinConfirmations()).isZero();
+        assertThat(restored.getExecutionSettings().getRetryPolicy().getBackoffStrategy()).isEqualTo(BackoffStrategy.LINEAR);
+    }
+
+    @Test
+    void fromYaml_shouldRejectContextMaxRollbackRetriesAlias() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "context:\n" +
+                "  max_rollback_retries: 0\n" +
+                "flow:\n" +
+                "  id: invalid-context-alias\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to deserialize YAML to FlowDocument");
+    }
+
+    @Test
+    void fromYaml_shouldRejectEmptyConfirmationObject() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "context:\n" +
+                "  confirmation: {}\n" +
+                "flow:\n" +
+                "  id: empty-confirmation\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("context.confirmation object cannot be empty");
+    }
+
+    @Test
+    void fromYaml_shouldRejectInvalidFlowLevelRetryStrictly() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "context:\n" +
+                "  retry:\n" +
+                "    backoff: sometimes\n" +
+                "flow:\n" +
+                "  id: invalid-flow-retry\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown backoff: sometimes");
+    }
+
+    @Test
+    void fromYaml_shouldRejectInvalidStepRetryStrictly() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "flow:\n" +
+                "  id: invalid-step-retry\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        retry:\n" +
+                "          initial_delay: soon\n" +
+                "        tx:\n" +
+                "          from: addr1\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid duration for initial_delay: soon");
+    }
+
+    @Test
+    void fromYaml_shouldRejectInvalidDependencyStrategyStrictly() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "flow:\n" +
+                "  id: invalid-dependency-strategy\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1\n" +
+                "    - step:\n" +
+                "        id: step2\n" +
+                "        depends_on:\n" +
+                "          - from_step: step1\n" +
+                "            strategy: frist\n" +
+                "        tx:\n" +
+                "          from: addr2\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown strategy: frist");
+    }
+
+    @Test
+    void fromYaml_shouldRejectInvalidConfirmationBounds() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "context:\n" +
+                "  confirmation:\n" +
+                "    check_interval: 0s\n" +
+                "flow:\n" +
+                "  id: invalid-confirmation-bounds\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("check_interval must be positive");
+    }
+
+    @Test
+    void fromYaml_shouldRejectNegativeRollbackRetryCount() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "context:\n" +
+                "  confirmation:\n" +
+                "    max_rollback_retries: -1\n" +
+                "flow:\n" +
+                "  id: invalid-rollback-retries\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("max_rollback_retries cannot be negative");
+    }
+
+    @Test
+    void fromYaml_shouldRejectInvalidRetryBounds() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "context:\n" +
+                "  retry:\n" +
+                "    max_attempts: 0\n" +
+                "flow:\n" +
+                "  id: invalid-retry-bounds\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("max_attempts must be positive");
+    }
+
+    @Test
+    void fromYaml_shouldRejectNegativeRetryDelay() {
+        // Given
+        String yaml = "version: \"1.0\"\n" +
+                "context:\n" +
+                "  retry:\n" +
+                "    initial_delay: -1s\n" +
+                "flow:\n" +
+                "  id: invalid-retry-delay\n" +
+                "  steps:\n" +
+                "    - step:\n" +
+                "        id: step1\n" +
+                "        tx:\n" +
+                "          from: addr1\n";
+
+        // Then
+        assertThatThrownBy(() -> TxFlow.fromYaml(yaml))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("initial_delay cannot be negative");
     }
 }


### PR DESCRIPTION
Fix #630 

 ## Summary

  Adds flow-level execution settings to TxFlow YAML via top-level `context:` and carries them through the TxFlow domain model.

  ## Changes

  - Add `FlowExecutionSettings` to `TxFlow`
  - Support YAML round-trip for:
    - `context.chaining_mode`
    - `context.confirmation`
    - `context.rollback_strategy`
    - `context.retry`
  - Refactor `FlowExecutor` to compute per-execution effective settings instead of mutating shared executor state
  - Scope `ConfirmationTracker` per execution
  - Preserve executor override precedence, including explicit null/default setter calls
  - Add strict parsing and validation for flow/step retry and dependency strategies
  - Add ADRs for TxFlow execution context and QuickTx policy references for minting
  - Add unit tests for parsing, precedence, concurrency isolation, and validation
  - Add DevKit integration test coverage for YAML context
