### PR TITLE
feat: add QuickTx policy and script reference resolution

### DIFF
--- a/quicktx/README.md
+++ b/quicktx/README.md
@@ -42,7 +42,7 @@ TxResult result = builder
 QuickTx resolves senders, fee payers, collateral payers, and extra witnesses from URI-style references using a pluggable `SignerRegistry`. This keeps YAML free from secrets while letting the runtime decide how to sign:
 
 ```java
-SignerRegistry registry = new InMemorySignerRegistry()
+SignerRegistry registry = new DefaultSignerRegistry()
     .addAccount("account://ops", opsAccount)
     .addPolicy("policy://nft", policy);
 
@@ -51,8 +51,8 @@ Tx tx = new Tx()
     .payToAddress("addr_test1_receiver", Amount.ada(5));
 
 TxResult result = builder
-    .withSignerRegistry(registry)
     .compose(tx)
+    .withSignerRegistry(registry)
     .feePayerRef("account://ops")
     .withSignerRef("policy://nft", "policy")
     .completeAndWait();
@@ -62,6 +62,84 @@ TxResult result = builder
 - `feePayerRef` / `collateralPayerRef` resolve to a wallet or preferred address at compose time.
 - `withSignerRef(ref, scope)` adds additional witnesses such as `stake`, `drep`, or `policy`.
 - Mixing address-based APIs with references is allowed; conflicts raise a `TxBuildException`.
+
+Native minting can use the same policy reference without embedding the policy script in YAML:
+
+```java
+Tx tx = new Tx()
+    .fromRef("account://ops")
+    .mintAssets(PolicyRef.ref("policy://nft"), new Asset("ExampleToken", BigInteger.ONE), "addr_test1_receiver");
+```
+
+```yaml
+transaction:
+  - tx:
+      from_ref: account://ops
+      intents:
+        - type: minting
+          policy_ref: policy://nft
+          assets:
+            - name: ExampleToken
+              value: 1
+          receiver: addr_test1_receiver
+```
+
+`policy_ref` is for native `Policy`-backed minting. Plutus minting continues to use validator attachment or reference-script workflows.
+
+### Script Registry & Attachment References
+
+Validator and native script witnesses can also be kept out of YAML and resolved at build time through a `ScriptRegistry`.
+
+```java
+ScriptRegistry scripts = new DefaultScriptRegistry()
+    .addPlutusScript("validator://mint", mintValidator)
+    .addNativeScript("native://policy", nativeScript);
+
+Tx tx = new Tx()
+    .fromRef("account://ops")
+    .payToAddress("addr_test1_receiver", Amount.ada(5))
+    .attachMintValidator(ScriptRef.ref("validator://mint"))
+    .attachNativeScript(ScriptRef.hash(nativeScript.getPolicyId()));
+
+Transaction transaction = builder
+    .compose(tx)
+    .withSignerRegistry(registry)
+    .withScriptRegistry(scripts)
+    .build();
+```
+
+The same references can be represented in TxPlan YAML:
+
+```yaml
+version: 1.0
+transaction:
+  - tx:
+      from_ref: account://ops
+      intents:
+        - type: payment
+          address: addr_test1_receiver
+          amounts:
+            - unit: lovelace
+              quantity: 5000000
+      scripts:
+        - type: validator
+          role: mint
+          script_ref: validator://mint
+        - type: native_script
+          script_hash: f711cc44f1611e6784f13ca21a0863ed2923d065d4493ef24246ea46
+```
+
+`script_ref` is a runtime registry reference, not a Cardano on-chain reference script. On-chain reference scripts still use reference inputs, `script_ref_bytes`, and the existing reference-script resolver flow. `script_hash` can resolve Plutus scripts through a configured `ScriptSupplier`; logical `script_ref` values require a `ScriptRegistry`.
+
+For TxPlan execution, configure registries on the composed context:
+
+```java
+TxPlan plan = TxPlan.from(yaml);
+
+Transaction transaction = builder
+    .compose(plan, registry, scripts)
+    .build();
+```
 
 ## TxPlan YAML Serialization
 
@@ -117,7 +195,7 @@ TxResult result = context
 #### Basic Structure
 
 ```yaml
-version: 1.1
+version: 1.0
 variables:
   sender_ref: account://ops_sender
   receiver: addr_test1_receiver_address
@@ -126,8 +204,7 @@ context:
   fee_payer_ref: account://ops
   collateral_payer_ref: account://ops
   signers:
-    - type: policy
-      ref: policy://nft
+    - ref: policy://nft
       scope: policy
   required_signers:
     - ab123def
@@ -139,10 +216,10 @@ transaction:
       from_ref: ${sender_ref}
       intents:
         - type: payment
-          to: ${receiver}
-          amount:
-            unit: lovelace
-            quantity: ${amount}
+          address: ${receiver}
+          amounts:
+            - unit: lovelace
+              quantity: ${amount}
 ```
 
 Address-based fields (`from`, `fee_payer`, `collateral_payer`) remain valid for backward compatibility; mix and match them with references as needed.
@@ -153,7 +230,7 @@ Address-based fields (`from`, `fee_payer`, `collateral_payer`) remain valid for 
 - **fee_payer_ref**: Registry reference that resolves to a wallet or address for paying fees
 - **collateral_payer**: Address that provides collateral for script transactions
 - **collateral_payer_ref**: Registry reference used when collateral should be derived at runtime
-- **signers**: Array of `{ type, ref, scope }` entries resolved via the registry for extra witnesses
+- **signers**: Array of `{ ref, scope }` entries resolved via the registry for extra witnesses
 - **required_signers**: List of required signer credentials (hex-encoded)
 - **valid_from_slot**: Transaction validity start slot (optional)
 - **valid_to_slot**: Transaction validity end slot (optional)
@@ -175,10 +252,10 @@ transaction:
       from: ${treasury}
       intents:
         - type: payment
-          to: ${alice}
-          amount:
-            unit: lovelace
-            quantity: ${amount}
+          address: ${alice}
+          amounts:
+            - unit: lovelace
+              quantity: ${amount}
 ```
 
 ### Multiple Transactions
@@ -200,36 +277,56 @@ transaction:
       from: ${treasury}
       intents:
         - type: payment
-          to: ${pool_operator}
-          amount:
-            unit: lovelace
-            quantity: 500000000
+          address: ${pool_operator}
+          amounts:
+            - unit: lovelace
+              quantity: 500000000
             
-  - scriptTx:
+  - tx:
+      from: ${treasury}
       intents:
         - type: stake_pool_registration
           pool_id: pool1abc123
           # ... pool parameters
 ```
 
-### Script Transactions in YAML
+### Script Attachments in YAML
+
+Use the unified `tx` format for script operations. The legacy `scriptTx` YAML form is not supported.
 
 ```yaml
+version: 1.0
 transaction:
-  - scriptTx:
-      change_address: addr_test1_change
-      change_datum: "590a01a1581c..."  # hex-encoded PlutusData
+  - tx:
+      from: addr_test1_sender
       intents:
-        - type: script_call
-          contract_address: addr_test1_contract
-          datum_hex: "d87980"
-          redeemer_hex: "d87a80"
-          amount:
-            unit: lovelace
-            quantity: 10000000
-      validators:
-        - script_hex: "590a01..."
-          type: plutus_v2
+        - type: payment
+          address: addr_test1_receiver
+          amounts:
+            - unit: lovelace
+              quantity: 5000000
+      scripts:
+        - type: validator
+          role: spend
+          cbor_hex: "49480100002221200101"
+          version: v2
+        - type: native_script
+          script_hex: "8200581c..."
+```
+
+The same attachments can be referenced through a runtime `ScriptRegistry`:
+
+```yaml
+version: 1.0
+transaction:
+  - tx:
+      from_ref: account://ops
+      scripts:
+        - type: validator
+          role: spend
+          script_ref: validator://spend
+        - type: native_script
+          script_ref: native://policy
 ```
 
 ## Examples
@@ -251,10 +348,10 @@ String yamlPlan = """
           from: ${sender}
           intents:
             - type: payment
-              to: ${receiver}
-              amount:
-                unit: lovelace
-                quantity: 5000000
+              address: ${receiver}
+              amounts:
+                - unit: lovelace
+                  quantity: 5000000
     """;
 
 // 2. Load and execute

--- a/quicktx/adr/policy-references-for-minting.md
+++ b/quicktx/adr/policy-references-for-minting.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed
 **Date**: 2026-06-17
-**Issue**: https://github.com/bloxbean/cardano-client-lib/issues/630
+**Issue**: https://github.com/bloxbean/cardano-client-lib/issues/632
 **Modules**: `quicktx`, `transaction-spec`
 
 ## 1. Context
@@ -86,11 +86,15 @@ private String policyRef;
 Add fluent Java helpers, for example:
 
 ```java
