### PR TITLE
fix(txflow): harden reconciliation and CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,34 @@ jobs:
             verified-structures/jellyfish-merkle-rdbms/build/reports/tests/test/
             verified-structures/jellyfish-merkle-rdbms/build/test-results/test/
 
+  txflow-rdbms:
+    name: TxFlow RDBMS qualification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run TxFlow RDBMS integration suite
+        run: >-
+          ./gradlew :txflow-extensions:txflow-store-rdbms:integrationTest
+          -PskipSigning=true --stacktrace
+      - name: Upload TxFlow RDBMS test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: txflow-rdbms-test-report
+          path: |
+            txflow-extensions/txflow-store-rdbms/build/reports/tests/integrationTest/
+            txflow-extensions/txflow-store-rdbms/build/test-results/integrationTest/
+
   jmt-fuzz:
     name: JMT bounded fuzz qualification
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,8 +1,8 @@
 name: Integration Tests (Devnet)
 
 # Runs integration tests that require a local Cardano devnet (yaci-devkit).
-# These tests generate code from blueprint JSON via annotation processor,
-# then deploy, lock, and unlock funds against a real Cardano devnet.
+# These tests exercise generated blueprint validators and TxFlow stream execution
+# against a real Cardano devnet.
 
 on:
   push:
@@ -67,6 +67,13 @@ jobs:
       - name: Run integration tests
         run: ./gradlew :annotation-processor:integrationTest :annotation-processor:integrationTestNoRegistry -PskipSigning=true --info --stacktrace
 
+      - name: Run TxFlow stream integration tests
+        run: >-
+          ./gradlew :txflow:integrationTest
+          --tests "com.bloxbean.cardano.client.txflow.stream.TxFlowStreamIntegrationTest"
+          --tests "com.bloxbean.cardano.client.txflow.stream.TxFlowStreamContractIntegrationTest"
+          -PskipSigning=true --info --stacktrace
+
       # Upload Gradle HTML test report and JUnit XML results as artifacts
       # so full stack traces are available even when the job fails
       - name: Upload test reports
@@ -86,3 +93,12 @@ jobs:
           path: |
             annotation-processor/build/reports/tests/integrationTestNoRegistry/
             annotation-processor/build/test-results/integrationTestNoRegistry/
+
+      - name: Upload TxFlow stream test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: txflow-stream-test-reports
+          path: |
+            txflow/build/reports/tests/integrationTest/
+            txflow/build/test-results/integrationTest/

