### PR TITLE
fix(quicktx): restore native scripts after YAML round-trip

### DIFF
--- a/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/helper/ContractTransactionIT.java
+++ b/integration-test/src/it/java/com/bloxbean/cardano/client/backend/api/helper/ContractTransactionIT.java
@@ -32,7 +32,6 @@ import com.bloxbean.cardano.client.metadata.cbor.CBORMetadataMap;
 import com.bloxbean.cardano.client.plutus.annotation.Constr;
 import com.bloxbean.cardano.client.plutus.annotation.PlutusField;
 import com.bloxbean.cardano.client.plutus.spec.*;
-import com.bloxbean.cardano.client.spec.Era;
 import com.bloxbean.cardano.client.spec.NetworkId;
 import com.bloxbean.cardano.client.transaction.model.PaymentTransaction;
 import com.bloxbean.cardano.client.transaction.model.TransactionDetailsParams;
@@ -42,6 +41,7 @@ import com.bloxbean.cardano.client.plutus.util.ScriptDataHashGenerator;
 import com.bloxbean.cardano.client.util.HexUtil;
 import com.bloxbean.cardano.client.util.JsonUtil;
 import com.bloxbean.cardano.client.util.Tuple;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -165,9 +165,9 @@ public class ContractTransactionIT extends BaseITTest {
         transactionWitnessSet.setPlutusDataList(Arrays.asList(plutusData));
         transactionWitnessSet.setRedeemers(Arrays.asList(redeemer));
 
-        var costMdls = new CostMdls();
-        costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
+        var costMdls = getPlutusV1CostMdls();
+
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -308,10 +308,9 @@ public class ContractTransactionIT extends BaseITTest {
         transactionWitnessSet.setPlutusDataList(Arrays.asList(plutusData));
         transactionWitnessSet.setRedeemers(Arrays.asList(redeemer));
 
-        var costMdls = new CostMdls();
-        costMdls.add(CostModelUtil.PlutusV1CostModel);
+        var costMdls = getPlutusV1CostMdls();
 
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -439,9 +438,9 @@ public class ContractTransactionIT extends BaseITTest {
         transactionWitnessSet.setPlutusDataList(Arrays.asList(plutusData));
         transactionWitnessSet.setRedeemers(Arrays.asList(redeemer));
 
-        var costMdls = new CostMdls();
-        costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
+        var costMdls = getPlutusV1CostMdls();
+
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -576,9 +575,9 @@ public class ContractTransactionIT extends BaseITTest {
         transactionWitnessSet.setPlutusDataList(Arrays.asList(plutusData));
         transactionWitnessSet.setRedeemers(Arrays.asList(redeemer));
 
-        var costMdls = new CostMdls();
-        costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
+        var costMdls = getPlutusV1CostMdls();
+
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -615,6 +614,15 @@ public class ContractTransactionIT extends BaseITTest {
         System.out.println(result);
         assertTrue(result.isSuccessful());
         waitForTransaction(result);
+    }
+
+    @NotNull
+    private CostMdls getPlutusV1CostMdls() throws ApiException {
+        var costMdls = new CostMdls();
+        var protocolParams = getBackendService().getEpochService().getProtocolParameters().getValue();
+        var costMdl = CostModelUtil.getCostModelFromProtocolParams(protocolParams, Language.PLUTUS_V1).get();
+        costMdls.add(costMdl);
+        return costMdls;
     }
 
     @Test
@@ -711,9 +719,9 @@ public class ContractTransactionIT extends BaseITTest {
         transactionWitnessSet.setPlutusDataList(Arrays.asList(plutusData));
         transactionWitnessSet.setRedeemers(Arrays.asList(redeemer));
 
-        var costMdls = new CostMdls();
-        costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
+        var costMdls = getPlutusV1CostMdls();
+
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -844,9 +852,9 @@ public class ContractTransactionIT extends BaseITTest {
         transactionWitnessSet.setPlutusDataList(Arrays.asList(plutusData));
         transactionWitnessSet.setRedeemers(Arrays.asList(redeemer));
 
-        var costMdls = new CostMdls();
-        costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
+        var costMdls = getPlutusV1CostMdls();
+
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
                 Arrays.asList(plutusData), costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -977,9 +985,8 @@ public class ContractTransactionIT extends BaseITTest {
         transactionWitnessSet.setPlutusDataList(Arrays.asList(plutusData));
         transactionWitnessSet.setRedeemers(Arrays.asList(redeemer));
 
-        var costMdls = new CostMdls();
-        costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
+        var costMdls = getPlutusV1CostMdls();
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
                 Arrays.asList(plutusData),  costMdls);
         body.setScriptDataHash(scriptDataHash);
 
@@ -1132,9 +1139,9 @@ public class ContractTransactionIT extends BaseITTest {
         transactionWitnessSet.setPlutusV1Scripts(Arrays.asList(plutusScript));
         transactionWitnessSet.setRedeemers(Arrays.asList(redeemer));
 
-        var costMdls = new CostMdls();
-        costMdls.add(CostModelUtil.PlutusV1CostModel);
-        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Era.Babbage, Arrays.asList(redeemer),
+        var costMdls = getPlutusV1CostMdls();
+
+        byte[] scriptDataHash = ScriptDataHashGenerator.generate(Arrays.asList(redeemer),
                 Collections.emptyList(), costMdls);
 
         body.setScriptDataHash(scriptDataHash);

--- a/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/intent/NativeScriptAttachmentIntent.java
+++ b/quicktx/src/main/java/com/bloxbean/cardano/client/quicktx/intent/NativeScriptAttachmentIntent.java
@@ -102,10 +102,6 @@ public class NativeScriptAttachmentIntent implements TxScriptAttachmentIntent {
 
     @Override
     public TxIntent resolveVariables(java.util.Map<String, Object> variables) {
-        if (variables == null || variables.isEmpty()) {
-            return this;
-        }
-
         String resolvedScriptRef = VariableResolver.resolve(scriptRef, variables);
         String resolvedScriptHash = VariableResolver.resolve(scriptHash, variables);
 

--- a/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/NativeScriptAttachmentIntentTest.java
+++ b/quicktx/src/test/java/com/bloxbean/cardano/client/quicktx/NativeScriptAttachmentIntentTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.client.quicktx;
 
+import com.bloxbean.cardano.client.quicktx.intent.NativeScriptAttachmentIntent;
 import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
 import com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey;
 import org.junit.jupiter.api.Test;
@@ -28,5 +29,12 @@ class NativeScriptAttachmentIntentTest {
 
         assertThat(deTx.getIntentions()).isNotEmpty();
         assertThat(deTx.getIntentions().stream().anyMatch(i -> "native_script".equals(i.getType()))).isTrue();
+        NativeScriptAttachmentIntent restoredIntent = deTx.getIntentions().stream()
+                .filter(NativeScriptAttachmentIntent.class::isInstance)
+                .map(NativeScriptAttachmentIntent.class::cast)
+                .findFirst()
+                .orElseThrow();
+        assertThat(restoredIntent.getScript()).isNotNull();
+        assertThat(restoredIntent.getScript().getPolicyId()).isEqualTo(script.getPolicyId());
     }
 }


### PR DESCRIPTION
## Summary

- allow native-script YAML hydration to run when a transaction plan has no variables
- preserve existing null-safe variable resolution for script references and hashes
- assert that a YAML round-trip restores a non-null runtime native script with the original policy ID

## Cause

`NativeScriptAttachmentIntent.resolveVariables(...)` returned immediately for null or empty variable maps. That skipped the existing `script_hex` decoder, so a deserialized attachment retained its YAML field but reached transaction construction with a null runtime script.

## Validation

- `./gradlew :quicktx:test -PskipSigning=true --stacktrace` under Java 17
- `./gradlew :quicktx:build -PskipSigning=true --stacktrace` under Java 17
- `git diff --check`

Closes #645