-Tx mintAssetRef(String policyRef, Asset asset, String receiver)
-Tx mintAssetRef(String policyRef, List<Asset> assets, String receiver)
+PolicyRef.ref(String ref)
+
+Tx mintAssets(PolicyRef policyRef, Asset asset, String receiver)
+Tx mintAssets(PolicyRef policyRef, List<Asset> assets, String receiver)
 ```
 
-Exact overload naming can follow local API style, but it should be clear that the policy is resolved at composition/build time.
+Do not add string-based `mintAssetsRef(String, ...)` helpers in the initial implementation. The typed `PolicyRef` overloads are the Java API, so callers explicitly choose the lookup type.
+
+The first implementation supports `PolicyRef.ref(...)`, backed by `policy_ref` in YAML. A future extension can add `PolicyRef.policyId(...)` and a YAML `policy_id` field if policy-id lookup is needed. A policy id alone is not enough to mint; it must resolve to a full native `Policy` with script material and signing capability.
 
 ## 4. Resolution Flow
 

--- a/quicktx/adr/script-registry-for-attachment-references.md
+++ b/quicktx/adr/script-registry-for-attachment-references.md
@@ -1,0 +1,281 @@
+# Script Registry for Attachment References
+
+**Status**: Proposed
+**Date**: 2026-06-17
+**Issue**: TBD
+**Modules**: `quicktx`
+
+## 1. Context
+
+QuickTx YAML can currently keep signers and policies out of documents through runtime registries such as `SignerRegistry`.
+
+Script witness material is different. Several QuickTx intents still require script bytes in YAML or runtime script objects:
+
+- `ScriptValidatorAttachmentIntent` requires a runtime `PlutusScript` or YAML `cbor_hex` plus `version`.
+- `NativeScriptAttachmentIntent` requires a runtime `NativeScript` or YAML `script_hex`.
+- `PaymentIntent` can embed output reference script bytes through `script_ref_bytes`.
+
+This creates large YAML documents and forces tools to serialize script bytes even when applications already hold scripts at runtime.
+
+There is also an existing `ScriptSupplier`, but it serves a narrower purpose:
+
+- It resolves Plutus scripts by hash for on-chain reference-script handling.
+- It is hash-oriented, not logical-name-oriented.
+- It returns only `PlutusScript`, not native scripts.
+- It is used after reference inputs or inputs expose a `referenceScriptHash`.
+
+Therefore, `ScriptSupplier` should not become the only user-facing runtime script abstraction for TxPlan YAML.
+
+## 2. Decision
+
+Add a QuickTx `ScriptRegistry` for runtime script material and allow script attachment intents to resolve scripts using either:
+
+- `script_ref`: a logical runtime reference URI, such as `validator://mint-nft`;
+- `script_hash`: the content hash of the script.
+
+Example:
+
+```yaml
+version: "1.0"
+transaction:
+  - tx:
+      from_ref: account://alice
+      scripts:
+        - type: validator
+          role: mint
+          script_ref: validator://mint-nft
+        - type: native_script
+          script_hash: f711cc44f1611e6784f13ca21a0863ed2923d065d4493ef24246ea46
+```
+
+The term `script_ref` in this ADR means a runtime registry reference, not a Cardano on-chain reference script. On-chain reference scripts remain represented by reference inputs, `script_ref_bytes`, `referenceScriptHash`, and the existing `ScriptSupplier` / `ReferenceScriptResolver` flow.
+
+## 3. API Changes
+
+Add a QuickTx-level registry:
+
+```java
+public interface ScriptRegistry {
+    Optional<Script> resolve(String ref);
+
+    default Optional<Script> resolveByHash(String scriptHash) {
+        return Optional.empty();
+    }
+}
+```
+
+Add a default implementation:
+
+```java
+public class DefaultScriptRegistry implements ScriptRegistry {
+    public DefaultScriptRegistry addScript(String ref, Script script);
+    public DefaultScriptRegistry addPlutusScript(String ref, PlutusScript script);
+    public DefaultScriptRegistry addNativeScript(String ref, NativeScript script);
+    public DefaultScriptRegistry withScriptSupplier(ScriptSupplier scriptSupplier);
+}
+```
+
+`DefaultScriptRegistry` indexes scripts by:
+
+- explicit `ref`;
+- computed script hash, using `Script.getPolicyId()` / `Script.getScriptHash()`.
+
+If a `ScriptSupplier` is configured, `resolveByHash(scriptHash)` may fall back to `scriptSupplier.getScript(scriptHash)`. Because `ScriptSupplier` returns only `PlutusScript`, this fallback only supports Plutus scripts. Native scripts must be present in the registry unless a future generalized supplier is introduced.
+
+Add configuration to `QuickTxBuilder.TxContext`:
+
+```java
+TxContext withScriptRegistry(ScriptRegistry registry)
+```
+
+Optionally add convenience composition overloads:
+
+```java
+TxContext compose(TxPlan plan, SignerRegistry signerRegistry, ScriptRegistry scriptRegistry)
+```
+
+## 4. YAML Field Changes
+
+Add `script_ref` and `script_hash` to `ScriptValidatorAttachmentIntent`:
+
+```yaml
+scripts:
+  - type: validator
+    role: spend
+    script_ref: validator://spend
+```
+
+```yaml
+scripts:
+  - type: validator
+    role: mint
+    script_hash: 5c17ca2cb0ed76c8c6345f7db447d1c8f260e032cd2fb8267a17aa3e
+```
+
+Add `script_ref` and `script_hash` to `NativeScriptAttachmentIntent`:
+
+```yaml
+scripts:
+  - type: native_script
+    script_ref: native://policy
+```
+
+```yaml
+scripts:
+  - type: native_script
+    script_hash: f711cc44f1611e6784f13ca21a0863ed2923d065d4493ef24246ea46
+```
+
+## 5. Resolution Flow
+
+Resolution should happen in `QuickTxBuilder.TxContext._build()` after the effective `ScriptRegistry` is known and before `tx.verifyData()` / `tx.complete()`.
+
+For each `ScriptValidatorAttachmentIntent` or `NativeScriptAttachmentIntent`:
+
+1. Resolve `${...}` variables in `script_ref` or `script_hash` through the normal TxPlan variable path.
+2. If neither field exists, keep current runtime-script or embedded-script behavior.
+3. If either field exists, require a configured `ScriptRegistry`; otherwise throw `TxBuildException`.
+4. Resolve by `script_ref` or `script_hash`.
+5. For hash resolution, verify the resolved script's computed hash exactly equals the requested hash.
+6. Require the expected script kind:
+   - validator attachment requires `PlutusScript`;
+   - native script attachment requires `NativeScript`.
+7. Inject the resolved runtime script into the intent before validation and build execution.
+
+YAML loading must remain pure. `TxPlan.from(yaml)` should not require a registry, backend, or script supplier.
+
+## 6. Validation Rules
+
+Each attachment intent must use exactly one script source.
+
+For `ScriptValidatorAttachmentIntent`:
+
+- runtime `PlutusScript`;
+- `cbor_hex` plus `version`;
+- `script_ref`;
+- `script_hash`.
+
+For `NativeScriptAttachmentIntent`:
+
+- runtime `NativeScript`;
+- `script_hex`;
+- `script_ref`;
+- `script_hash`.
+
+Fail fast for:
+
+- blank `script_ref`;
+- blank or non-hex `script_hash`;
+- missing `ScriptRegistry`;
+- unresolved `script_ref`;
+- unresolved `script_hash`;
+- hash mismatch after resolution;
+- wrong script kind;
+- ambiguous combinations such as `script_ref` plus `cbor_hex`, or `script_hash` plus `script_hex`.
+
+## 7. Serialization Rules
+
+When an intent was created with `script_ref`, `toYaml()` should preserve `script_ref` and should not emit derived `cbor_hex`, `version`, or `script_hex`.
+
+When an intent was created with `script_hash`, `toYaml()` should preserve `script_hash` and should not emit derived script bytes.
+
+When an intent was created from a runtime script without a ref or hash, keep existing behavior and emit script bytes.
+
+When an intent was created from embedded YAML script bytes, keep existing behavior and round-trip those fields.
+
+Do not serialize any private keys or signing material.
+
+## 8. Relationship to ScriptSupplier
+
+`ScriptSupplier` should remain the low-level API for resolving Plutus scripts by script hash, especially for on-chain reference-script workflows.
+
+`ScriptRegistry` may use `ScriptSupplier` internally as a fallback for `script_hash` lookup:
+
+```java
+ScriptRegistry registry = new DefaultScriptRegistry()
+    .addScript("validator://mint", localMintScript)
+    .withScriptSupplier(scriptSupplier);
+```
+
+This keeps YAML and Java APIs consistent while preserving existing backend-driven reference-script behavior.
+
+When `QuickTxBuilder` has no explicit `ScriptRegistry` but does have a context-level or backend-level `ScriptSupplier`, it may treat that supplier as an implicit hash-only registry for `script_hash` lookups. This implicit path only supports Plutus scripts because `ScriptSupplier` is Plutus-only. Logical `script_ref` values still require an explicit `ScriptRegistry`; with only a supplier configured, unresolved logical refs fail as unresolved refs rather than as a missing-registry error.
+
+Do not change `ScriptSupplier` in the first implementation. It is Plutus-only today and changing its return type would be a broader public API change.
+
+## 9. Scope
+
+Initial implementation:
+
+- Add a typed script reference value:
+
+```java
+ScriptRef.ref(String ref)
+ScriptRef.hash(String scriptHash)
+```
+
+- Add `ScriptRegistry` and `DefaultScriptRegistry`.
+- Add `script_ref` and `script_hash` to `ScriptValidatorAttachmentIntent`.
+- Add `script_ref` and `script_hash` to `NativeScriptAttachmentIntent`.
+- Add `QuickTxBuilder.TxContext.withScriptRegistry(...)`.
+- Add typed Java overloads on `Tx`, for example:
+  - `attachSpendingValidator(ScriptRef scriptRef)`;
+  - `attachMintValidator(ScriptRef scriptRef)`;
+  - `attachCertificateValidator(ScriptRef scriptRef)`;
+  - `attachRewardValidator(ScriptRef scriptRef)`;
+  - `attachProposingValidator(ScriptRef scriptRef)`;
+  - `attachVotingValidator(ScriptRef scriptRef)`;
+  - `attachNativeScript(ScriptRef scriptRef)`.
+
+Use explicit factories instead of `ScriptRef.of(String)` so callers must choose whether the value is a logical reference or a script hash. Although `ScriptRef` overlaps with Cardano reference-script terminology, the explicit `ref(...)` and `hash(...)` factories make the Java call sites clear.
+
+Out of scope for the first implementation:
+
+- Direct `script_ref` or `script_hash` on `ScriptMintingIntent`.
+- Direct refs on script spend, staking, or governance intents.
+- A generalized backend script supplier that supports both native and Plutus scripts.
+- Changing existing on-chain reference-script resolution behavior.
+
+## 10. Future Work
+
+A later ADR can introduce intent-level script references for Plutus operations, such as:
+
+- `mint_validator_ref` / `mint_validator_hash` on `ScriptMintingIntent`;
+- `spending_validator_ref` on script collection intents;
+- certificate, reward, proposal, and voting validator refs.
+
+That design must cover policy id derivation, witness attachment, reference inputs, redeemer defaults, execution units, and script versioning explicitly.
+
+## 11. Tests
+
+Add focused unit tests for:
+
+- YAML parse of validator attachment with `script_ref`;
+- YAML parse of validator attachment with `script_hash`;
+- YAML parse of native script attachment with `script_ref`;
+- YAML parse of native script attachment with `script_hash`;
+- TxPlan round-trip preserves refs and hashes without serializing script bytes;
+- build resolves Plutus validator refs and attaches witness scripts;
+- build resolves native script refs and attaches witness scripts;
+- `script_hash` resolution verifies hash equality;
+- `script_hash` falls back to `ScriptSupplier` for Plutus scripts;
+- missing registry fails;
+- unknown ref/hash fails;
+- wrong script kind fails;
+- ambiguous script sources fail;
+- existing embedded script YAML still works.
+
+## 12. Consequences
+
+Positive:
+
+- TxPlan YAML can avoid embedded script bytes for common runtime-managed scripts.
+- Users can choose stable logical names (`script_ref`) or content-addressed lookup (`script_hash`).
+- Existing `ScriptSupplier` remains useful without becoming the primary YAML registry abstraction.
+- Native and Plutus attachment workflows get consistent ref-based ergonomics.
+
+Tradeoffs:
+
+- QuickTx gains another registry abstraction.
+- `script_ref` needs careful documentation because Cardano already has on-chain reference scripts.
+- `ScriptSupplier` fallback is Plutus-only until a broader script-supplier API exists.