--- a/txflow-extensions/txflow-soak/src/main/java/com/bloxbean/cardano/client/txflow/soak/SoakReconciler.java
+++ b/txflow-extensions/txflow-soak/src/main/java/com/bloxbean/cardano/client/txflow/soak/SoakReconciler.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.IntFunction;
@@ -36,6 +37,26 @@ import java.util.function.IntFunction;
  * of the things being tested; the chain is the authority.
  */
 public final class SoakReconciler {
+
+    /**
+     * Explicit ownership allowlist. Keep this aligned with the TxFlow and TxStream migrations;
+     * database metadata must never become executable SQL.
+     */
+    private static final Map<String, String> STORE_TABLE_COUNT_QUERIES = Map.ofEntries(
+            Map.entry("txflow_schema_history", "SELECT COUNT(*) FROM txflow_schema_history"),
+            Map.entry("txflow_execution", "SELECT COUNT(*) FROM txflow_execution"),
+            Map.entry("txflow_idempotency", "SELECT COUNT(*) FROM txflow_idempotency"),
+            Map.entry("txflow_event", "SELECT COUNT(*) FROM txflow_event"),
+            Map.entry("txflow_execution_lease", "SELECT COUNT(*) FROM txflow_execution_lease"),
+            Map.entry("txflow_resource_lease", "SELECT COUNT(*) FROM txflow_resource_lease"),
+            Map.entry("txflow_lease_epoch", "SELECT COUNT(*) FROM txflow_lease_epoch"),
+            Map.entry("txstream_schema_history", "SELECT COUNT(*) FROM txstream_schema_history"),
+            Map.entry("txstream_item", "SELECT COUNT(*) FROM txstream_item"),
+            Map.entry("txstream_binding", "SELECT COUNT(*) FROM txstream_binding"),
+            Map.entry("txstream_planned", "SELECT COUNT(*) FROM txstream_planned"),
+            Map.entry("txstream_batch", "SELECT COUNT(*) FROM txstream_batch"),
+            Map.entry("txstream_bootstrap", "SELECT COUNT(*) FROM txstream_bootstrap"),
+            Map.entry("txstream_ownership", "SELECT COUNT(*) FROM txstream_ownership"));
 
     public record Report(long submitted, long confirmed, long failed, long cancelled,
                          long recoveryRequired, long unresolvedRecovery,
@@ -271,10 +292,11 @@ public final class SoakReconciler {
                 while (rs.next()) tables.add(rs.getString(1));
             }
             for (String table : tables) {
-                String lower = table.toLowerCase();
-                if (!lower.startsWith("txflow") && !lower.startsWith("txstream")) continue;
+                String lower = table.toLowerCase(Locale.ROOT);
+                String countQuery = STORE_TABLE_COUNT_QUERIES.get(lower);
+                if (countQuery == null) continue;
                 try (Statement st = conn.createStatement();
-                     ResultSet rs = st.executeQuery("SELECT COUNT(*) FROM \"" + table + "\"")) {
+                     ResultSet rs = st.executeQuery(countQuery)) {
                     if (rs.next()) counts.put(lower, rs.getLong(1));
                 }
             }

--- a/txflow-extensions/txflow-soak/src/test/java/com/bloxbean/cardano/client/txflow/soak/SoakReconcilerTest.java
+++ b/txflow-extensions/txflow-soak/src/test/java/com/bloxbean/cardano/client/txflow/soak/SoakReconcilerTest.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.client.txflow.soak;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class SoakReconcilerTest {
+
+    @Test
+    void storeRowCountsIgnoresUnsafeMetadataIdentifiers() throws Exception {
+        String jdbcUrl = "jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1";
+        try (Connection connection = DriverManager.getConnection(jdbcUrl);
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE txflow_event (id INTEGER)");
+            statement.execute("INSERT INTO txflow_event VALUES (1), (2)");
+            statement.execute("CREATE TABLE \"TXFLOW_A\"\"BROKEN\" (id INTEGER)");
+        }
+
+        Map<String, Long> counts = new SoakReconciler(null, jdbcUrl, 0).storeRowCounts();
+
+        assertEquals(2L, counts.get("txflow_event"));
+        assertFalse(counts.containsKey("txflow_a\"broken"));
+    }
+}

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/EngineTxFlowStream.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/EngineTxFlowStream.java
@@ -972,10 +972,10 @@ final class EngineTxFlowStream implements TxFlowStream {
         LaneFundingScope funding = partitioning.fundingSource();
         input.append(funding.kind()).append(':').append(funding.source());
         for (String laneAddress : partitioning.laneAddresses()) {
-            input.append(' ').append(laneAddress);
+            input.append('\0').append(laneAddress);
         }
         Amount seed = partitioning.seedPerLane();
-        input.append(' ').append(seed.getUnit()).append(':').append(seed.getQuantity());
+        input.append('\0').append(seed.getUnit()).append(':').append(seed.getQuantity());
         return "bootstrap:" + partitionLanes.size() + ":"
                 + StreamIdentities.fingerprint40(input.toString());
     }


### PR DESCRIPTION
## Summary

- replace metadata-derived dynamic SQL in the soak reconciler with an explicit owned-table allowlist and static queries
- add a regression test for unsafe metadata identifiers
- replace raw NUL source bytes with escaped Java character literals while preserving the bootstrap fingerprint input
- add TxFlow RDBMS integration qualification to the build workflow
- run the TxFlow stream and contract integration tests in the Yaci DevKit workflow and upload their reports

## Validation

- `JAVA_HOME=/Users/satya/.sdkman/candidates/java/17.0.6-tem ./gradlew clean build -PskipSigning=true --stacktrace` — passed, 411 tasks executed
- final incremental Java 17 build and soak javadocs — passed
- soak reconciler regression test — passed
- H2 RDBMS integration suite — passed
- workflow YAML parsing and `git diff --check` — passed

## Environment notes

- the complete PostgreSQL Testcontainers suite needs the new clean CI job; the local Docker database previously exhausted its allocated disk while creating test databases
- the exact TxFlow devnet selectors were exercised locally, but the long-running local Yaci chain was stale and faucet transactions did not land, producing only insufficient-balance failures; the workflow runs them against a fresh Yaci instance