### PR TITLE
spike: count body-implied witnesses in fee estimation (#650)

### DIFF
--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/BalanceTxBuilders.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/BalanceTxBuilders.java
@@ -107,10 +107,20 @@ public class BalanceTxBuilders {
         return (context, txn) -> {
             String changeAddress = changeAddressIter.getFirst().getAddress();
 
-            FeeCalculators.feeCalculator(changeAddress, UtxoUtil.getNoOfRequiredSigners(context.getAllUtxos()) + additionalSigners).apply(context, txn);
+            // The transaction itself already shows most witnesses it will need (certificates,
+            // withdrawals, votes, required signers, native scripts) — count them, so callers that
+            // build unsigned and cannot attach signers get a correct fee by default (#650).
+            // max() rather than sum keeps existing callers who pass the count themselves from
+            // double-budgeting; additionalSigners remains the override for what the body cannot
+            // show (e.g. scripts supplied via reference inputs).
+            int bodyImpliedSigners = WitnessCountEstimator.countBodyImpliedSigners(txn);
+            int estimatedSigners = UtxoUtil.getNoOfRequiredSigners(context.getAllUtxos())
+                    + Math.max(additionalSigners, bodyImpliedSigners);
+
+            FeeCalculators.feeCalculator(changeAddress, estimatedSigners).apply(context, txn);
 
             //Incase change output goes below min ada after fee deduction
-            ChangeOutputAdjustments.adjustChangeOutput(changeAddressIter.clone(), UtxoUtil.getNoOfRequiredSigners(context.getAllUtxos()) + additionalSigners).apply(context, txn);
+            ChangeOutputAdjustments.adjustChangeOutput(changeAddressIter.clone(), estimatedSigners).apply(context, txn);
 
             //If collateral return found, balance collateral outputs
             if (txn.getBody().getCollateralReturn() != null)

--- a/function/src/main/java/com/bloxbean/cardano/client/function/helper/WitnessCountEstimator.java
+++ b/function/src/main/java/com/bloxbean/cardano/client/function/helper/WitnessCountEstimator.java
@@ -1,0 +1,206 @@
+package com.bloxbean.cardano.client.function.helper;
+
+import com.bloxbean.cardano.client.address.Address;
+import com.bloxbean.cardano.client.address.Credential;
+import com.bloxbean.cardano.client.address.CredentialType;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionBody;
+import com.bloxbean.cardano.client.transaction.spec.Withdrawal;
+import com.bloxbean.cardano.client.transaction.spec.cert.AuthCommitteeHotCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.Certificate;
+import com.bloxbean.cardano.client.transaction.spec.cert.PoolRegistration;
+import com.bloxbean.cardano.client.transaction.spec.cert.PoolRetirement;
+import com.bloxbean.cardano.client.transaction.spec.cert.RegCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.RegDRepCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.ResignCommitteeColdCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeCredType;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeCredential;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeDelegation;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeDeregistration;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeRegDelegCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeRegistration;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeVoteDelegCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeVoteRegDelegCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.UnregCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.UnregDRepCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.UpdateDRepCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.VoteDelegCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.VoteRegDelegCert;
+import com.bloxbean.cardano.client.transaction.spec.governance.Voter;
+import com.bloxbean.cardano.client.transaction.spec.governance.VoterType;
+import com.bloxbean.cardano.client.transaction.spec.script.NativeScript;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptAll;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptAny;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptAtLeast;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey;
+import com.bloxbean.cardano.client.util.HexUtil;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Estimates the number of vkey witnesses a transaction will need beyond those implied by its
+ * inputs, by inspecting the transaction itself: certificates, withdrawals, votes, plan-level
+ * required signers, and attached native scripts all demand witnesses that
+ * {@code UtxoUtil.getNoOfRequiredSigners} (which only sees input UTXOs) cannot know about.
+ *
+ * <p><b>Spike / prototype</b> for
+ * <a href="https://github.com/bloxbean/cardano-client-lib/issues/650">#650</a>: today this count
+ * must be supplied by the caller via {@code additionalSignersCount}, which build-unsigned consumers
+ * (FFI bindings, services) routinely get wrong — underestimation is rejected by the node with
+ * {@code FeeTooSmallUTxO}. By fee-calculation time the body already contains the information, so
+ * the library can count it itself.
+ *
+ * <p>Counting rules: one witness per distinct key-hash credential; script-hash credentials are
+ * skipped (witnessed by scripts, not vkeys); native scripts contribute every {@code ScriptPubkey}
+ * in their tree ({@code any}/{@code atLeast} therefore over-count — overpaying is safe,
+ * underpaying is a rejection). Credentials that coincide with an input's payment key are counted
+ * anyway (again: safe direction). Scripts referenced via reference inputs are invisible here and
+ * remain the caller's responsibility.
+ */
+public final class WitnessCountEstimator {
+
+    private WitnessCountEstimator() {
+    }
+
+    /**
+     * Number of distinct key-hash credentials the transaction's body and native scripts require as
+     * witnesses, beyond the input payment keys.
+     */
+    public static int countBodyImpliedSigners(Transaction transaction) {
+        if (transaction == null || transaction.getBody() == null)
+            return 0;
+
+        Set<String> keyHashes = new HashSet<>();
+        TransactionBody body = transaction.getBody();
+
+        if (body.getCerts() != null) {
+            for (Certificate cert : body.getCerts()) {
+                addCertificateKeyHashes(cert, keyHashes);
+            }
+        }
+
+        if (body.getWithdrawals() != null) {
+            for (Withdrawal withdrawal : body.getWithdrawals()) {
+                addRewardAddressKeyHash(withdrawal.getRewardAddress(), keyHashes);
+            }
+        }
+
+        if (body.getRequiredSigners() != null) {
+            for (byte[] requiredSigner : body.getRequiredSigners()) {
+                if (requiredSigner != null)
+                    keyHashes.add(HexUtil.encodeHexString(requiredSigner));
+            }
+        }
+
+        if (body.getVotingProcedures() != null && body.getVotingProcedures().getVoting() != null) {
+            for (Voter voter : body.getVotingProcedures().getVoting().keySet()) {
+                addVoterKeyHash(voter, keyHashes);
+            }
+        }
+
+        if (transaction.getWitnessSet() != null && transaction.getWitnessSet().getNativeScripts() != null) {
+            for (NativeScript nativeScript : transaction.getWitnessSet().getNativeScripts()) {
+                addNativeScriptKeyHashes(nativeScript, keyHashes);
+            }
+        }
+
+        return keyHashes.size();
+    }
+
+    private static void addCertificateKeyHashes(Certificate cert, Set<String> keyHashes) {
+        if (cert instanceof StakeRegistration stakeRegistration) {
+            // Pre-Conway stake registration needs no witness, but budgeting one is the safe
+            // direction and Conway-era RegCert (below) does need it.
+            addStakeCredential(stakeRegistration.getStakeCredential(), keyHashes);
+        } else if (cert instanceof StakeDeregistration stakeDeregistration) {
+            addStakeCredential(stakeDeregistration.getStakeCredential(), keyHashes);
+        } else if (cert instanceof StakeDelegation stakeDelegation) {
+            addStakeCredential(stakeDelegation.getStakeCredential(), keyHashes);
+        } else if (cert instanceof RegCert regCert) {
+            addStakeCredential(regCert.getStakeCredential(), keyHashes);
+        } else if (cert instanceof UnregCert unregCert) {
+            addStakeCredential(unregCert.getStakeCredential(), keyHashes);
+        } else if (cert instanceof VoteDelegCert voteDelegCert) {
+            addStakeCredential(voteDelegCert.getStakeCredential(), keyHashes);
+        } else if (cert instanceof StakeVoteDelegCert stakeVoteDelegCert) {
+            addStakeCredential(stakeVoteDelegCert.getStakeCredential(), keyHashes);
+        } else if (cert instanceof StakeRegDelegCert stakeRegDelegCert) {
+            addStakeCredential(stakeRegDelegCert.getStakeCredential(), keyHashes);
+        } else if (cert instanceof VoteRegDelegCert voteRegDelegCert) {
+            addStakeCredential(voteRegDelegCert.getStakeCredential(), keyHashes);
+        } else if (cert instanceof StakeVoteRegDelegCert stakeVoteRegDelegCert) {
+            addStakeCredential(stakeVoteRegDelegCert.getStakeCredential(), keyHashes);
+        } else if (cert instanceof RegDRepCert regDRepCert) {
+            addCredential(regDRepCert.getDrepCredential(), keyHashes);
+        } else if (cert instanceof UnregDRepCert unregDRepCert) {
+            addCredential(unregDRepCert.getDrepCredential(), keyHashes);
+        } else if (cert instanceof UpdateDRepCert updateDRepCert) {
+            addCredential(updateDRepCert.getDrepCredential(), keyHashes);
+        } else if (cert instanceof AuthCommitteeHotCert authCommitteeHotCert) {
+            addCredential(authCommitteeHotCert.getCommitteeColdCredential(), keyHashes);
+        } else if (cert instanceof ResignCommitteeColdCert resignCommitteeColdCert) {
+            addCredential(resignCommitteeColdCert.getCommitteeColdCredential(), keyHashes);
+        } else if (cert instanceof PoolRegistration poolRegistration) {
+            if (poolRegistration.getOperator() != null)
+                keyHashes.add(HexUtil.encodeHexString(poolRegistration.getOperator()));
+            // Pool owners must also witness; kept out of the spike for discussion (they live in
+            // poolOwners as stake key hashes).
+        } else if (cert instanceof PoolRetirement poolRetirement) {
+            if (poolRetirement.getPoolKeyHash() != null)
+                keyHashes.add(HexUtil.encodeHexString(poolRetirement.getPoolKeyHash()));
+        }
+        // GenesisKeyDelegation / MoveInstataneous: legacy, out of scope.
+    }
+
+    private static void addStakeCredential(StakeCredential credential, Set<String> keyHashes) {
+        if (credential != null && credential.getType() == StakeCredType.ADDR_KEYHASH
+                && credential.getHash() != null) {
+            keyHashes.add(HexUtil.encodeHexString(credential.getHash()));
+        }
+    }
+
+    private static void addCredential(Credential credential, Set<String> keyHashes) {
+        if (credential != null && credential.getType() == CredentialType.Key
+                && credential.getBytes() != null) {
+            keyHashes.add(HexUtil.encodeHexString(credential.getBytes()));
+        }
+    }
+
+    private static void addRewardAddressKeyHash(String rewardAddress, Set<String> keyHashes) {
+        if (rewardAddress == null || rewardAddress.isEmpty())
+            return;
+        try {
+            new Address(rewardAddress).getDelegationCredential()
+                    .filter(credential -> credential.getType() == CredentialType.Key)
+                    .ifPresent(credential -> keyHashes.add(HexUtil.encodeHexString(credential.getBytes())));
+        } catch (Exception e) {
+            // Unparseable address: leave it unbudgeted; the build surfaces the real error.
+        }
+    }
+
+    private static void addVoterKeyHash(Voter voter, Set<String> keyHashes) {
+        if (voter == null || voter.getCredential() == null)
+            return;
+        VoterType type = voter.getType();
+        if (type == VoterType.DREP_KEY_HASH
+                || type == VoterType.CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH
+                || type == VoterType.STAKING_POOL_KEY_HASH) {
+            keyHashes.add(HexUtil.encodeHexString(voter.getCredential().getBytes()));
+        }
+    }
+
+    private static void addNativeScriptKeyHashes(NativeScript script, Set<String> keyHashes) {
+        if (script instanceof ScriptPubkey scriptPubkey) {
+            if (scriptPubkey.getKeyHash() != null)
+                keyHashes.add(scriptPubkey.getKeyHash());
+        } else if (script instanceof ScriptAll scriptAll) {
+            scriptAll.getScripts().forEach(s -> addNativeScriptKeyHashes(s, keyHashes));
+        } else if (script instanceof ScriptAny scriptAny) {
+            scriptAny.getScripts().forEach(s -> addNativeScriptKeyHashes(s, keyHashes));
+        } else if (script instanceof ScriptAtLeast scriptAtLeast) {
+            scriptAtLeast.getScripts().forEach(s -> addNativeScriptKeyHashes(s, keyHashes));
+        }
+        // RequireTimeBefore / RequireTimeAfter carry no keys.
+    }
+}

--- a/function/src/test/java/com/bloxbean/cardano/client/function/helper/WitnessCountEstimatorTest.java
+++ b/function/src/test/java/com/bloxbean/cardano/client/function/helper/WitnessCountEstimatorTest.java
@@ -1,0 +1,95 @@
+package com.bloxbean.cardano.client.function.helper;
+
+import com.bloxbean.cardano.client.address.Credential;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionBody;
+import com.bloxbean.cardano.client.transaction.spec.TransactionWitnessSet;
+import com.bloxbean.cardano.client.transaction.spec.cert.RegDRepCert;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeCredential;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeDelegation;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakePoolId;
+import com.bloxbean.cardano.client.transaction.spec.cert.StakeRegistration;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptAll;
+import com.bloxbean.cardano.client.transaction.spec.script.ScriptPubkey;
+import com.bloxbean.cardano.client.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WitnessCountEstimatorTest {
+
+    private static final byte[] STAKE_KEY = hash((byte) 1);
+    private static final byte[] DREP_KEY = hash((byte) 2);
+    private static final byte[] REQUIRED_SIGNER = hash((byte) 3);
+    private static final byte[] SCRIPT_KEY_A = hash((byte) 4);
+    private static final byte[] SCRIPT_KEY_B = hash((byte) 5);
+
+    private static byte[] hash(byte fill) {
+        byte[] hash = new byte[28];
+        java.util.Arrays.fill(hash, fill);
+        return hash;
+    }
+
+    private static Transaction txWithBody(TransactionBody body) {
+        Transaction transaction = new Transaction();
+        transaction.setBody(body);
+        return transaction;
+    }
+
+    @Test
+    void emptyTransaction_countsZero() {
+        assertThat(WitnessCountEstimator.countBodyImpliedSigners(txWithBody(new TransactionBody())))
+                .isZero();
+    }
+
+    @Test
+    void stakeAndDrepCertificates_countDistinctKeys() {
+        TransactionBody body = new TransactionBody();
+        body.getCerts().add(new StakeRegistration(StakeCredential.fromKeyHash(STAKE_KEY)));
+        // Same stake key again — must not double-count.
+        body.getCerts().add(new StakeDelegation(StakeCredential.fromKeyHash(STAKE_KEY),
+                new StakePoolId(hash((byte) 9))));
+        body.getCerts().add(RegDRepCert.builder()
+                .drepCredential(Credential.fromKey(DREP_KEY))
+                .build());
+
+        assertThat(WitnessCountEstimator.countBodyImpliedSigners(txWithBody(body))).isEqualTo(2);
+    }
+
+    @Test
+    void requiredSigners_counted_andDedupedAgainstCertKeys() {
+        TransactionBody body = new TransactionBody();
+        body.getCerts().add(new StakeRegistration(StakeCredential.fromKeyHash(STAKE_KEY)));
+        body.getRequiredSigners().add(REQUIRED_SIGNER);
+        body.getRequiredSigners().add(STAKE_KEY); // duplicate of the cert's key
+
+        assertThat(WitnessCountEstimator.countBodyImpliedSigners(txWithBody(body))).isEqualTo(2);
+    }
+
+    @Test
+    void nativeScriptPubkeys_countedFromWitnessSet() throws Exception {
+        List<ScriptPubkey> keys = new ArrayList<>();
+        keys.add(new ScriptPubkey(HexUtil.encodeHexString(SCRIPT_KEY_A)));
+        keys.add(new ScriptPubkey(HexUtil.encodeHexString(SCRIPT_KEY_B)));
+        ScriptAll scriptAll = new ScriptAll();
+        keys.forEach(scriptAll::addScript);
+
+        Transaction transaction = txWithBody(new TransactionBody());
+        TransactionWitnessSet witnessSet = new TransactionWitnessSet();
+        witnessSet.getNativeScripts().add(scriptAll);
+        transaction.setWitnessSet(witnessSet);
+
+        assertThat(WitnessCountEstimator.countBodyImpliedSigners(transaction)).isEqualTo(2);
+    }
+
+    @Test
+    void scriptHashCredentials_areSkipped() {
+        TransactionBody body = new TransactionBody();
+        body.getCerts().add(new StakeRegistration(StakeCredential.fromScriptHash(hash((byte) 7))));
+
+        assertThat(WitnessCountEstimator.countBodyImpliedSigners(txWithBody(body))).isZero();
+    }
+}


### PR DESCRIPTION
## What this is

A **prototype/spike** for #650, to judge whether the juice is worth the squeeze — not a polished change. Close it freely if the answer is no.

## Problem

`balanceTxWithAdditionalSigners` budgets fee witnesses as `UtxoUtil.getNoOfRequiredSigners(inputs) + additionalSigners`. The UTXO half is automatic; the rest is a caller-supplied guess. Callers that **build unsigned** (FFI bindings, services — no `withSigner`) routinely guess wrong, and underestimation means the node rejects with `FeeTooSmallUTxO`. Measured in cardano-client-bindings (bloxbean/cardano-client-bindings#75): a tx combining a stake and a DRep certificate was short by exactly one witness (4,444 lovelace at `min_fee_a=44`); a native-script spend whose script UTXO covered the whole tx was short the script's sig witness.

By fee-calculation time the transaction already shows most witnesses it will need. This spike makes the library count them.

## Change

- **`WitnessCountEstimator.countBodyImpliedSigners(Transaction)`** — distinct key-hash credentials across: certificates (pre-Conway stake certs + Conway `RegCert`/`UnregCert`/vote-deleg combos, DRep certs, committee certs, pool registration/retirement), withdrawals, `votingProcedures` voters, `requiredSigners`, and native-script `ScriptPubkey` trees. Script-hash credentials are skipped (script-witnessed, not vkey). `any`/`atLeast` scripts deliberately over-count — overpaying is safe, underpaying is a rejection.
- **`balanceTxWithAdditionalSigners`** now uses `utxoSigners + max(additionalSigners, bodyImplied)` — `max` (not sum) so existing callers passing an accurate count aren't double-budgeted, and `additionalSigners` stays as the override for what the body cannot show (e.g. scripts via reference inputs).

## Open questions for review

1. **`max` vs sum vs replace** — `max` is the backward-compatible middle ground; happy to change.
2. **Pool owners** — `PoolRegistration.poolOwners` also must witness; noted in the code but not counted in the spike.
3. **Legacy certs** (genesis, MIR) skipped.
4. Whether this belongs in `FeeCalculators` instead so every fee path benefits, not just `balanceTx*`.
5. `withSigner` users are unaffected in correctness but could see slightly higher (safer) fees where their signer count was lower than what the body implies.

## Tests

New `WitnessCountEstimatorTest` (cert/required-signer/native-script counting, dedup, script-hash skipping). `:function:test` and `:quicktx:test` pass unchanged.