--- a/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/ScriptRegistryAttachmentIT.java
+++ b/quicktx/src/it/java/com/bloxbean/cardano/client/quicktx/ScriptRegistryAttachmentIT.java
@@ -1,0 +1,127 @@
+package com.bloxbean.cardano.client.quicktx;
+
+import com.bloxbean.cardano.client.account.Account;
+import com.bloxbean.cardano.client.api.ProtocolParamsSupplier;
+import com.bloxbean.cardano.client.api.TransactionProcessor;
+import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.common.OrderEnum;
+import com.bloxbean.cardano.client.api.exception.ApiException;
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.model.EvaluationResult;
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
+import com.bloxbean.cardano.client.quicktx.script.DefaultScriptRegistry;
+import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScriptRegistryAttachmentIT {
+
+    @Test
+    void yamlPlan_build_resolvesScriptRegistryAttachments() throws Exception {
+        String sender = new Account().baseAddress();
+        String receiver = new Account().baseAddress();
+        PlutusV2Script validator = PlutusV2Script.builder()
+                .type("PlutusScriptV2")
+                .cborHex("49480100002221200101")
+                .build();
+        ScriptPubkey nativeScript = ScriptPubkey.createWithNewKey()._1;
+
+        String yaml = """
+                version: 1.0
+                transaction:
+                  - tx:
+                      from: %s
+                      intents:
+                        - type: payment
+                          address: %s
+                          amounts:
+                            - unit: lovelace
+                              quantity: 5000000
+                      scripts:
+                        - type: validator
+                          role: mint
+                          script_ref: validator://mint
+                        - type: native_script
+                          script_hash: %s
+                """.formatted(sender, receiver, nativeScript.getPolicyId());
+
+        TxPlan plan = TxPlan.from(yaml);
+        Transaction transaction = new QuickTxBuilder(
+                new FixedUtxoSupplier(sender),
+                protocolParamsSupplier(),
+                new NoopTransactionProcessor())
+                .compose(plan)
+                .withScriptRegistry(new DefaultScriptRegistry()
+                        .addPlutusScript("validator://mint", validator)
+                        .addNativeScript("native://policy", nativeScript))
+                .build();
+
+        assertThat(transaction.getWitnessSet().getPlutusV2Scripts()).contains(validator);
+        assertThat(transaction.getWitnessSet().getNativeScripts()).contains(nativeScript);
+    }
+
+    private ProtocolParamsSupplier protocolParamsSupplier() {
+        return () -> {
+            try {
+                InputStream inputStream = getClass().getClassLoader().getResourceAsStream("protocol-params.json");
+                if (inputStream != null) {
+                    return new ObjectMapper().readValue(inputStream, ProtocolParams.class);
+                }
+
+                return new ObjectMapper().readValue(new File("src/test/resources/protocol-params.json"), ProtocolParams.class);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    private static class FixedUtxoSupplier implements UtxoSupplier {
+        private final String address;
+
+        private FixedUtxoSupplier(String address) {
+            this.address = address;
+        }
+
+        @Override
+        public List<Utxo> getPage(String address, Integer nrOfItems, Integer page, OrderEnum order) {
+            return List.of(Utxo.builder()
+                    .address(this.address)
+                    .txHash("5c6e2d88f7eeff25871e3572fdb994df65170aa406b211652537ee0c2c360a3f")
+                    .outputIndex(0)
+                    .amount(List.of(Amount.ada(100)))
+                    .build());
+        }
+
+        @Override
+        public Optional<Utxo> getTxOutput(String txHash, int outputIndex) {
+            return Optional.empty();
+        }
+    }
+
+    private static class NoopTransactionProcessor implements TransactionProcessor {
+        @Override
+        @SuppressWarnings("unchecked")
+        public Result<List<EvaluationResult>> evaluateTx(byte[] cbor, Set<Utxo> inputUtxos) throws ApiException {
+            return Result.success("").withValue(Collections.emptyList());
+        }
+
+        @Override
+        public Result<String> submitTransaction(byte[] cborData) throws ApiException {
+            return Result.success("txhash");
+        }
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/PolicyRef.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/PolicyRef.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.client.quicktx;
+
+import com.bloxbean.cardano.client.function.exception.TxBuildException;
+
+/**
+ * Runtime policy lookup reference for QuickTx native minting APIs.
+ */
+public final class PolicyRef {
+    private final String ref;
+
+    private PolicyRef(String ref) {
+        this.ref = ref;
+    }
+
+    public static PolicyRef ref(String ref) {
+        if (ref == null || ref.isBlank())
+            throw new TxBuildException("policy ref cannot be null or blank");
+        return new PolicyRef(ref);
+    }
+
+    public String getRef() {
+        return ref;
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/QuickTxBuilder.java
@@ -18,16 +18,25 @@ import com.bloxbean.cardano.client.function.TxSigner;
 import com.bloxbean.cardano.client.function.exception.TxBuildException;
 import com.bloxbean.cardano.client.function.helper.*;
 import com.bloxbean.cardano.client.plutus.spec.PlutusScript;
+import com.bloxbean.cardano.client.quicktx.intent.MintingIntent;
+import com.bloxbean.cardano.client.quicktx.intent.NativeScriptAttachmentIntent;
+import com.bloxbean.cardano.client.quicktx.intent.ScriptValidatorAttachmentIntent;
+import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
+import com.bloxbean.cardano.client.quicktx.script.DefaultScriptRegistry;
+import com.bloxbean.cardano.client.quicktx.script.ScriptRegistry;
+import com.bloxbean.cardano.client.quicktx.signing.SignerBinding;
+import com.bloxbean.cardano.client.quicktx.signing.SignerRegistry;
+import com.bloxbean.cardano.client.quicktx.signing.SignerScopes;
 import com.bloxbean.cardano.client.spec.Era;
+import com.bloxbean.cardano.client.spec.Script;
 import com.bloxbean.cardano.client.transaction.spec.Transaction;
 import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
+import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.util.JsonUtil;
 import com.bloxbean.cardano.client.util.Tuple;
 import com.bloxbean.cardano.hdwallet.Wallet;
 import com.bloxbean.cardano.hdwallet.util.HDWalletAddressIterator;
-import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
-import com.bloxbean.cardano.client.util.HexUtil;
-import com.bloxbean.cardano.client.quicktx.signing.SignerRegistry;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -244,6 +253,16 @@ public class QuickTxBuilder {
     }
 
     /**
+     * Compose from a TxPlan and configure registries for ref resolution.
+     */
+    public TxContext compose(TxPlan plan, SignerRegistry signerRegistry, ScriptRegistry scriptRegistry) {
+        TxContext ctx = compose(plan);
+        if (signerRegistry != null) ctx.withSignerRegistry(signerRegistry);
+        if (scriptRegistry != null) ctx.withScriptRegistry(scriptRegistry);
+        return ctx;
+    }
+
+    /**
      * TxContext is created for group of transactions which are to be submitted as a single transaction.
      */
     public class TxContext {
@@ -287,6 +306,7 @@ public class QuickTxBuilder {
 
         // Optional per-context override for registry
         private SignerRegistry contextSignerRegistry;
+        private ScriptRegistry contextScriptRegistry;
 
         // Additional signer refs (ref + scope)
         private class SignerRef {
@@ -297,6 +317,7 @@ public class QuickTxBuilder {
             }
         }
         private List<SignerRef> signerRefs;
+        private Set<String> resolvedSignerRefKeys;
 
         TxContext(AbstractTx... txs) {
             this.txList = txs;
@@ -404,6 +425,16 @@ public class QuickTxBuilder {
         }
 
         /**
+         * Override the builder-level script registry for this composition.
+         * Logical script_ref values require a registry. Hash-based Plutus script_hash
+         * values can also be resolved through a configured ScriptSupplier.
+         */
+        public TxContext withScriptRegistry(ScriptRegistry registry) {
+            this.contextScriptRegistry = registry;
+            return this;
+        }
+
+        /**
          * Set the fee payer using a reference (e.g., account://..., wallet://...).
          */
         public TxContext feePayerRef(String ref) {
@@ -507,6 +538,11 @@ public class QuickTxBuilder {
         private Tuple<TxBuilderContext, TxBuilder> _build() {
             // Resolve references (fromRef, payer refs, additional signer refs) before building
             SignerRegistry effectiveRegistry = this.contextSignerRegistry;
+            boolean hasScriptReferences = hasScriptReferences();
+            ScriptRegistry effectiveScriptRegistry = hasScriptReferences ? effectiveScriptRegistry() : null;
+            if (this.resolvedSignerRefKeys == null)
+                this.resolvedSignerRefKeys = new HashSet<>();
+            Set<String> resolvedSignerRefs = this.resolvedSignerRefKeys;
 
             if (effectiveRegistry != null) {
                 // Resolve tx-level fromRef for regular Txs and add payment signer
@@ -562,18 +598,12 @@ public class QuickTxBuilder {
                     }
                 }
 
+                resolvePolicyRefs(effectiveRegistry, resolvedSignerRefs);
+
                 // Resolve additional signer refs
                 if (this.signerRefs != null && !this.signerRefs.isEmpty()) {
                     for (SignerRef sr : this.signerRefs) {
-                        var bindingOpt = effectiveRegistry.resolve(sr.ref);
-                        if (bindingOpt.isEmpty())
-                            throw new TxBuildException("Unable to resolve signer ref: " + sr.ref);
-                        var binding = bindingOpt.get();
-                        try {
-                            this.withSigner(binding.signerFor(sr.scope));
-                        } catch (Exception e) {
-                            throw new TxBuildException("Failed to create signer for ref: " + sr.ref + ", scope: " + sr.scope, e);
-                        }
+                        resolveSignerRef(effectiveRegistry, sr.ref, sr.scope, resolvedSignerRefs);
                     }
                 }
             } else {
@@ -584,6 +614,8 @@ public class QuickTxBuilder {
                         if (ref != null && !ref.isBlank())
                             throw new TxBuildException("fromRef set but no SignerRegistry configured");
                     }
+                    if (hasPolicyRefs(tx))
+                        throw new TxBuildException("policy_ref set but no SignerRegistry configured");
                 }
                 if (this.feePayerRef != null)
                     throw new TxBuildException("feePayerRef set but no SignerRegistry configured");
@@ -591,6 +623,12 @@ public class QuickTxBuilder {
                     throw new TxBuildException("collateralPayerRef set but no SignerRegistry configured");
                 if (this.signerRefs != null && !this.signerRefs.isEmpty())
                     throw new TxBuildException("signer refs set but no SignerRegistry configured");
+            }
+
+            if (hasScriptReferences && effectiveScriptRegistry != null) {
+                resolveScriptReferences(effectiveScriptRegistry);
+            } else if (hasScriptReferences) {
+                throw new TxBuildException("script_ref/script_hash set but no ScriptRegistry or ScriptSupplier configured");
             }
 
             TxBuilder txBuilder = (context, txn) -> {
@@ -771,6 +809,223 @@ public class QuickTxBuilder {
             }
 
             return new Tuple<>(txBuilderContext, txBuilder);
+        }
+
+        private void resolvePolicyRefs(SignerRegistry registry, Set<String> resolvedSignerRefs) {
+            for (AbstractTx tx : txList) {
+                for (var intent : tx.getIntentions()) {
+                    if (intent instanceof MintingIntent) {
+                        resolvePolicyRef((MintingIntent) intent, registry, resolvedSignerRefs);
+                    }
+                }
+            }
+        }
+
+        private void resolvePolicyRef(MintingIntent intent, SignerRegistry registry, Set<String> resolvedSignerRefs) {
+            String policyRef = intent.getPolicyRef();
+            if (policyRef == null) {
+                return;
+            }
+
+            policyRef = policyRef.trim();
+            if (policyRef.isEmpty()) {
+                throw new TxBuildException("policy_ref cannot be blank");
+            }
+            intent.setPolicyRef(policyRef);
+
+            if (intent.hasSerializedScriptFields()) {
+                throw new TxBuildException("policy_ref cannot be combined with script_hex or script_type");
+            }
+            if (intent.getScript() != null && !intent.isPolicyRefResolved()) {
+                throw new TxBuildException("policy_ref cannot be combined with a runtime script");
+            }
+
+            var bindingOpt = registry.resolve(policyRef);
+            if (bindingOpt.isEmpty()) {
+                throw new TxBuildException("Unable to resolve policy_ref: " + policyRef);
+            }
+
+            SignerBinding binding = bindingOpt.get();
+            var policyOpt = binding.asPolicy();
+            if (policyOpt.isEmpty()) {
+                throw new TxBuildException("Resolved policy_ref does not expose a policy script: " + policyRef);
+            }
+
+            intent.resolvePolicy(policyOpt.get());
+            addSignerForBinding(policyRef, SignerScopes.POLICY, binding, resolvedSignerRefs);
+        }
+
+        private void resolveScriptReferences(ScriptRegistry registry) {
+            for (AbstractTx tx : txList) {
+                for (var intent : tx.getIntentions()) {
+                    if (intent instanceof ScriptValidatorAttachmentIntent) {
+                        resolveValidatorScriptReference((ScriptValidatorAttachmentIntent) intent, registry);
+                    } else if (intent instanceof NativeScriptAttachmentIntent) {
+                        resolveNativeScriptReference((NativeScriptAttachmentIntent) intent, registry);
+                    }
+                }
+            }
+        }
+
+        private ScriptRegistry effectiveScriptRegistry() {
+            if (this.contextScriptRegistry != null) {
+                return this.contextScriptRegistry;
+            }
+
+            ScriptSupplier effectiveScriptSupplier = this.scriptSupplier != null ? this.scriptSupplier : backendScriptSupplier;
+            if (effectiveScriptSupplier != null) {
+                // Hash-based Plutus lookups can reuse the existing ScriptSupplier. Logical script_ref
+                // values still need an explicit ScriptRegistry because ScriptSupplier is hash-only.
+                return new DefaultScriptRegistry().withScriptSupplier(effectiveScriptSupplier);
+            }
+
+            return null;
+        }
+
+        private void resolveValidatorScriptReference(ScriptValidatorAttachmentIntent intent, ScriptRegistry registry) {
+            if (!intent.hasScriptReference()) {
+                return;
+            }
+            if (intent.hasScriptRef() && intent.hasScriptHash()) {
+                throw new TxBuildException("ValidatorAttachment requires only one of script_ref or script_hash");
+            }
+
+            Script script = resolveScriptReference(intent.getScriptRef(), intent.getScriptHash(), registry);
+            if (!(script instanceof PlutusScript)) {
+                throw new TxBuildException("Resolved validator script reference is not a PlutusScript");
+            }
+
+            intent.resolveScript((PlutusScript) script);
+        }
+
+        private void resolveNativeScriptReference(NativeScriptAttachmentIntent intent, ScriptRegistry registry) {
+            if (!intent.hasScriptReference()) {
+                return;
+            }
+            if (intent.hasScriptRef() && intent.hasScriptHash()) {
+                throw new TxBuildException("NativeScriptAttachment requires only one of script_ref or script_hash");
+            }
+
+            Script script = resolveScriptReference(intent.getScriptRef(), intent.getScriptHash(), registry);
+            if (!(script instanceof NativeScript)) {
+                throw new TxBuildException("Resolved native script reference is not a NativeScript");
+            }
+
+            intent.resolveScript((NativeScript) script);
+        }
+
+        private Script resolveScriptReference(String scriptRef, String scriptHash, ScriptRegistry registry) {
+            if (scriptRef != null) {
+                String resolvedRef = scriptRef.trim();
+                if (resolvedRef.isEmpty()) {
+                    throw new TxBuildException("script_ref cannot be blank");
+                }
+
+                return registry.resolve(resolvedRef)
+                        .orElseThrow(() -> new TxBuildException("Unable to resolve script_ref: " + resolvedRef));
+            }
+
+            String resolvedHash = normalizeScriptHash(scriptHash);
+            Script script = registry.resolveByHash(resolvedHash)
+                    .orElseThrow(() -> new TxBuildException("Unable to resolve script_hash: " + resolvedHash));
+            verifyScriptHash(resolvedHash, script);
+            return script;
+        }
+
+        private String normalizeScriptHash(String scriptHash) {
+            if (scriptHash == null || scriptHash.isBlank()) {
+                throw new TxBuildException("script_hash cannot be blank");
+            }
+
+            String normalized = scriptHash.trim().toLowerCase(Locale.ROOT);
+            try {
+                byte[] hashBytes = HexUtil.decodeHexString(normalized);
+                if (hashBytes.length != 28) {
+                    throw new TxBuildException("script_hash must be 28 bytes");
+                }
+            } catch (Exception e) {
+                if (e instanceof TxBuildException) {
+                    throw (TxBuildException) e;
+                }
+                throw new TxBuildException("script_hash must be hex encoded", e);
+            }
+
+            return normalized;
+        }
+
+        private void verifyScriptHash(String expectedHash, Script script) {
+            try {
+                String actualHash = script.getPolicyId();
+                if (!expectedHash.equalsIgnoreCase(actualHash)) {
+                    throw new TxBuildException("Resolved script hash mismatch. Expected: " + expectedHash + ", actual: " + actualHash);
+                }
+            } catch (TxBuildException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new TxBuildException("Unable to calculate resolved script hash", e);
+            }
+        }
+
+        private boolean hasPolicyRefs(AbstractTx tx) {
+            for (var intent : tx.getIntentions()) {
+                if (intent instanceof MintingIntent && ((MintingIntent) intent).getPolicyRef() != null) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean hasScriptReferences(AbstractTx tx) {
+            for (var intent : tx.getIntentions()) {
+                if (intent instanceof ScriptValidatorAttachmentIntent) {
+                    ScriptValidatorAttachmentIntent validatorIntent = (ScriptValidatorAttachmentIntent) intent;
+                    if (validatorIntent.getScriptRef() != null || validatorIntent.getScriptHash() != null) {
+                        return true;
+                    }
+                } else if (intent instanceof NativeScriptAttachmentIntent) {
+                    NativeScriptAttachmentIntent nativeIntent = (NativeScriptAttachmentIntent) intent;
+                    if (nativeIntent.getScriptRef() != null || nativeIntent.getScriptHash() != null) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        private boolean hasScriptReferences() {
+            for (AbstractTx tx : txList) {
+                if (hasScriptReferences(tx)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void resolveSignerRef(SignerRegistry registry, String ref, String scope, Set<String> resolvedSignerRefs) {
+            var bindingOpt = registry.resolve(ref);
+            if (bindingOpt.isEmpty())
+                throw new TxBuildException("Unable to resolve signer ref: " + ref);
+
+            addSignerForBinding(ref, scope, bindingOpt.get(), resolvedSignerRefs);
+        }
+
+        private void addSignerForBinding(String ref, String scope, SignerBinding binding, Set<String> resolvedSignerRefs) {
+            String signerKey = signerKey(ref, scope);
+            if (!resolvedSignerRefs.add(signerKey)) {
+                return;
+            }
+
+            try {
+                this.withSigner(binding.signerFor(scope));
+            } catch (Exception e) {
+                throw new TxBuildException("Failed to create signer for ref: " + ref + ", scope: " + scope, e);
+            }
+        }
+
+        private String signerKey(String ref, String scope) {
+            String normalizedRef = ref == null ? "" : ref.trim();
+            String normalizedScope = scope == null ? "" : scope.trim().toLowerCase(Locale.ROOT);
+            return normalizedRef + "|" + normalizedScope;
         }
 
         private int getTotalSigners() {
@@ -1131,6 +1386,10 @@ public class QuickTxBuilder {
          * Use the given {@link ScriptSupplier} to get script for the transaction
          * For example: To calculate tier reference script fee when reference scripts are used in the transaction, script supplier can be used
          * to get the reference scripts through the UtxoSupplier.
+         * <p>
+         * QuickTx also uses this supplier as a hash-only fallback for script attachment
+         * intents that use script_hash. Logical script_ref values still require
+         * {@link #withScriptRegistry(ScriptRegistry)}.
          *
          * @param scriptSupplier
          * @return

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/ScriptRef.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/ScriptRef.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.client.quicktx;
+
+import com.bloxbean.cardano.client.function.exception.TxBuildException;
+
+/**
+ * Runtime script lookup reference for QuickTx attachment APIs.
+ */
+public final class ScriptRef {
+    private final String ref;
+    private final String hash;
+
+    private ScriptRef(String ref, String hash) {
+        this.ref = ref;
+        this.hash = hash;
+    }
+
+    public static ScriptRef ref(String ref) {
+        if (ref == null || ref.isBlank())
+            throw new TxBuildException("script ref cannot be null or blank");
+        return new ScriptRef(ref, null);
+    }
+
+    public static ScriptRef hash(String scriptHash) {
+        if (scriptHash == null || scriptHash.isBlank())
+            throw new TxBuildException("script hash cannot be null or blank");
+        return new ScriptRef(null, scriptHash);
+    }
+
+    public String getRef() {
+        return ref;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/Tx.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/Tx.java
@@ -127,6 +127,61 @@ public class Tx extends AbstractTx<Tx> {
     }
 
     /**
+     * Add a mint asset to the transaction using a typed runtime policy reference.
+     *
+     * @param policyRef policy reference
+     * @param asset     asset to mint
+     * @return Tx
+     */
+    public Tx mintAssets(@NonNull PolicyRef policyRef, Asset asset) {
+        return mintAssets(policyRef, List.of(asset), null);
+    }
+
+    /**
+     * Add a mint asset to the transaction using a typed runtime policy reference.
+     *
+     * @param policyRef policy reference
+     * @param asset     asset to mint
+     * @param receiver  receiver address
+     * @return Tx
+     */
+    public Tx mintAssets(@NonNull PolicyRef policyRef, Asset asset, String receiver) {
+        return mintAssets(policyRef, List.of(asset), receiver);
+    }
+
+    /**
+     * Add mint assets to the transaction using a typed runtime policy reference.
+     *
+     * @param policyRef policy reference
+     * @param assets    assets to mint
+     * @return Tx
+     */
+    public Tx mintAssets(@NonNull PolicyRef policyRef, List<Asset> assets) {
+        return mintAssets(policyRef, assets, null);
+    }
+
+    /**
+     * Add mint assets to the transaction using a typed runtime policy reference.
+     *
+     * @param policyRef policy reference
+     * @param assets    assets to mint
+     * @param receiver  receiver address
+     * @return Tx
+     */
+    public Tx mintAssets(@NonNull PolicyRef policyRef, List<Asset> assets, String receiver) {
+        MintingIntent intention = MintingIntent.fromPolicyRef(policyRef.getRef(), assets, receiver);
+
+        if (intentions == null) {
+            intentions = new ArrayList<>();
+        }
+        intentions.add(intention);
+
+        hasMultiAssetMinting = true;
+
+        return this;
+    }
+
+    /**
      * Attaches a NativeScript to the current transaction.
      * This method ensures that the given NativeScript is added to
      * the set of native scripts associated with the transaction.
@@ -139,6 +194,20 @@ public class Tx extends AbstractTx<Tx> {
             intentions = new ArrayList<>();
         }
         intentions.add(NativeScriptAttachmentIntent.of(script));
+        return this;
+    }
+
+    /**
+     * Attaches a NativeScript resolved from a runtime script reference or hash.
+     *
+     * @param scriptRef script reference or hash
+     * @return the current Tx instance
+     */
+    public Tx attachNativeScript(@NonNull ScriptRef scriptRef) {
+        if (intentions == null) {
+            intentions = new ArrayList<>();
+        }
+        intentions.add(NativeScriptAttachmentIntent.of(scriptRef));
         return this;
     }
 
@@ -985,6 +1054,16 @@ public class Tx extends AbstractTx<Tx> {
     }
 
     /**
+     * Attach a spending validator resolved from a runtime script reference or hash.
+     *
+     * @param scriptRef script reference or hash
+     * @return Tx
+     */
+    public Tx attachSpendingValidator(@NonNull ScriptRef scriptRef) {
+        return attachValidator(RedeemerTag.Spend, scriptRef);
+    }
+
+    /**
      * Attach a minting validator script to the transaction
      *
      * @param plutusScript plutus script
@@ -994,6 +1073,16 @@ public class Tx extends AbstractTx<Tx> {
         if (intentions == null) intentions = new ArrayList<>();
         intentions.add(ScriptValidatorAttachmentIntent.of(RedeemerTag.Mint, plutusScript));
         return this;
+    }
+
+    /**
+     * Attach a minting validator resolved from a runtime script reference or hash.
+     *
+     * @param scriptRef script reference or hash
+     * @return Tx
+     */
+    public Tx attachMintValidator(@NonNull ScriptRef scriptRef) {
+        return attachValidator(RedeemerTag.Mint, scriptRef);
     }
 
     /**
@@ -1009,6 +1098,16 @@ public class Tx extends AbstractTx<Tx> {
     }
 
     /**
+     * Attach a certificate validator resolved from a runtime script reference or hash.
+     *
+     * @param scriptRef script reference or hash
+     * @return Tx
+     */
+    public Tx attachCertificateValidator(@NonNull ScriptRef scriptRef) {
+        return attachValidator(RedeemerTag.Cert, scriptRef);
+    }
+
+    /**
      * Attach a reward validator script to the transaction
      *
      * @param plutusScript plutus script
@@ -1018,6 +1117,16 @@ public class Tx extends AbstractTx<Tx> {
         if (intentions == null) intentions = new ArrayList<>();
         intentions.add(ScriptValidatorAttachmentIntent.of(RedeemerTag.Reward, plutusScript));
         return this;
+    }
+
+    /**
+     * Attach a reward validator resolved from a runtime script reference or hash.
+     *
+     * @param scriptRef script reference or hash
+     * @return Tx
+     */
+    public Tx attachRewardValidator(@NonNull ScriptRef scriptRef) {
+        return attachValidator(RedeemerTag.Reward, scriptRef);
     }
 
     /**
@@ -1033,6 +1142,16 @@ public class Tx extends AbstractTx<Tx> {
     }
 
     /**
+     * Attach a proposing validator resolved from a runtime script reference or hash.
+     *
+     * @param scriptRef script reference or hash
+     * @return Tx
+     */
+    public Tx attachProposingValidator(@NonNull ScriptRef scriptRef) {
+        return attachValidator(RedeemerTag.Proposing, scriptRef);
+    }
+
+    /**
      * Attach a voting validator script to the transaction
      *
      * @param plutusScript plutus script
@@ -1041,6 +1160,25 @@ public class Tx extends AbstractTx<Tx> {
     public Tx attachVotingValidator(PlutusScript plutusScript) {
         if (intentions == null) intentions = new ArrayList<>();
         intentions.add(ScriptValidatorAttachmentIntent.of(RedeemerTag.Voting, plutusScript));
+        return this;
+    }
+
+    /**
+     * Attach a voting validator resolved from a runtime script reference or hash.
+     *
+     * @param scriptRef script reference or hash
+     * @return Tx
+     */
+    public Tx attachVotingValidator(@NonNull ScriptRef scriptRef) {
+        return attachValidator(RedeemerTag.Voting, scriptRef);
+    }
+
+    /**
+     * Attach a validator by role using a runtime script reference or hash.
+     */
+    private Tx attachValidator(RedeemerTag role, ScriptRef scriptRef) {
+        if (intentions == null) intentions = new ArrayList<>();
+        intentions.add(ScriptValidatorAttachmentIntent.of(role, scriptRef));
         return this;
     }
 

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/intent/MintingIntent.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/intent/MintingIntent.java
@@ -16,6 +16,7 @@ import com.bloxbean.cardano.client.quicktx.serialization.VariableResolver;
 import com.bloxbean.cardano.client.spec.Script;
 import com.bloxbean.cardano.client.transaction.spec.Asset;
 import com.bloxbean.cardano.client.transaction.spec.MultiAsset;
+import com.bloxbean.cardano.client.transaction.spec.Policy;
 import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
 import com.bloxbean.cardano.client.transaction.spec.Value;
 import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
@@ -31,6 +32,7 @@ import lombok.*;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Objects;
 
 import static com.bloxbean.cardano.client.common.CardanoConstants.LOVELACE;
 
@@ -53,6 +55,9 @@ public class MintingIntent implements TxIntent {
     @JsonIgnore
     private Script script;
 
+    @JsonIgnore
+    private boolean policyRefResolved;
+
     /**
      * List of assets to mint (can have negative quantities for burning).
      */
@@ -65,6 +70,12 @@ public class MintingIntent implements TxIntent {
      */
     @JsonProperty("receiver")
     private String receiver;
+
+    /**
+     * Runtime policy reference resolved through SignerRegistry during build.
+     */
+    @JsonProperty("policy_ref")
+    private String policyRef;
 
     // Serialization fields - computed from runtime objects or set during deserialization
     /**
@@ -91,6 +102,9 @@ public class MintingIntent implements TxIntent {
      */
     @JsonProperty("script_hex")
     public String getScriptHex() {
+        if (hasPolicyRef()) {
+            return null;
+        }
         if (script != null) {
             try {
                 return HexUtil.encodeHexString(script.serializeScriptBody());
@@ -107,6 +121,9 @@ public class MintingIntent implements TxIntent {
      */
     @JsonProperty("script_type")
     public Integer getScriptType() {
+        if (hasPolicyRef()) {
+            return null;
+        }
         if (script != null) {
             return script.getScriptType();
         }
@@ -137,6 +154,17 @@ public class MintingIntent implements TxIntent {
             .build();
     }
 
+    /**
+     * Factory method to create MintingIntention from a runtime policy reference.
+     */
+    public static MintingIntent fromPolicyRef(String policyRef, List<Asset> assets, String receiver) {
+        return MintingIntent.builder()
+            .policyRef(policyRef)
+            .assets(assets)
+            .receiver(receiver)
+            .build();
+    }
+
 
     /**
      * Check if this has a specific receiver address.
@@ -146,6 +174,41 @@ public class MintingIntent implements TxIntent {
     }
 
 
+    /**
+     * Check if this has a runtime policy reference.
+     */
+    @JsonIgnore
+    public boolean hasPolicyRef() {
+        return policyRef != null && !policyRef.isBlank();
+    }
+
+    @JsonIgnore
+    public boolean hasScriptHexField() {
+        return scriptHex != null && !scriptHex.isBlank();
+    }
+
+    @JsonIgnore
+    public boolean hasScriptTypeField() {
+        return scriptType != null;
+    }
+
+    @JsonIgnore
+    public boolean hasSerializedScriptFields() {
+        return hasScriptHexField() || hasScriptTypeField();
+    }
+
+    /**
+     * Resolve the runtime policy reference to its native policy script.
+     */
+    @JsonIgnore
+    public void resolvePolicy(Policy policy) {
+        if (policy == null || policy.getPolicyScript() == null) {
+            throw new TxBuildException("Resolved policy_ref has no policy script");
+        }
+        this.script = policy.getPolicyScript();
+        this.policyRefResolved = true;
+    }
+
 
     @Override
     public void validate() {
@@ -153,9 +216,31 @@ public class MintingIntent implements TxIntent {
             throw new IllegalStateException("Minting intention requires assets");
         }
 
-        // Check that we have either runtime script or serialized data
-        if (script == null && (scriptHex == null || scriptHex.isEmpty() || scriptType == null)) {
-            throw new IllegalStateException("Minting intention requires either runtime script or script hex with type");
+        if (policyRef != null && policyRef.isBlank()) {
+            throw new IllegalStateException("Minting intention policy_ref cannot be blank");
+        }
+
+        boolean hasPolicyRef = hasPolicyRef();
+        boolean hasRuntimeScript = script != null;
+        boolean hasScriptHex = hasScriptHexField();
+        boolean hasScriptType = hasScriptTypeField();
+        boolean hasCompleteScriptFields = hasScriptHex && hasScriptType;
+
+        if (hasPolicyRef && (hasScriptHex || hasScriptType)) {
+            throw new IllegalStateException("Minting intention policy_ref cannot be combined with script_hex or script_type");
+        }
+
+        if (hasPolicyRef && hasRuntimeScript && !policyRefResolved) {
+            throw new IllegalStateException("Minting intention policy_ref cannot be combined with a runtime script");
+        }
+
+        if (!hasPolicyRef && (hasScriptHex != hasScriptType)) {
+            throw new IllegalStateException("Minting intention requires script_hex and script_type together");
+        }
+
+        // Check that we have either runtime script, serialized data, or a runtime policy ref.
+        if (!hasPolicyRef && !hasRuntimeScript && !hasCompleteScriptFields) {
+            throw new IllegalStateException("Minting intention requires either runtime script, script hex with type, or policy_ref");
         }
     }
 
@@ -167,12 +252,16 @@ public class MintingIntent implements TxIntent {
 
         String resolvedReceiver = VariableResolver.resolve(receiver, variables);
         String resolvedScriptHex = VariableResolver.resolve(scriptHex, variables);
+        String resolvedPolicyRef = VariableResolver.resolve(policyRef, variables);
 
         // Check if any variables were resolved
-        if (!java.util.Objects.equals(resolvedReceiver, receiver) || !java.util.Objects.equals(resolvedScriptHex, scriptHex)) {
+        if (!java.util.Objects.equals(resolvedReceiver, receiver) ||
+                !Objects.equals(resolvedScriptHex, scriptHex) ||
+                !Objects.equals(resolvedPolicyRef, policyRef)) {
             return this.toBuilder()
                 .receiver(resolvedReceiver)
                 .scriptHex(resolvedScriptHex)
+                .policyRef(resolvedPolicyRef)
                 .build();
         }
 

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/intent/NativeScriptAttachmentIntent.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/intent/NativeScriptAttachmentIntent.java
@@ -5,7 +5,9 @@ import com.bloxbean.cardano.client.common.cbor.CborSerializationUtil;
 import com.bloxbean.cardano.client.exception.CborRuntimeException;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.client.function.TxBuilder;
+import com.bloxbean.cardano.client.function.exception.TxBuildException;
 import com.bloxbean.cardano.client.quicktx.IntentContext;
+import com.bloxbean.cardano.client.quicktx.ScriptRef;
 import com.bloxbean.cardano.client.quicktx.serialization.VariableResolver;
 import com.bloxbean.cardano.client.transaction.spec.TransactionWitnessSet;
 import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
@@ -34,8 +36,17 @@ public class NativeScriptAttachmentIntent implements TxScriptAttachmentIntent {
     @JsonIgnore
     private NativeScript script;
 
+    @JsonIgnore
+    private boolean scriptReferenceResolved;
+
     @JsonProperty("script_hex")
     private String scriptHex;
+
+    @JsonProperty("script_ref")
+    private String scriptRef;
+
+    @JsonProperty("script_hash")
+    private String scriptHash;
 
     @Override
     public String getType() {
@@ -44,6 +55,9 @@ public class NativeScriptAttachmentIntent implements TxScriptAttachmentIntent {
 
     @JsonProperty("script_hex")
     public String getScriptHex() {
+        if (hasScriptReference()) {
+            return null;
+        }
         if (script != null) {
             try {
                 //Store script body as hex. This is an 2-element array. First element is native script type and body
@@ -59,13 +73,50 @@ public class NativeScriptAttachmentIntent implements TxScriptAttachmentIntent {
 
     @Override
     public void validate() {
-        if (script == null) {
-            throw new IllegalStateException("NativeScriptAttachment requires script");
+        if (scriptRef != null && scriptRef.isBlank()) {
+            throw new IllegalStateException("NativeScriptAttachment script_ref cannot be blank");
+        }
+        if (scriptHash != null && scriptHash.isBlank()) {
+            throw new IllegalStateException("NativeScriptAttachment script_hash cannot be blank");
+        }
+
+        boolean hasScriptRef = hasScriptRef();
+        boolean hasScriptHash = hasScriptHash();
+        boolean hasScriptReference = hasScriptRef || hasScriptHash;
+        boolean hasRuntimeScript = script != null;
+        boolean hasScriptHex = hasScriptHexField();
+
+        if (hasScriptRef && hasScriptHash) {
+            throw new IllegalStateException("NativeScriptAttachment requires only one of script_ref or script_hash");
+        }
+        if (hasScriptReference && hasScriptHex) {
+            throw new IllegalStateException("NativeScriptAttachment script_ref/script_hash cannot be combined with script_hex");
+        }
+        if (hasScriptReference && hasRuntimeScript && !scriptReferenceResolved) {
+            throw new IllegalStateException("NativeScriptAttachment script_ref/script_hash cannot be combined with a runtime script");
+        }
+        if (!hasScriptReference && !hasRuntimeScript && !hasScriptHex) {
+            throw new IllegalStateException("NativeScriptAttachment requires script, script_hex, script_ref, or script_hash");
         }
     }
 
     @Override
     public TxIntent resolveVariables(java.util.Map<String, Object> variables) {
+        if (variables == null || variables.isEmpty()) {
+            return this;
+        }
+
+        String resolvedScriptRef = VariableResolver.resolve(scriptRef, variables);
+        String resolvedScriptHash = VariableResolver.resolve(scriptHash, variables);
+
+        if (!java.util.Objects.equals(resolvedScriptRef, scriptRef) ||
+                !java.util.Objects.equals(resolvedScriptHash, scriptHash)) {
+            return this.toBuilder()
+                    .scriptRef(resolvedScriptRef)
+                    .scriptHash(resolvedScriptHash)
+                    .build();
+        }
+
         // If script is not set but script_hex is available, deserialize it
         if (script == null && scriptHex != null && !scriptHex.isEmpty()) {
             try {
@@ -112,11 +163,55 @@ public class NativeScriptAttachmentIntent implements TxScriptAttachmentIntent {
         };
     }
 
+    @JsonIgnore
+    public boolean hasScriptRef() {
+        return scriptRef != null && !scriptRef.isBlank();
+    }
+
+    @JsonIgnore
+    public boolean hasScriptHash() {
+        return scriptHash != null && !scriptHash.isBlank();
+    }
+
+    @JsonIgnore
+    public boolean hasScriptReference() {
+        return hasScriptRef() || hasScriptHash();
+    }
+
+    @JsonIgnore
+    public boolean hasScriptHexField() {
+        return scriptHex != null && !scriptHex.isBlank();
+    }
+
+    @JsonIgnore
+    public void resolveScript(NativeScript script) {
+        if (script == null) {
+            throw new IllegalArgumentException("script cannot be null");
+        }
+        this.script = script;
+        this.scriptReferenceResolved = true;
+    }
+
     // Factory helper
     public static NativeScriptAttachmentIntent of(NativeScript script) {
         return NativeScriptAttachmentIntent.builder()
                 .script(script)
                 .build();
     }
-}
 
+    public static NativeScriptAttachmentIntent of(ScriptRef scriptRef) {
+        if (scriptRef == null) {
+            throw new TxBuildException("scriptRef cannot be null");
+        }
+
+        NativeScriptAttachmentIntentBuilder builder = NativeScriptAttachmentIntent.builder();
+
+        if (scriptRef.getRef() != null) {
+            builder.scriptRef(scriptRef.getRef());
+        } else {
+            builder.scriptHash(scriptRef.getHash());
+        }
+
+        return builder.build();
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/intent/ScriptValidatorAttachmentIntent.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/intent/ScriptValidatorAttachmentIntent.java
@@ -1,9 +1,11 @@
 package com.bloxbean.cardano.client.quicktx.intent;
 
 import com.bloxbean.cardano.client.function.TxBuilder;
+import com.bloxbean.cardano.client.function.exception.TxBuildException;
 import com.bloxbean.cardano.client.plutus.blueprint.model.PlutusVersion;
 import com.bloxbean.cardano.client.plutus.spec.*;
 import com.bloxbean.cardano.client.quicktx.IntentContext;
+import com.bloxbean.cardano.client.quicktx.ScriptRef;
 import com.bloxbean.cardano.client.quicktx.serialization.VariableResolver;
 import com.bloxbean.cardano.client.transaction.spec.TransactionWitnessSet;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -28,11 +30,20 @@ public class ScriptValidatorAttachmentIntent implements TxScriptAttachmentIntent
     @JsonIgnore
     private PlutusScript script;
 
+    @JsonIgnore
+    private boolean scriptReferenceResolved;
+
     @JsonProperty("role")
     private RedeemerTag role;
 
     @JsonProperty("cbor_hex")
     private String scriptHex;
+
+    @JsonProperty("script_ref")
+    private String scriptRef;
+
+    @JsonProperty("script_hash")
+    private String scriptHash;
 
     // 1=V1, 2=V2, 3=V3
     @JsonProperty("version")
@@ -45,6 +56,9 @@ public class ScriptValidatorAttachmentIntent implements TxScriptAttachmentIntent
 
     @JsonProperty("cbor_hex")
     public String getScriptHex() {
+        if (hasScriptReference()) {
+            return null;
+        }
         if (script != null) {
             try { return script.getCborHex(); } catch (Exception e) {}
         }
@@ -53,6 +67,9 @@ public class ScriptValidatorAttachmentIntent implements TxScriptAttachmentIntent
 
     @JsonProperty("version")
     public PlutusVersion getScriptVersion() {
+        if (hasScriptReference()) {
+            return null;
+        }
         if (script != null) {
             if (script instanceof PlutusV1Script) return PlutusVersion.v1;
             if (script instanceof PlutusV2Script) return PlutusVersion.v2;
@@ -63,10 +80,37 @@ public class ScriptValidatorAttachmentIntent implements TxScriptAttachmentIntent
 
     @Override
     public void validate() {
-        if (script == null && (scriptHex == null || scriptHex.isEmpty() || scriptVersion == null)) {
-            throw new IllegalStateException("ValidatorAttachment requires script or script_hex + script_version");
+        if (scriptRef != null && scriptRef.isBlank()) {
+            throw new IllegalStateException("ValidatorAttachment script_ref cannot be blank");
+        }
+        if (scriptHash != null && scriptHash.isBlank()) {
+            throw new IllegalStateException("ValidatorAttachment script_hash cannot be blank");
+        }
+
+        boolean hasScriptRef = hasScriptRef();
+        boolean hasScriptHash = hasScriptHash();
+        boolean hasScriptReference = hasScriptRef || hasScriptHash;
+        boolean hasRuntimeScript = script != null;
+        boolean hasScriptHex = hasScriptHexField();
+        boolean hasScriptVersion = scriptVersion != null;
+
+        if (hasScriptRef && hasScriptHash) {
+            throw new IllegalStateException("ValidatorAttachment requires only one of script_ref or script_hash");
+        }
+        if (hasScriptReference && (hasScriptHex || hasScriptVersion)) {
+            throw new IllegalStateException("ValidatorAttachment script_ref/script_hash cannot be combined with cbor_hex or version");
+        }
+        if (hasScriptReference && hasRuntimeScript && !scriptReferenceResolved) {
+            throw new IllegalStateException("ValidatorAttachment script_ref/script_hash cannot be combined with a runtime script");
+        }
+        if (!hasScriptReference && (hasScriptHex != hasScriptVersion)) {
+            throw new IllegalStateException("ValidatorAttachment requires cbor_hex and version together");
+        }
+        if (!hasScriptReference && !hasRuntimeScript && !(hasScriptHex && hasScriptVersion)) {
+            throw new IllegalStateException("ValidatorAttachment requires script, cbor_hex + version, script_ref, or script_hash");
         }
     }
+
     @Override
     public TxIntent resolveVariables(java.util.Map<String, Object> variables) {
         if (variables == null || variables.isEmpty()) {
@@ -74,11 +118,17 @@ public class ScriptValidatorAttachmentIntent implements TxScriptAttachmentIntent
         }
 
         String resolvedScriptHex = VariableResolver.resolve(scriptHex, variables);
+        String resolvedScriptRef = VariableResolver.resolve(scriptRef, variables);
+        String resolvedScriptHash = VariableResolver.resolve(scriptHash, variables);
 
         // Check if any variables were resolved
-        if (!java.util.Objects.equals(resolvedScriptHex, scriptHex)) {
+        if (!java.util.Objects.equals(resolvedScriptHex, scriptHex) ||
+                !java.util.Objects.equals(resolvedScriptRef, scriptRef) ||
+                !java.util.Objects.equals(resolvedScriptHash, scriptHash)) {
             return this.toBuilder()
                 .scriptHex(resolvedScriptHex)
+                .scriptRef(resolvedScriptRef)
+                .scriptHash(resolvedScriptHash)
                 .build();
         }
 
@@ -125,11 +175,57 @@ public class ScriptValidatorAttachmentIntent implements TxScriptAttachmentIntent
         throw new IllegalStateException("Invalid script version: " + scriptVersion);
     }
 
+    @JsonIgnore
+    public boolean hasScriptRef() {
+        return scriptRef != null && !scriptRef.isBlank();
+    }
+
+    @JsonIgnore
+    public boolean hasScriptHash() {
+        return scriptHash != null && !scriptHash.isBlank();
+    }
+
+    @JsonIgnore
+    public boolean hasScriptReference() {
+        return hasScriptRef() || hasScriptHash();
+    }
+
+    @JsonIgnore
+    public boolean hasScriptHexField() {
+        return scriptHex != null && !scriptHex.isBlank();
+    }
+
+    @JsonIgnore
+    public void resolveScript(PlutusScript script) {
+        if (script == null) {
+            throw new IllegalArgumentException("script cannot be null");
+        }
+        this.script = script;
+        this.scriptReferenceResolved = true;
+    }
+
     // Factory helper
     public static ScriptValidatorAttachmentIntent of(com.bloxbean.cardano.client.plutus.spec.RedeemerTag role, PlutusScript script) {
         return ScriptValidatorAttachmentIntent.builder()
                 .role(role)
                 .script(script)
                 .build();
+    }
+
+    public static ScriptValidatorAttachmentIntent of(com.bloxbean.cardano.client.plutus.spec.RedeemerTag role, ScriptRef scriptRef) {
+        if (scriptRef == null) {
+            throw new TxBuildException("scriptRef cannot be null");
+        }
+
+        ScriptValidatorAttachmentIntentBuilder builder = ScriptValidatorAttachmentIntent.builder()
+                .role(role);
+
+        if (scriptRef.getRef() != null) {
+            builder.scriptRef(scriptRef.getRef());
+        } else {
+            builder.scriptHash(scriptRef.getHash());
+        }
+
+        return builder.build();
     }
 }

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/script/DefaultScriptRegistry.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/script/DefaultScriptRegistry.java
@@ -1,0 +1,94 @@
+package com.bloxbean.cardano.client.quicktx.script;
+
+import com.bloxbean.cardano.client.api.ScriptSupplier;
+import com.bloxbean.cardano.client.function.exception.TxBuildException;
+import com.bloxbean.cardano.client.plutus.spec.PlutusScript;
+import com.bloxbean.cardano.client.spec.Script;
+import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Locale;
+
+/**
+ * Default in-memory script registry.
+ * <p>
+ * Scripts added to this registry are indexed by logical reference and computed
+ * script hash. A configured ScriptSupplier is used only as a Plutus script_hash
+ * fallback; supplied scripts are hash-verified and cached before being returned.
+ */
+public class DefaultScriptRegistry implements ScriptRegistry {
+    private final Map<String, Script> scriptsByRef = new ConcurrentHashMap<>();
+    private final Map<String, Script> scriptsByHash = new ConcurrentHashMap<>();
+    private ScriptSupplier scriptSupplier;
+
+    public DefaultScriptRegistry addScript(String ref, Script script) {
+        if (ref == null || ref.isBlank())
+            throw new TxBuildException("script ref cannot be null or blank");
+        if (script == null)
+            throw new TxBuildException("script cannot be null");
+
+        scriptsByRef.put(ref, script);
+        scriptsByHash.put(scriptHash(script), script);
+        return this;
+    }
+
+    public DefaultScriptRegistry addPlutusScript(String ref, PlutusScript script) {
+        return addScript(ref, script);
+    }
+
+    public DefaultScriptRegistry addNativeScript(String ref, NativeScript script) {
+        return addScript(ref, script);
+    }
+
+    public DefaultScriptRegistry withScriptSupplier(ScriptSupplier scriptSupplier) {
+        this.scriptSupplier = scriptSupplier;
+        return this;
+    }
+
+    @Override
+    public Optional<Script> resolve(String ref) {
+        if (ref == null || ref.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(scriptsByRef.get(ref));
+    }
+
+    @Override
+    public Optional<Script> resolveByHash(String scriptHash) {
+        String normalizedHash = normalizeHash(scriptHash);
+        Script script = scriptsByHash.get(normalizedHash);
+        if (script != null)
+            return Optional.of(script);
+
+        if (scriptSupplier != null) {
+            Optional<PlutusScript> suppliedScript = scriptSupplier.getScript(normalizedHash);
+            if (suppliedScript.isPresent()) {
+                Script resolvedScript = suppliedScript.get();
+                String resolvedHash = scriptHash(resolvedScript);
+                if (!normalizedHash.equalsIgnoreCase(resolvedHash)) {
+                    throw new TxBuildException("Resolved script hash mismatch. Expected: " + normalizedHash + ", actual: " + resolvedHash);
+                }
+                scriptsByHash.put(normalizedHash, resolvedScript);
+                return Optional.of(resolvedScript);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private String scriptHash(Script script) {
+        try {
+            return normalizeHash(script.getPolicyId());
+        } catch (Exception e) {
+            throw new TxBuildException("Unable to calculate script hash", e);
+        }
+    }
+
+    private String normalizeHash(String scriptHash) {
+        if (scriptHash == null || scriptHash.isBlank())
+            throw new TxBuildException("script hash cannot be null or blank");
+        return scriptHash.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/script/ScriptRegistry.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/script/ScriptRegistry.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.client.quicktx.script;
+
+import com.bloxbean.cardano.client.spec.Script;
+
+import java.util.Optional;
+
+/**
+ * Registry for resolving runtime-held script material by logical reference or script hash.
+ */
+public interface ScriptRegistry {
+
+    /**
+     * Resolve a script by a logical runtime reference.
+     *
+     * @param ref logical script reference
+     * @return resolved script, if available
+     */
+    Optional<Script> resolve(String ref);
+
+    /**
+     * Resolve a script by its script hash.
+     *
+     * @param scriptHash script hash in hex
+     * @return resolved script, if available
+     */
+    default Optional<Script> resolveByHash(String scriptHash) {
+        return Optional.empty();
+    }
+}

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/signing/BasicSignerBinding.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/signing/BasicSignerBinding.java
@@ -88,6 +88,11 @@ class BasicSignerBinding implements SignerBinding {
     }
 
     @Override
+    public Optional<Policy> asPolicy() {
+        return Optional.ofNullable(policy);
+    }
+
+    @Override
     public Optional<String> preferredAddress() {
         if (wallet != null) {
             return Optional.ofNullable(wallet.getBaseAddressString(0));

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/signing/SignerBinding.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/signing/SignerBinding.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.client.quicktx.signing;
 
 import com.bloxbean.cardano.client.function.TxSigner;
+import com.bloxbean.cardano.client.transaction.spec.Policy;
 import com.bloxbean.cardano.hdwallet.Wallet;
 
 import java.util.Optional;
@@ -34,5 +35,13 @@ public interface SignerBinding {
      * Useful for sender/fee/collateral payer selection when an address is needed.
      */
     Optional<String> preferredAddress();
-}
 
+    /**
+     * Optional native policy exposed by this binding.
+     * Used by policy_ref minting when the transaction needs both policy script
+     * material and the policy signer.
+     */
+    default Optional<Policy> asPolicy() {
+        return Optional.empty();
+    }
+}

--- a/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/PolicyRefMintingTest.java
+++ b/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/PolicyRefMintingTest.java
@@ -1,0 +1,246 @@
+package com.bloxbean.cardano.client.quicktx;
+
+import com.bloxbean.cardano.client.account.Account;
+import com.bloxbean.cardano.client.api.ProtocolParamsSupplier;
+import com.bloxbean.cardano.client.api.TransactionProcessor;
+import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.api.util.PolicyUtil;
+import com.bloxbean.cardano.client.function.TxSigner;
+import com.bloxbean.cardano.client.function.exception.TxBuildException;
+import com.bloxbean.cardano.client.function.helper.SignerProviders;
+import com.bloxbean.cardano.client.quicktx.intent.MintingIntent;
+import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
+import com.bloxbean.cardano.client.quicktx.signing.DefaultSignerRegistry;
+import com.bloxbean.cardano.client.quicktx.signing.SignerBinding;
+import com.bloxbean.cardano.client.transaction.spec.Asset;
+import com.bloxbean.cardano.client.transaction.spec.MultiAsset;
+import com.bloxbean.cardano.client.transaction.spec.Policy;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.hdwallet.Wallet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PolicyRefMintingTest extends QuickTxBaseTest {
+
+    private final String sender = new Account().baseAddress();
+    private final String receiver = new Account().baseAddress();
+
+    @Mock
+    private UtxoSupplier utxoSupplier;
+
+    private ProtocolParamsSupplier protocolParamsSupplier;
+
+    @Mock
+    private TransactionProcessor transactionProcessor;
+
+    @BeforeEach
+    void setup() throws Exception {
+        protocolParamJsonFile = "protocol-params.json";
+        ProtocolParams protocolParams = (ProtocolParams) loadObjectFromJson("protocol-parameters", ProtocolParams.class);
+        protocolParamsSupplier = () -> protocolParams;
+    }
+
+    @Test
+    void yaml_roundTrip_preservesPolicyRefWithoutScriptFields() {
+        Tx tx = new Tx()
+                .mintAssets(PolicyRef.ref("policy://nft"), new Asset("ExampleToken", BigInteger.ONE), receiver)
+                .from(sender);
+
+        String yaml = TxPlan.from(tx).toYaml();
+
+        assertThat(yaml).contains("policy_ref: policy://nft");
+        assertThat(yaml).doesNotContain("script_hex");
+        assertThat(yaml).doesNotContain("script_type");
+
+        Tx restoredTx = (Tx) TxPlan.from(yaml).getTxs().get(0);
+        MintingIntent restoredIntent = (MintingIntent) restoredTx.getIntentions().get(0);
+        assertThat(restoredIntent.getPolicyRef()).isEqualTo("policy://nft");
+    }
+
+    @Test
+    void yaml_variableResolution_resolvesPolicyRef() {
+        String yaml = """
+                version: 1.0
+                variables:
+                  policy_uri: policy://nft
+                transaction:
+                  - tx:
+                      from: addr_test1qfrom
+                      intents:
+                        - type: minting
+                          policy_ref: ${policy_uri}
+                          assets:
+                            - name: ExampleToken
+                              value: 1
+                          receiver: addr_test1qreceiver
+                """;
+
+        Tx tx = (Tx) TxPlan.from(yaml).getTxs().get(0);
+        MintingIntent intent = (MintingIntent) tx.getIntentions().get(0);
+
+        assertThat(intent.getPolicyRef()).isEqualTo("policy://nft");
+    }
+
+    @Test
+    void build_resolvesPolicyRefToPolicyScriptAndSigner() throws Exception {
+        Policy policy = PolicyUtil.createMultiSigScriptAtLeastPolicy("policy-ref", 1, 1);
+        Asset asset = new Asset("ExampleToken", BigInteger.valueOf(10));
+        givenSenderUtxo();
+
+        Tx tx = new Tx()
+                .payToAddress(receiver, Amount.ada(5))
+                .mintAssets(PolicyRef.ref("policy://nft"), asset, sender)
+                .from(sender);
+
+        Transaction transaction = new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withSignerRegistry(new DefaultSignerRegistry().addPolicy("policy://nft", policy))
+                .build();
+
+        assertThat(transaction.getBody().getMint()).contains(MultiAsset.builder()
+                .policyId(policy.getPolicyId())
+                .assets(List.of(asset))
+                .build());
+        assertThat(transaction.getWitnessSet().getNativeScripts()).contains(policy.getPolicyScript());
+
+        String yamlAfterBuild = TxPlan.from(tx).toYaml();
+        assertThat(yamlAfterBuild).contains("policy_ref: policy://nft");
+        assertThat(yamlAfterBuild).doesNotContain("script_hex");
+        assertThat(yamlAfterBuild).doesNotContain("script_type");
+    }
+
+    @Test
+    void build_withDuplicatePolicyRefSigner_doesNotDuplicateNativeWitness() throws Exception {
+        Policy policy = PolicyUtil.createMultiSigScriptAtLeastPolicy("policy-ref", 1, 1);
+        Asset asset = new Asset("ExampleToken", BigInteger.valueOf(10));
+        givenSenderUtxo();
+
+        Tx tx = new Tx()
+                .payToAddress(receiver, Amount.ada(5))
+                .mintAssets(PolicyRef.ref("policy://nft"), asset, sender)
+                .from(sender);
+
+        Transaction transaction = new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withSignerRegistry(new DefaultSignerRegistry().addPolicy("policy://nft", policy))
+                .withSignerRef("policy://nft", "policy")
+                .build();
+
+        assertThat(transaction.getWitnessSet().getNativeScripts())
+                .filteredOn(script -> script.equals(policy.getPolicyScript()))
+                .hasSize(1);
+    }
+
+    @Test
+    void build_throwsWhenPolicyRefHasNoRegistry() {
+        Tx tx = new Tx()
+                .mintAssets(PolicyRef.ref("policy://nft"), new Asset("ExampleToken", BigInteger.ONE), receiver)
+                .from(sender);
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("policy_ref set but no SignerRegistry configured");
+    }
+
+    @Test
+    void build_throwsWhenPolicyRefIsUnknown() {
+        Tx tx = new Tx()
+                .mintAssets(PolicyRef.ref("policy://nft"), new Asset("ExampleToken", BigInteger.ONE), receiver)
+                .from(sender);
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withSignerRegistry(new DefaultSignerRegistry())
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("Unable to resolve policy_ref: policy://nft");
+    }
+
+    @Test
+    void build_throwsWhenBindingCannotExposePolicy() throws Exception {
+        Policy policy = PolicyUtil.createMultiSigScriptAtLeastPolicy("policy-ref", 1, 1);
+        Tx tx = new Tx()
+                .mintAssets(PolicyRef.ref("policy://nft"), new Asset("ExampleToken", BigInteger.ONE), receiver)
+                .from(sender);
+
+        DefaultSignerRegistry registry = new DefaultSignerRegistry()
+                .addCustom("policy://nft", signerOnlyBinding(policy));
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withSignerRegistry(registry)
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("Resolved policy_ref does not expose a policy script: policy://nft");
+    }
+
+    @Test
+    void build_throwsWhenPolicyRefIsCombinedWithScriptFields() throws Exception {
+        Policy policy = PolicyUtil.createMultiSigScriptAtLeastPolicy("policy-ref", 1, 1);
+        Tx tx = new Tx().from(sender);
+        tx.addIntention(MintingIntent.builder()
+                .policyRef("policy://nft")
+                .scriptHex("00")
+                .scriptType(0)
+                .assets(List.of(new Asset("ExampleToken", BigInteger.ONE)))
+                .receiver(receiver)
+                .build());
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withSignerRegistry(new DefaultSignerRegistry().addPolicy("policy://nft", policy))
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("policy_ref cannot be combined with script_hex or script_type");
+    }
+
+    private void givenSenderUtxo() {
+        given(utxoSupplier.getPage(anyString(), anyInt(), any(), any())).willReturn(List.of(
+                Utxo.builder()
+                        .address(sender)
+                        .txHash(generateRandomHexValue(32))
+                        .outputIndex(0)
+                        .amount(List.of(Amount.ada(100)))
+                        .build()
+        ));
+    }
+
+    private SignerBinding signerOnlyBinding(Policy policy) {
+        return new SignerBinding() {
+            @Override
+            public TxSigner signerFor(String scope) {
+                return SignerProviders.signerFrom(policy);
+            }
+
+            @Override
+            public Optional<Wallet> asWallet() {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<String> preferredAddress() {
+                return Optional.empty();
+            }
+        };
+    }
+}

--- a/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/ScriptRegistryAttachmentTest.java
+++ b/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/ScriptRegistryAttachmentTest.java
@@ -1,0 +1,386 @@
+package com.bloxbean.cardano.client.quicktx;
+
+import com.bloxbean.cardano.client.account.Account;
+import com.bloxbean.cardano.client.api.ProtocolParamsSupplier;
+import com.bloxbean.cardano.client.api.ScriptSupplier;
+import com.bloxbean.cardano.client.api.TransactionProcessor;
+import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import com.bloxbean.cardano.client.api.model.Utxo;
+import com.bloxbean.cardano.client.function.exception.TxBuildException;
+import com.bloxbean.cardano.client.plutus.spec.RedeemerTag;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
+import com.bloxbean.cardano.client.quicktx.intent.NativeScriptAttachmentIntent;
+import com.bloxbean.cardano.client.quicktx.intent.ScriptValidatorAttachmentIntent;
+import com.bloxbean.cardano.client.quicktx.script.DefaultScriptRegistry;
+import com.bloxbean.cardano.client.quicktx.script.ScriptRegistry;
+import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
+import com.bloxbean.cardano.client.spec.Script;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ScriptRegistryAttachmentTest extends QuickTxBaseTest {
+
+    private final String sender = new Account().baseAddress();
+    private final String receiver = new Account().baseAddress();
+
+    @Mock
+    private UtxoSupplier utxoSupplier;
+
+    private ProtocolParamsSupplier protocolParamsSupplier;
+
+    @Mock
+    private TransactionProcessor transactionProcessor;
+
+    @BeforeEach
+    void setup() throws Exception {
+        protocolParamJsonFile = "protocol-params.json";
+        ProtocolParams protocolParams = (ProtocolParams) loadObjectFromJson("protocol-parameters", ProtocolParams.class);
+        protocolParamsSupplier = () -> protocolParams;
+    }
+
+    @Test
+    void validatorScriptRef_roundTripPreservesRefWithoutScriptBytes() {
+        Tx tx = new Tx()
+                .attachMintValidator(ScriptRef.ref("validator://mint"));
+
+        String yaml = TxPlan.from(tx).toYaml();
+
+        assertThat(yaml).contains("script_ref: validator://mint");
+        assertThat(yaml).doesNotContain("cbor_hex");
+        assertThat(yaml).doesNotContain("version: v");
+
+        Tx restoredTx = (Tx) TxPlan.from(yaml).getTxs().get(0);
+        ScriptValidatorAttachmentIntent intent = (ScriptValidatorAttachmentIntent) restoredTx.getIntentions().get(0);
+        assertThat(intent.getScriptRef()).isEqualTo("validator://mint");
+    }
+
+    @Test
+    void nativeScriptHash_roundTripPreservesHashWithoutScriptBytes() throws Exception {
+        String scriptHash = ScriptPubkey.createWithNewKey()._1.getPolicyId();
+        Tx tx = new Tx()
+                .attachNativeScript(ScriptRef.hash(scriptHash));
+
+        String yaml = TxPlan.from(tx).toYaml();
+
+        assertThat(yaml).contains("script_hash: " + scriptHash);
+        assertThat(yaml).doesNotContain("script_hex");
+
+        Tx restoredTx = (Tx) TxPlan.from(yaml).getTxs().get(0);
+        NativeScriptAttachmentIntent intent = (NativeScriptAttachmentIntent) restoredTx.getIntentions().get(0);
+        assertThat(intent.getScriptHash()).isEqualTo(scriptHash);
+    }
+
+    @Test
+    void validatorScriptHash_roundTripPreservesHashWithoutScriptBytes() throws Exception {
+        String scriptHash = plutusScript("49480100002221200101").getPolicyId();
+        Tx tx = new Tx()
+                .attachMintValidator(ScriptRef.hash(scriptHash));
+
+        String yaml = TxPlan.from(tx).toYaml();
+
+        assertThat(yaml).contains("script_hash: " + scriptHash);
+        assertThat(yaml).doesNotContain("cbor_hex");
+        assertThat(yaml).doesNotContain("version: v");
+
+        Tx restoredTx = (Tx) TxPlan.from(yaml).getTxs().get(0);
+        ScriptValidatorAttachmentIntent intent = (ScriptValidatorAttachmentIntent) restoredTx.getIntentions().get(0);
+        assertThat(intent.getScriptHash()).isEqualTo(scriptHash);
+    }
+
+    @Test
+    void nativeScriptRef_roundTripPreservesRefWithoutScriptBytes() {
+        Tx tx = new Tx()
+                .attachNativeScript(ScriptRef.ref("native://policy"));
+
+        String yaml = TxPlan.from(tx).toYaml();
+
+        assertThat(yaml).contains("script_ref: native://policy");
+        assertThat(yaml).doesNotContain("script_hex");
+
+        Tx restoredTx = (Tx) TxPlan.from(yaml).getTxs().get(0);
+        NativeScriptAttachmentIntent intent = (NativeScriptAttachmentIntent) restoredTx.getIntentions().get(0);
+        assertThat(intent.getScriptRef()).isEqualTo("native://policy");
+    }
+
+    @Test
+    void yaml_variableResolution_resolvesScriptRefAndScriptHash() throws Exception {
+        String nativeScriptHash = ScriptPubkey.createWithNewKey()._1.getPolicyId();
+        String yaml = """
+                version: 1.0
+                variables:
+                  validator_ref: validator://mint
+                  native_hash: %s
+                transaction:
+                  - tx:
+                      from: addr_test1qfrom
+                      scripts:
+                        - type: validator
+                          role: mint
+                          script_ref: ${validator_ref}
+                        - type: native_script
+                          script_hash: ${native_hash}
+                """.formatted(nativeScriptHash);
+
+        Tx tx = (Tx) TxPlan.from(yaml).getTxs().get(0);
+        ScriptValidatorAttachmentIntent validatorIntent = tx.getIntentions().stream()
+                .filter(ScriptValidatorAttachmentIntent.class::isInstance)
+                .map(ScriptValidatorAttachmentIntent.class::cast)
+                .findFirst()
+                .orElseThrow();
+        NativeScriptAttachmentIntent nativeIntent = tx.getIntentions().stream()
+                .filter(NativeScriptAttachmentIntent.class::isInstance)
+                .map(NativeScriptAttachmentIntent.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(validatorIntent.getScriptRef()).isEqualTo("validator://mint");
+        assertThat(nativeIntent.getScriptHash()).isEqualTo(nativeScriptHash);
+    }
+
+    @Test
+    void attachValidatorScriptRefOverloads_createExpectedRolesAndRefs() {
+        Tx tx = new Tx()
+                .attachSpendingValidator(ScriptRef.ref("validator://spend"))
+                .attachMintValidator(ScriptRef.ref("validator://mint"))
+                .attachCertificateValidator(ScriptRef.ref("validator://cert"))
+                .attachRewardValidator(ScriptRef.ref("validator://reward"))
+                .attachProposingValidator(ScriptRef.ref("validator://propose"))
+                .attachVotingValidator(ScriptRef.ref("validator://vote"));
+
+        List<ScriptValidatorAttachmentIntent> validatorIntents = tx.getIntentions().stream()
+                .filter(ScriptValidatorAttachmentIntent.class::isInstance)
+                .map(ScriptValidatorAttachmentIntent.class::cast)
+                .collect(Collectors.toList());
+
+        assertThat(validatorIntents)
+                .extracting(ScriptValidatorAttachmentIntent::getRole)
+                .containsExactly(RedeemerTag.Spend, RedeemerTag.Mint, RedeemerTag.Cert,
+                        RedeemerTag.Reward, RedeemerTag.Proposing, RedeemerTag.Voting);
+        assertThat(validatorIntents)
+                .extracting(ScriptValidatorAttachmentIntent::getScriptRef)
+                .containsExactly("validator://spend", "validator://mint", "validator://cert",
+                        "validator://reward", "validator://propose", "validator://vote");
+    }
+
+    @Test
+    void build_resolvesValidatorScriptRefAndAttachesWitness() throws Exception {
+        PlutusV2Script script = plutusScript("49480100002221200101");
+        givenSenderUtxo();
+
+        Tx tx = new Tx()
+                .payToAddress(receiver, Amount.ada(5))
+                .attachMintValidator(ScriptRef.ref("validator://mint"))
+                .from(sender);
+
+        Transaction transaction = new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptRegistry(new DefaultScriptRegistry().addPlutusScript("validator://mint", script))
+                .build();
+
+        assertThat(transaction.getWitnessSet().getPlutusV2Scripts()).contains(script);
+        assertThat(TxPlan.from(tx).toYaml()).contains("script_ref: validator://mint")
+                .doesNotContain("cbor_hex");
+    }
+
+    @Test
+    void build_resolvesNativeScriptRefAndAttachesWitness() throws Exception {
+        ScriptPubkey script = ScriptPubkey.createWithNewKey()._1;
+        givenSenderUtxo();
+
+        Tx tx = new Tx()
+                .payToAddress(receiver, Amount.ada(5))
+                .attachNativeScript(ScriptRef.ref("native://policy"))
+                .from(sender);
+
+        Transaction transaction = new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptRegistry(new DefaultScriptRegistry().addNativeScript("native://policy", script))
+                .build();
+
+        assertThat(transaction.getWitnessSet().getNativeScripts()).contains(script);
+        assertThat(TxPlan.from(tx).toYaml()).contains("script_ref: native://policy")
+                .doesNotContain("script_hex");
+    }
+
+    @Test
+    void build_resolvesNativeScriptHashAndAttachesWitness() throws Exception {
+        ScriptPubkey script = ScriptPubkey.createWithNewKey()._1;
+        givenSenderUtxo();
+
+        Tx tx = new Tx()
+                .payToAddress(receiver, Amount.ada(5))
+                .attachNativeScript(ScriptRef.hash(script.getPolicyId()))
+                .from(sender);
+
+        Transaction transaction = new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptRegistry(new DefaultScriptRegistry().addNativeScript("native://policy", script))
+                .build();
+
+        assertThat(transaction.getWitnessSet().getNativeScripts()).contains(script);
+        assertThat(TxPlan.from(tx).toYaml()).contains("script_hash: " + script.getPolicyId())
+                .doesNotContain("script_hex");
+    }
+
+    @Test
+    void build_resolvesValidatorScriptHashThroughScriptSupplier() throws Exception {
+        PlutusV2Script script = plutusScript("49480100002221200101");
+        String scriptHash = script.getPolicyId();
+        ScriptSupplier scriptSupplier = hash -> scriptHash.equals(hash) ? Optional.of(script) : Optional.empty();
+        givenSenderUtxo();
+
+        Tx tx = new Tx()
+                .payToAddress(receiver, Amount.ada(5))
+                .attachMintValidator(ScriptRef.hash(scriptHash))
+                .from(sender);
+
+        Transaction transaction = new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptSupplier(scriptSupplier)
+                .build();
+
+        assertThat(transaction.getWitnessSet().getPlutusV2Scripts()).contains(script);
+    }
+
+    @Test
+    void build_throwsWhenScriptReferenceHasNoRegistry() {
+        Tx tx = new Tx()
+                .attachMintValidator(ScriptRef.ref("validator://mint"));
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("script_ref/script_hash set but no ScriptRegistry or ScriptSupplier configured");
+    }
+
+    @Test
+    void build_throwsWhenScriptHashUnknown() throws Exception {
+        String scriptHash = plutusScript("49480100002221200101").getPolicyId();
+        Tx tx = new Tx()
+                .attachMintValidator(ScriptRef.hash(scriptHash));
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptRegistry(new DefaultScriptRegistry())
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("Unable to resolve script_hash");
+    }
+
+    @Test
+    void build_throwsWhenScriptHashIsNotHex() {
+        Tx tx = new Tx()
+                .attachMintValidator(ScriptRef.hash("not-a-script-hash"));
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptRegistry(new DefaultScriptRegistry())
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("script_hash must be hex encoded");
+    }
+
+    @Test
+    void build_throwsWhenScriptHashHasWrongLength() {
+        Tx tx = new Tx()
+                .attachMintValidator(ScriptRef.hash("abcd"));
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptRegistry(new DefaultScriptRegistry())
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("script_hash must be 28 bytes");
+    }
+
+    @Test
+    void build_throwsWhenResolvedScriptKindIsWrong() throws Exception {
+        ScriptPubkey script = ScriptPubkey.createWithNewKey()._1;
+        Tx tx = new Tx()
+                .attachMintValidator(ScriptRef.ref("native://policy"));
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptRegistry(new DefaultScriptRegistry().addNativeScript("native://policy", script))
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("not a PlutusScript");
+    }
+
+    @Test
+    void build_throwsWhenResolvedScriptHashMismatches() throws Exception {
+        PlutusV2Script requestedScript = plutusScript("49480100002221200101");
+        PlutusV2Script wrongScript = plutusScript("49480100002221200102");
+        Tx tx = new Tx()
+                .attachMintValidator(ScriptRef.hash(requestedScript.getPolicyId()));
+
+        ScriptRegistry registry = new ScriptRegistry() {
+            @Override
+            public Optional<Script> resolve(String ref) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<Script> resolveByHash(String scriptHash) {
+                return Optional.of(wrongScript);
+            }
+        };
+
+        assertThatThrownBy(() -> new QuickTxBuilder(utxoSupplier, protocolParamsSupplier, transactionProcessor)
+                .compose(tx)
+                .withScriptRegistry(registry)
+                .build())
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("Resolved script hash mismatch");
+    }
+
+    @Test
+    void defaultScriptRegistry_throwsWhenSupplierReturnsDifferentScriptHash() throws Exception {
+        PlutusV2Script requestedScript = plutusScript("49480100002221200101");
+        PlutusV2Script wrongScript = plutusScript("49480100002221200102");
+        DefaultScriptRegistry registry = new DefaultScriptRegistry()
+                .withScriptSupplier(hash -> Optional.of(wrongScript));
+
+        assertThatThrownBy(() -> registry.resolveByHash(requestedScript.getPolicyId()))
+                .isInstanceOf(TxBuildException.class)
+                .hasMessageContaining("Resolved script hash mismatch");
+    }
+
+    private PlutusV2Script plutusScript(String cborHex) {
+        return PlutusV2Script.builder()
+                .type("PlutusScriptV2")
+                .cborHex(cborHex)
+                .build();
+    }
+
+    private void givenSenderUtxo() {
+        given(utxoSupplier.getPage(anyString(), anyInt(), any(), any())).willReturn(List.of(
+                Utxo.builder()
+                        .address(sender)
+                        .txHash(generateRandomHexValue(32))
+                        .outputIndex(0)
+                        .amount(List.of(Amount.ada(100)))
+                        .build()
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
  - Add typed `PolicyRef` and `ScriptRef` APIs for QuickTx runtime references.
  - Add `policy_ref` support for native minting through `SignerRegistry`.
  - Add `ScriptRegistry` / `DefaultScriptRegistry` for validator and native script attachment refs.
  - Support `script_ref` and `script_hash` in validator and native script attachment intents.
  - Update QuickTx README and ADRs for policy/script reference workflows.
  - Add unit and offline integration tests for YAML round-trip, variable resolution, registry resolution, and failure cases.
