### PR TITLE
fix: attach durable TxStream redelivery and reconcile stored outcomes

### DIFF
--- a/docs/content/preview/txflow/txstream-durability.mdx
+++ b/docs/content/preview/txflow/txstream-durability.mdx
@@ -330,3 +330,32 @@ Semantics to plan around:
   lifecycle.
 - [TxStream: Lanes, Batching & Throughput](./txstream-throughput) — the concurrency model these
   guarantees compose with.
+
+### Review corrections
+
+Healthy foreign-item reads are observations. They do not install live items or
+advance the owner's projection sequence, even when the engine snapshot is absent.
+Explicit foreign receipt attachment retains a local observation; poll `reconcile`
+or enable the observer to refresh it. Stored recovery-required items may still be
+hydrated and terminally repaired from engine truth. Observation never infers
+recovery authority from a missing snapshot.
+
+The shipped stores resolve a plan through the item's binding. The observer pages
+nonterminal IDs with a cursor and charges every inspected row against its budget,
+including live or abandoned rows. This keeps a pass bounded and lets later rows
+progress; restart still inventories all unresolved work.
+
+After fencing/stopping all producers and recovery workers and investigating an
+abandoned registration, an operator can call
+`store.acknowledgeAbandoned(streamId, itemId, expectedSequence, reason, acknowledgedAt)`.
+It atomically checks the exact stored sequence and RECOVERY_REQUIRED/TXSTREAM_ABANDONED
+state, marks the bookkeeping FAILED, and retains registration, binding, and hash.
+A stale or already-resolved row returns false. This acknowledgement is not proof
+that a transaction failed and is not permission to submit a replacement payment.
+Custom stores must implement this atomic operation explicitly; it is unsupported
+by default. The paging and targeted-lookup SPI methods have compatibility fallbacks.
+
+Registration matching includes the lane name. Changing lane assignment across
+deployments can therefore conflict even when the transaction payload is unchanged.
+No-binding observations do not authorize automatic same-ID reacceptance: another
+owner may still have accepted work queued before its write-ahead binding.

--- a/docs/content/preview/txflow/txstream-durability.mdx
+++ b/docs/content/preview/txflow/txstream-durability.mdx
@@ -13,10 +13,15 @@ requests and supports reattachment, but it is not yet a general exactly-once que
 
 - Shipped durable stores atomically register or match item identity and content.
   Identical redelivery after live eviction or restart attaches to stored work;
-  different content conflicts. Matching never plans another execution.
-- Stored terminal outcomes are returned directly. Nonterminal items with persisted
-  plans are hydrated and reconciled against their original engine execution.
-  Explicit reads, redelivery, and the reconciliation observer share that path.
+  different content conflicts. Matching includes the lane name: changing lane
+  assignment across deployments can conflict even with an unchanged payload.
+  Matching never plans another execution.
+- Stored terminal outcomes are returned directly. Healthy foreign-item reads are
+  detached observations: no live item, claim, counter, event, or owner projection
+  write. A missing or running engine snapshot never establishes recovery authority.
+  Explicit foreign receipt attachment retains a local observation; use `reconcile`
+  or the observer to refresh it. Stored `RECOVERY_REQUIRED` items with persisted
+  plans may be hydrated and terminally repaired from their original engine truth.
 - A registration without a recoverable plan is not automatically replayed.
   Redelivery returns `REJECTED` / `TXSTREAM_REGISTRATION_INCOMPLETE`; a projected
   accepted item found incomplete on restart remains `RECOVERY_REQUIRED` with
@@ -24,7 +29,10 @@ requests and supports reattachment, but it is not yet a general exactly-once que
   the registration, engine claim, and source journal. Do not generate a replacement ID.
 - Custom stores must implement `registerOrMatch` and coherent `getStoredProjection`
   reads to provide the same guarantees. The compatibility defaults retain legacy
-  registration behavior. Item IDs must be unique across streams sharing a store:
+  registration behavior. Shipped stores resolve a plan through its item binding;
+  custom stores can override the lookup and paging compatibility fallbacks for
+  efficient reads, and must explicitly implement atomic abandoned acknowledgement.
+  Item IDs must be unique across streams sharing a store:
   registration keys remain store-scoped in this preview schema.
 - `perWindow()` and `batching()` deduplicate exact flow member sets, not arbitrary
   individual redeliveries after their registration history is removed. Use `perItem()`
@@ -149,6 +157,31 @@ against engine truth (`reattach()`):
 
 `ReattachReport` summarizes the pass (`reattachedItems`, `redispatched`, `recoveryRequired`).
 
+Restart inventories all unresolved work. An absent binding alone does not authorize
+same-ID reacceptance: another owner may still have the accepted item queued before
+its write-ahead binding.
+
+For an abandoned registration, stop or fence **all producers and recovery workers**
+and investigate the source journal, original engine claim, binding, and transaction
+hash first. Then read `getStoredProjection` to obtain the exact sequence expected
+by `acknowledgeAbandoned`:
+
+```java
+TxStreamStoredProjection observed = store.getStoredProjection("payouts", "payment-1")
+        .orElseThrow();
+boolean acknowledged = store.acknowledgeAbandoned(
+        "payouts", "payment-1", observed.sourceSequence(),
+        "Investigated original claim with producers and recovery workers fenced",
+        Instant.now());
+// false means the sequence or abandoned state no longer matches; investigate again.
+```
+
+Acknowledgement atomically checks `RECOVERY_REQUIRED` / `TXSTREAM_ABANDONED` at
+that sequence and marks the bookkeeping `FAILED`, retaining registration, binding,
+and hash. It is **not proof that a transaction failed** and does not authorize a
+replacement payment. Already-resolved or stale observations return false. Custom
+stores that do not implement this atomic operation reject it as unsupported.
+
 ## Dedup scopes: what "exactly-once" actually covers
 
 This is the most important honest section in these docs. The engine supports exactly one
@@ -266,7 +299,9 @@ TxFlowStream stream = TxFlowStream.builder("payouts", engine)
 ```
 
 Repairs are emitted to the `TxStreamEventListener`; `reconciliationBatchSize` (default 100) caps
-work per pass.
+work per pass. Durable candidates are paged with an item-ID cursor; every inspected
+row consumes budget, including live and abandoned rows. The cursor advances so
+later recoverable work is not starved by earlier incomplete registrations.
 
 **3. Operator recovery.** When the engine itself reports the execution `RECOVERY_REQUIRED`, an
 operator runs `engine.recover(...)` — which verifies the persisted signed payload against the
@@ -330,32 +365,3 @@ Semantics to plan around:
   lifecycle.
 - [TxStream: Lanes, Batching & Throughput](./txstream-throughput) — the concurrency model these
   guarantees compose with.
-
-### Review corrections
-
-Healthy foreign-item reads are observations. They do not install live items or
-advance the owner's projection sequence, even when the engine snapshot is absent.
-Explicit foreign receipt attachment retains a local observation; poll `reconcile`
-or enable the observer to refresh it. Stored recovery-required items may still be
-hydrated and terminally repaired from engine truth. Observation never infers
-recovery authority from a missing snapshot.
-
-The shipped stores resolve a plan through the item's binding. The observer pages
-nonterminal IDs with a cursor and charges every inspected row against its budget,
-including live or abandoned rows. This keeps a pass bounded and lets later rows
-progress; restart still inventories all unresolved work.
-
-After fencing/stopping all producers and recovery workers and investigating an
-abandoned registration, an operator can call
-`store.acknowledgeAbandoned(streamId, itemId, expectedSequence, reason, acknowledgedAt)`.
-It atomically checks the exact stored sequence and RECOVERY_REQUIRED/TXSTREAM_ABANDONED
-state, marks the bookkeeping FAILED, and retains registration, binding, and hash.
-A stale or already-resolved row returns false. This acknowledgement is not proof
-that a transaction failed and is not permission to submit a replacement payment.
-Custom stores must implement this atomic operation explicitly; it is unsupported
-by default. The paging and targeted-lookup SPI methods have compatibility fallbacks.
-
-Registration matching includes the lane name. Changing lane assignment across
-deployments can therefore conflict even when the transaction payload is unchanged.
-No-binding observations do not authorize automatic same-ID reacceptance: another
-owner may still have accepted work queued before its write-ahead binding.

--- a/docs/content/preview/txflow/txstream-durability.mdx
+++ b/docs/content/preview/txflow/txstream-durability.mdx
@@ -9,23 +9,32 @@ TxStream is experimental. The default managed runtime is process-local; it does 
 provide crash-durable acceptance. Durable store pairing persists planned execution
 requests and supports reattachment, but it is not yet a general exactly-once queue consumer.
 
-**Current preview restrictions:**
+**Current preview contract:**
 
-- Identical redelivery after an item leaves the live map can report `CONFLICT`, even
-  when its durable registration has identical content. Persistence alone does not
-  provide attach-after-eviction.
-- Accepted work without a persisted execution plan cannot be automatically replayed.
-  Current restart handling can retain an abandoned registration; do not assume that
-  resubmitting the same ID will run it, or that generating a new ID is safe.
-- `awaitResolution` can return stored terminal outcomes. Store-only uncertain items
-  still require hydration/engine recovery; polling never submits a replacement.
+- Shipped durable stores atomically register or match item identity and content.
+  Identical redelivery after live eviction or restart attaches to stored work;
+  different content conflicts. Matching never plans another execution.
+- Stored terminal outcomes are returned directly. Nonterminal items with persisted
+  plans are hydrated and reconciled against their original engine execution.
+  Explicit reads, redelivery, and the reconciliation observer share that path.
+- A registration without a recoverable plan is not automatically replayed.
+  Redelivery returns `REJECTED` / `TXSTREAM_REGISTRATION_INCOMPLETE`; a projected
+  accepted item found incomplete on restart remains `RECOVERY_REQUIRED` with
+  `TXSTREAM_ABANDONED`. Wait for an accepting owner still processing it, or investigate
+  the registration, engine claim, and source journal. Do not generate a replacement ID.
+- Custom stores must implement `registerOrMatch` and coherent `getStoredProjection`
+  reads to provide the same guarantees. The compatibility defaults retain legacy
+  registration behavior. Item IDs must be unique across streams sharing a store:
+  registration keys remain store-scoped in this preview schema.
 - `perWindow()` and `batching()` deduplicate exact flow member sets, not arbitrary
-  individual redeliveries. Use `perItem()` for independently redelivered work.
+  individual redeliveries after their registration history is removed. Use `perItem()`
+  for independently redelivered work and retain durable registrations.
 
-Durable registration matching, shared hydration, and partial-registration recovery
-are tracked separately in ADR 0006. The guarantees below apply to persisted planned
-requests, not every accepted item. Use a controlled evaluation with an application
-journal and an explicit recovery procedure before relying on durable payout processing.
+This is a conservative preview implementation of the registration/hydration portion
+of ADR 0006. It does not implement automatic recovery of accepted-but-unplanned work,
+change the registration key schema, or provide active/active wallet ownership.
+Existing terminal `CANCELLED` / `TXSTREAM_ABANDONED` rows from older builds stay
+terminal and attach as cancelled; upgrades never replay them automatically.
 
 ## The durable pairing
 
@@ -113,8 +122,8 @@ The same operational guidance as the engine store applies (migration with a sche
 `VALIDATE` at runtime, one transactionally consistent backup unit); see
 [Durable Runtime](./durable-runtime) and the RDBMS module README. A durable store ignores the
 stream's retention eviction and keeps settled items indefinitely. This preserves status
-history, but the current acceptance path does not attach after live eviction; it does not lift the
-duplicate-detection guard window below.
+history and enables identical redelivery to attach after live eviction. Receipt
+hydration does not increment acceptance counters or create another execution.
 
 ## What start() does in durable mode
 
@@ -133,9 +142,10 @@ against engine truth (`reattach()`):
    the same execution id on every process and every retry: if the execution somehow does exist,
    the engine answers `MATCHED` and returns the stored execution instead of running a duplicate.
    Double-submission is structurally prevented by the engine claim, not by stream bookkeeping.
-4. Items accepted without a persisted plan cannot be automatically resumed. Their
-   registrations can survive while restart marks them abandoned. Source redelivery
-   may conflict; use an explicit recovery procedure rather than a replacement ID.
+4. Items accepted without a persisted plan cannot be automatically resumed. Restart
+   reports projected incomplete work as recovery-required; same-content redelivery
+   reports `TXSTREAM_REGISTRATION_INCOMPLETE`, not a content conflict. Use an explicit
+   recovery procedure rather than a replacement ID.
 
 `ReattachReport` summarizes the pass (`reattachedItems`, `redispatched`, `recoveryRequired`).
 
@@ -180,8 +190,8 @@ remaining guarantee is *engine-request equality* on the claim-derived execution:
   have been a typed content conflict.
 
 Size the cap to cover your longest realistic redelivery horizon. A durable stream store retains
-settled items indefinitely, but identical redelivery after live eviction currently conflicts.
-The retained status history does not extend the live attach contract.
+settled items indefinitely. The shipped durable stores compare the retained registration
+atomically and attach identical redelivery without another execution.
 
 ## No secrets in the stream store
 

--- a/docs/content/preview/txflow/txstream-getting-started.mdx
+++ b/docs/content/preview/txflow/txstream-getting-started.mdx
@@ -128,8 +128,8 @@ must reuse the original item id.
 > (`maxRetainedSettledItems`, default 10,000). After eviction the engine claim is still the
 > exactly-once guard for identical resubmits, but the stream-level content-conflict check has
 > lapsed — see [the eviction guard window](./txstream-durability#the-eviction-guard-window) for
-> the exact post-eviction guarantees. A durable store retains status history, but identical
-> redelivery after live eviction currently conflicts; see the durable preview restrictions.
+> the exact post-eviction guarantees. Shipped durable stores retain registration history and
+> attach identical redelivery after eviction; incomplete registrations require explicit recovery.
 
 For non-blocking producers, `trySubmit` mirrors `submit` without throwing and without blocking on
 a full buffer:

--- a/txflow-extensions/txflow-soak/README.md
+++ b/txflow-extensions/txflow-soak/README.md
@@ -298,3 +298,12 @@ addition to this tool.
   out — itself a useful signal.
 - `SIGTERM` (Ctrl-C) stops submission, drains what was accepted, and still reconciles. A soak
   interrupted early still produces a valid report.
+
+## Qualifying the SDK indexing check
+
+The soak engine now uses `FlowEngine.builder(backend)`, enabling the SDK's
+between-execution output-visibility check. `--utxo-gate=false` disables only the
+soak application's extra submission gate; it leaves the SDK check enabled. Use
+that profile when measuring ordinary TxStream dispatch behavior and record the
+flag alongside results. Neither a short smoke run nor a gated run establishes
+public-network throughput or crash durability across every acceptance boundary.

--- a/txflow-extensions/txflow-soak/src/main/java/com/bloxbean/cardano/client/txflow/soak/TxStreamSoak.java
+++ b/txflow-extensions/txflow-soak/src/main/java/com/bloxbean/cardano/client/txflow/soak/TxStreamSoak.java
@@ -3,9 +3,6 @@ package com.bloxbean.cardano.client.txflow.soak;
 import com.bloxbean.cardano.client.api.model.Amount;
 import com.bloxbean.cardano.client.api.UtxoSupplier;
 import com.bloxbean.cardano.client.backend.api.BackendService;
-import com.bloxbean.cardano.client.backend.api.DefaultChainDataSupplier;
-import com.bloxbean.cardano.client.backend.api.DefaultProtocolParamsSupplier;
-import com.bloxbean.cardano.client.backend.api.DefaultTransactionProcessor;
 import com.bloxbean.cardano.client.backend.api.DefaultUtxoSupplier;
 import com.bloxbean.cardano.client.backend.blockfrost.service.BFBackendService;
 import com.bloxbean.cardano.client.common.model.Network;
@@ -93,12 +90,9 @@ public final class TxStreamSoak {
         Path dataDir = options.path("data", "./soak-data");
         String streamId = options.string("stream-id", "soak-payouts");
 
-        // Replaying interrupted work is safe under every planner, because the durable store
-        // registers an item id in accept() — BEFORE the item is buffered, planned or merged
-        // into a batch. So an id the store already knows is refused outright (CONFLICT, never
-        // re-planned), and an id it does not know was never batched and cannot be duplicated.
-        // The batching hazard is real but lives elsewhere: resubmitting the same logical
-        // payment under a DIFFERENT item id, which is a new claim and a genuine second payment.
+        // Durable redelivery matches registered content without re-planning. An
+        // incomplete registration is surfaced for recovery, never silently replayed.
+        // Stable IDs remain mandatory: a replacement ID is a new payment intent.
         String onRestart = options.string("on-restart", "resubmit");
         boolean utxoGate = options.flag("utxo-gate", true);
 
@@ -211,11 +205,7 @@ public final class TxStreamSoak {
             signers.addAccount(lane.ref(), lane.account());
         }
 
-        FlowEngine engine = FlowEngine.builder(
-                        new DefaultUtxoSupplier(backend.getUtxoService()),
-                        new DefaultProtocolParamsSupplier(backend.getEpochService()),
-                        new DefaultTransactionProcessor(backend.getTransactionService()),
-                        new DefaultChainDataSupplier(backend))
+        FlowEngine engine = FlowEngine.builder(backend)
                 .executor(engineExec)
                 .maintenanceExecutor(maintenance)
                 .store(RdbmsFlowExecutionStore.builder().jdbcUrl(jdbcUrl).build())

--- a/txflow-extensions/txflow-store-rdbms/src/main/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamStateStore.java
+++ b/txflow-extensions/txflow-store-rdbms/src/main/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamStateStore.java
@@ -12,6 +12,7 @@ import com.bloxbean.cardano.client.txflow.stream.TxStreamItemStatus;
 import com.bloxbean.cardano.client.txflow.stream.StreamOwnershipLease;
 import com.bloxbean.cardano.client.txflow.stream.TxStreamPlannedRecord;
 import com.bloxbean.cardano.client.txflow.stream.TxStreamStateStore;
+import com.bloxbean.cardano.client.txflow.stream.TxStreamStoredProjection;
 import com.bloxbean.cardano.client.txflow.stream.TxStreamStoreCodec;
 
 import javax.sql.DataSource;
@@ -142,6 +143,58 @@ public final class RdbmsTxStreamStateStore implements TxStreamStateStore, AutoCl
     }
 
     @Override
+    public boolean registerOrMatch(TxStreamItemRecord record) {
+        Objects.requireNonNull(record, "record");
+        try {
+            return inTransaction("register or match stream item", connection -> {
+                RegistrationRow existing = readRegistration(connection, record.itemId());
+                if (existing != null && existing.registered()) {
+                    return matchRegistration(readRegistrationRecord(connection, record.itemId()), record);
+                }
+                if (existing != null) {
+                    updateRegistration(connection, record);
+                } else {
+                    insertRegistration(connection, record);
+                }
+                return true;
+            });
+        } catch (TxStreamException conflict) {
+            if (!"TXSTREAM_STORE_UNIQUE_CONFLICT".equals(conflict.getCode())) throw conflict;
+            // The unique constraint chooses one winner across connections. The
+            // losing transaction has rolled back; read the winner in a fresh
+            // transaction (essential on PostgreSQL after a unique violation).
+            return inTransaction("match concurrently registered stream item", connection -> {
+                TxStreamItemRecord existing = readRegistrationRecord(connection, record.itemId());
+                if (existing == null) throw conflict;
+                return matchRegistration(existing, record);
+            });
+        }
+    }
+
+    private boolean matchRegistration(TxStreamItemRecord existing, TxStreamItemRecord candidate) {
+        if (!existing.matches(candidate)) {
+            throw new TxStreamDuplicateItemException(candidate.itemId(),
+                    "Item registration has different content: " + candidate.itemId());
+        }
+        return false;
+    }
+
+    private TxStreamItemRecord readRegistrationRecord(Connection connection, String itemId)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(dialect.forUpdate(
+                "SELECT idempotency_key, lane_name, fingerprint, accepted_at FROM txstream_item "
+                        + "WHERE item_id = ?"))) {
+            statement.setString(1, itemId);
+            try (ResultSet row = statement.executeQuery()) {
+                if (!row.next() || row.getString("idempotency_key") == null) return null;
+                return new TxStreamItemRecord(itemId, row.getString("idempotency_key"),
+                        row.getString("lane_name"), row.getString("fingerprint"),
+                        row.getTimestamp("accepted_at").toInstant());
+            }
+        }
+    }
+
+    @Override
     public void bind(String itemId, TxStreamBinding binding) {
         Objects.requireNonNull(itemId, "itemId");
         Objects.requireNonNull(binding, "binding");
@@ -228,6 +281,26 @@ public final class RdbmsTxStreamStateStore implements TxStreamStateStore, AutoCl
                 try (ResultSet row = statement.executeQuery()) {
                     if (!row.next()) return Optional.<Long>empty();
                     return Optional.of(row.getLong(1));
+                }
+            }
+        });
+    }
+
+    @Override
+    public Optional<TxStreamStoredProjection> getStoredProjection(String streamId, String itemId) {
+        Objects.requireNonNull(streamId, "streamId");
+        Objects.requireNonNull(itemId, "itemId");
+        return inTransaction("read coherent stream projection", connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "SELECT stream_id, status, execution_id, step_id, projection_lane_name, "
+                            + "transaction_hash, error_code, error_message, updated_at, projection_sequence "
+                            + "FROM txstream_item WHERE item_id = ? AND stream_id = ? AND status IS NOT NULL")) {
+                statement.setString(1, itemId);
+                statement.setString(2, streamId);
+                try (ResultSet row = statement.executeQuery()) {
+                    if (!row.next()) return Optional.empty();
+                    return Optional.of(new TxStreamStoredProjection(decodeProjection(row, itemId),
+                            row.getLong("projection_sequence")));
                 }
             }
         });

--- a/txflow-extensions/txflow-store-rdbms/src/main/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamStateStore.java
+++ b/txflow-extensions/txflow-store-rdbms/src/main/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamStateStore.java
@@ -164,9 +164,13 @@ public final class RdbmsTxStreamStateStore implements TxStreamStateStore, AutoCl
             // losing transaction has rolled back; read the winner in a fresh
             // transaction (essential on PostgreSQL after a unique violation).
             return inTransaction("match concurrently registered stream item", connection -> {
-                TxStreamItemRecord existing = readRegistrationRecord(connection, record.itemId());
-                if (existing == null) throw conflict;
-                return matchRegistration(existing, record);
+                RegistrationRow row = readRegistration(connection, record.itemId());
+                if (row == null) throw conflict;
+                if (!row.registered()) {
+                    updateRegistration(connection, record);
+                    return true;
+                }
+                return matchRegistration(readRegistrationRecord(connection, record.itemId()), record);
             });
         }
     }
@@ -326,6 +330,77 @@ public final class RdbmsTxStreamStateStore implements TxStreamStateStore, AutoCl
                 }
             }
             return result;
+        });
+    }
+
+    @Override
+    public List<String> listRecoveryItemIds(String streamId, String afterItemId, int limit) {
+        if (limit <= 0) throw new IllegalArgumentException("limit must be positive");
+        return inTransaction("page recovery items", connection -> {
+            List<String> result = new ArrayList<>();
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "SELECT item_id FROM txstream_item WHERE stream_id = ? AND terminal = ?"
+                            + (afterItemId == null ? "" : " AND item_id > ?") + " ORDER BY item_id")) {
+                statement.setString(1, streamId);
+                statement.setBoolean(2, false);
+                if (afterItemId != null) statement.setString(3, afterItemId);
+                statement.setMaxRows(limit);
+                try (ResultSet rows = statement.executeQuery()) {
+                    while (rows.next()) result.add(rows.getString(1));
+                }
+            }
+            return result;
+        });
+    }
+
+    @Override
+    public Optional<TxStreamPlannedRecord> findPlanned(String streamId, String itemId) {
+        return inTransaction("find item's planned execution", connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(
+                    "SELECT p.execution_id, p.idempotency_key, p.lane_name, "
+                            + "p.canonical_spending_identity, p.portable_flow, p.metadata_payload "
+                            + "FROM txstream_planned p JOIN txstream_binding b ON b.execution_id = p.execution_id "
+                            + "WHERE p.stream_id = ? AND b.item_id = ?")) {
+                statement.setString(1, streamId);
+                statement.setString(2, itemId);
+                try (ResultSet row = statement.executeQuery()) {
+                    if (!row.next()) return Optional.empty();
+                    TxStreamStoreCodec.PlannedMetadata metadata =
+                            codec.decodePlannedMetadata(readText(row, "metadata_payload"));
+                    return Optional.of(new TxStreamPlannedRecord(streamId, row.getString("execution_id"),
+                            row.getString("idempotency_key"), row.getString("lane_name"),
+                            row.getString("canonical_spending_identity"), readText(row, "portable_flow"),
+                            metadata.bindings(), metadata.secureBindingReferences(),
+                            metadata.secureBindingFingerprints(), metadata.members(),
+                            metadata.templateId(), metadata.templateFingerprint()));
+                }
+            }
+        });
+    }
+
+    @Override
+    public boolean acknowledgeAbandoned(String streamId, String itemId,
+                                        long expectedSequence, String reason, Instant acknowledgedAt) {
+        if (reason == null || reason.isBlank()) throw new IllegalArgumentException("reason is required");
+        return inTransaction("acknowledge abandoned registration", connection -> {
+            try (PreparedStatement statement = connection.prepareStatement(dialect.forUpdate(
+                    "SELECT stream_id, status, execution_id, step_id, projection_lane_name, "
+                            + "transaction_hash, error_code, error_message, updated_at, projection_sequence "
+                            + "FROM txstream_item WHERE stream_id = ? AND item_id = ? AND status IS NOT NULL"))) {
+                statement.setString(1, streamId);
+                statement.setString(2, itemId);
+                try (ResultSet row = statement.executeQuery()) {
+                    if (!row.next() || row.getLong("projection_sequence") != expectedSequence
+                            || !"RECOVERY_REQUIRED".equals(row.getString("status"))
+                            || !"TXSTREAM_ABANDONED".equals(row.getString("error_code"))) return false;
+                    TxStreamItemResult result = decodeProjection(row, itemId).toBuilder()
+                            .status(TxStreamItemStatus.FAILED)
+                            .error(new TxStreamException("TXSTREAM_ABANDONED", "Operator acknowledgement: " + reason))
+                            .updatedAt(Objects.requireNonNull(acknowledgedAt, "acknowledgedAt")).build();
+                    updateProjection(connection, result, Math.addExact(expectedSequence, 1));
+                    return true;
+                }
+            }
         });
     }
 

--- a/txflow-extensions/txflow-store-rdbms/src/main/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamStateStore.java
+++ b/txflow-extensions/txflow-store-rdbms/src/main/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamStateStore.java
@@ -340,10 +340,11 @@ public final class RdbmsTxStreamStateStore implements TxStreamStateStore, AutoCl
             List<String> result = new ArrayList<>();
             try (PreparedStatement statement = connection.prepareStatement(
                     "SELECT item_id FROM txstream_item WHERE stream_id = ? AND terminal = ?"
-                            + (afterItemId == null ? "" : " AND item_id > ?") + " ORDER BY item_id")) {
+                            + " AND (? = TRUE OR item_id > ?) ORDER BY item_id")) {
                 statement.setString(1, streamId);
                 statement.setBoolean(2, false);
-                if (afterItemId != null) statement.setString(3, afterItemId);
+                statement.setBoolean(3, afterItemId == null);
+                statement.setString(4, afterItemId);
                 statement.setMaxRows(limit);
                 try (ResultSet rows = statement.executeQuery()) {
                     while (rows.next()) result.add(rows.getString(1));

--- a/txflow-extensions/txflow-store-rdbms/src/test/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamRedeliveryTest.java
+++ b/txflow-extensions/txflow-store-rdbms/src/test/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamRedeliveryTest.java
@@ -1,0 +1,119 @@
+package com.bloxbean.cardano.client.txflow.store.rdbms;
+
+import com.bloxbean.cardano.client.api.ChainDataSupplier;
+import com.bloxbean.cardano.client.api.ProtocolParamsSupplier;
+import com.bloxbean.cardano.client.api.TransactionProcessor;
+import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.quicktx.Tx;
+import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
+import com.bloxbean.cardano.client.txflow.FlowStep;
+import com.bloxbean.cardano.client.txflow.TxFlow;
+import com.bloxbean.cardano.client.txflow.codec.FlowFormat;
+import com.bloxbean.cardano.client.txflow.codec.FlowSchemaVersion;
+import com.bloxbean.cardano.client.txflow.codec.FlowWriteOptions;
+import com.bloxbean.cardano.client.txflow.codec.TxFlowCodec;
+import com.bloxbean.cardano.client.txflow.exec.FlowEngine;
+import com.bloxbean.cardano.client.txflow.exec.FlowExecutionState;
+import com.bloxbean.cardano.client.txflow.store.FlowExecutionSnapshot;
+import com.bloxbean.cardano.client.txflow.stream.EmitResult;
+import com.bloxbean.cardano.client.txflow.stream.TxFlowStream;
+import com.bloxbean.cardano.client.txflow.stream.TxStreamBinding;
+import com.bloxbean.cardano.client.txflow.stream.TxStreamItemRecord;
+import com.bloxbean.cardano.client.txflow.stream.TxStreamItemResult;
+import com.bloxbean.cardano.client.txflow.stream.TxStreamItemStatus;
+import com.bloxbean.cardano.client.txflow.stream.TxStreamPlannedRecord;
+import com.bloxbean.cardano.client.txflow.stream.WindowPolicy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class RdbmsTxStreamRedeliveryTest {
+    @TempDir
+    Path directory;
+
+    @Test
+    void terminalRedeliveryAttachesAcrossLiveEvictionAndDatabaseReopen() {
+        TransactionProcessor processor = mock(TransactionProcessor.class);
+        for (int pass = 0; pass < 2; pass++) {
+            try (RdbmsFlowExecutionStore executions = RdbmsFlowExecutionStore.builder()
+                    .jdbcUrl(url("engine")).build();
+                 RdbmsTxStreamStateStore items = RdbmsTxStreamStateStore.builder()
+                         .jdbcUrl(url("items")).build();
+                 TxFlowStream stream = TxFlowStream.builder("payouts", engine(executions, processor))
+                         .stateStore(items).window(WindowPolicy.count(100))
+                         .maxRetainedSettledItems(1).open()) {
+                if (pass == 0) {
+                    stream.submit("one", plan());
+                    assertTrue(stream.cancel("one", "cancel before dispatch"));
+                    stream.submit("two", plan());
+                    assertTrue(stream.cancel("two", "cancel before dispatch"));
+                }
+                EmitResult duplicate = stream.trySubmit("one", plan());
+                assertEquals(EmitResult.Status.DUPLICATE_ATTACHED, duplicate.getStatus());
+                assertEquals(TxStreamItemStatus.CANCELLED,
+                        duplicate.getReceipt().awaitSettled(Duration.ofSeconds(1)).getStatus());
+                assertEquals(pass == 0 ? 2 : 0, stream.getStats().acceptedItemCount());
+            }
+        }
+        verifyNoInteractions(processor);
+    }
+
+    @Test
+    void storeOnlyReconciliationUsesRealEngineSnapshotAndPersistsANewerProjection() {
+        TransactionProcessor processor = mock(TransactionProcessor.class);
+        try (RdbmsFlowExecutionStore executions = RdbmsFlowExecutionStore.builder()
+                .jdbcUrl(url("engine")).build();
+             RdbmsTxStreamStateStore items = RdbmsTxStreamStateStore.builder()
+                     .jdbcUrl(url("items")).build();
+             TxFlowStream reader = TxFlowStream.builder("payouts", engine(executions, processor))
+                     .stateStore(items).open()) {
+            Instant now = Instant.now();
+            TxFlow flow = TxFlow.builder("flow").addStep(FlowStep.builder("step").withTxPlan(plan()).build()).build();
+            String portable = TxFlowCodec.standard().write(flow,
+                    FlowWriteOptions.of(FlowFormat.JSON, FlowSchemaVersion.V1ALPHA1));
+            items.registerItem(new TxStreamItemRecord("one", "one", "lane", "fp", now));
+            items.bind("one", new TxStreamBinding("execution", "flow", "step", "lane"));
+            items.persistPlanned(new TxStreamPlannedRecord("payouts", "execution", "one", "lane",
+                    "addr:addr_test1vpqsender", portable, Map.of(), Map.of(), Map.of(),
+                    List.of(new TxStreamPlannedRecord.Member("one", "one", "step", "fp"))));
+            items.projectItem(TxStreamItemResult.builder("payouts", "one", TxStreamItemStatus.RECOVERY_REQUIRED)
+                    .executionId("execution").stepId("step").laneName("lane")
+                    .transactionHash("known-hash").updatedAt(now).build(), 100);
+            executions.createOrGet("namespace", "claim", new FlowExecutionSnapshot("execution", "def", "req",
+                    FlowExecutionState.COMPLETED, 0, 0, 0, now, Map.of()));
+
+            assertEquals(TxStreamItemStatus.CONFIRMED, reader.awaitResolution("one",
+                    Duration.ofSeconds(1), Duration.ofMillis(1)).getStatus());
+            assertEquals("known-hash", items.getItem("payouts", "one").orElseThrow().getTransactionHash());
+            assertEquals(TxStreamItemStatus.CONFIRMED, items.getItem("payouts", "one").orElseThrow().getStatus());
+            assertEquals(101, items.getStoredProjection("payouts", "one").orElseThrow().sourceSequence());
+            verifyNoInteractions(processor);
+        }
+    }
+
+    private FlowEngine engine(RdbmsFlowExecutionStore store, TransactionProcessor processor) {
+        return FlowEngine.builder(mock(UtxoSupplier.class), mock(ProtocolParamsSupplier.class),
+                        processor, mock(ChainDataSupplier.class))
+                .executor(Runnable::run).maintenanceExecutor(Runnable::run).store(store).build();
+    }
+
+    private TxPlan plan() {
+        return TxPlan.from(new Tx().payToAddress("addr_test1vpqreceiver", Amount.ada(2))
+                .from("addr_test1vpqsender"));
+    }
+
+    private String url(String name) {
+        return "jdbc:h2:file:" + directory.resolve(name).toAbsolutePath();
+    }
+}

--- a/txflow-extensions/txflow-store-rdbms/src/test/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamStateStoreTest.java
+++ b/txflow-extensions/txflow-store-rdbms/src/test/java/com/bloxbean/cardano/client/txflow/store/rdbms/RdbmsTxStreamStateStoreTest.java
@@ -11,6 +11,7 @@ import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -19,11 +20,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 /** H2-specific behaviours: builder validation, no-secret persistence, lifecycle, and coexistence. */
 class RdbmsTxStreamStateStoreTest {
@@ -33,6 +39,41 @@ class RdbmsTxStreamStateStoreTest {
     @AfterEach
     void closeStores() {
         stores.forEach(RdbmsTxStreamStateStore::close);
+    }
+
+    @Test
+    void projectionOnlyInsertWinningRegistrationRaceIsRegisteredInFreshTransaction() throws Exception {
+        JdbcDataSource source = new JdbcDataSource();
+        source.setURL("jdbc:h2:mem:projection-race-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+        RdbmsTxStreamStateStore projector = RdbmsTxStreamStateStore.builder()
+                .dataSource(source).schemaManagement(SchemaManagement.MIGRATE).build();
+        stores.add(projector);
+        AtomicBoolean inject = new AtomicBoolean(true);
+        DataSource intercepted = mock(DataSource.class, delegatesTo(source));
+        doAnswer(invocation -> {
+            Connection actual = source.getConnection();
+            Connection connection = mock(Connection.class, delegatesTo(actual));
+            doAnswer(prepare -> {
+                String sql = prepare.getArgument(0);
+                if (sql.startsWith("INSERT INTO txstream_item (item_id") && inject.compareAndSet(true, false)) {
+                    // The registration transaction has already read an absent row.
+                    // A separate connection commits a projection before its INSERT.
+                    projector.projectItem(TxStreamItemResult.builder("payouts", "one", TxStreamItemStatus.ACCEPTED)
+                            .updatedAt(NOW).build(), 7);
+                }
+                return actual.prepareStatement(sql);
+            }).when(connection).prepareStatement(anyString());
+            return connection;
+        }).when(intercepted).getConnection();
+        RdbmsTxStreamStateStore registrar = RdbmsTxStreamStateStore.builder()
+                .dataSource(intercepted).schemaManagement(SchemaManagement.VALIDATE).build();
+        stores.add(registrar);
+        TxStreamItemRecord record = new TxStreamItemRecord("one", "key", "lane", "fp", NOW);
+        assertTrue(registrar.registerOrMatch(record));
+        assertFalse(registrar.registerOrMatch(record));
+        assertEquals(7, registrar.lastProjectionSequence("payouts", "one").orElseThrow());
+        assertEquals(TxStreamItemStatus.ACCEPTED, registrar.getItem("payouts", "one").orElseThrow().getStatus());
+        assertFalse(inject.get(), "the projection-only insert must actually win the race");
     }
 
     @Test

--- a/txflow/adr/0006-txstream-durable-registration-and-hydration.md
+++ b/txflow/adr/0006-txstream-durable-registration-and-hydration.md
@@ -2,6 +2,12 @@
 
 **Status**: Proposed
 
+The conservative preview subset now implemented is recorded in
+[ADR 0007](0007-txstream-durable-redelivery-preview.md). It covers atomic matching,
+coherent projection reads, shared read-only hydration, and explicit intervention
+for incomplete registrations. This broader proposal remains open for aggregate
+versioning, schema scoping, and automatic pre-plan recovery.
+
 **ADR Document Version**: 1.0.0
 
 **Date**: 2026-08-23

--- a/txflow/adr/0007-txstream-durable-redelivery-preview.md
+++ b/txflow/adr/0007-txstream-durable-redelivery-preview.md
@@ -15,6 +15,8 @@ retained registration prevented that replay.
 1. `TxStreamStateStore.registerOrMatch` atomically installs a registration or
    matches its item ID, claim key, lane, and content fingerprint. Acceptance time
    is excluded from equality. Different content throws the existing typed conflict.
+   Changing lane assignment across deployments can conflict even if the payload
+   is unchanged.
    Shipped durable memory stores use one map insertion; H2/PostgreSQL use row locks
    and the database unique constraint. A concurrent insert loser rolls back and
    compares the winner in a fresh transaction. No pre-read decision permits an
@@ -29,11 +31,14 @@ retained registration prevented that replay.
    fallback retries when a separately read watermark changes; stores without
    watermarks retain the previous conservative sequence floor. Custom stores
    should implement the atomic read before claiming concurrent hydration support.
-4. Explicit status reads, `reconcile`, matching redelivery, and the periodic
-   observer share read-only hydration using the same reconstruction function as
-   restart. Hydration never submits, replaces, or regroups a flow. Snapshot truth
-   repairs the projection at a higher sequence; unresolved work settles as
-   `RECOVERY_REQUIRED`. Historical terminal reads do not populate the live map.
+4. Healthy foreign status reads are detached observations: no live-map entry,
+   claim, lifecycle counter, listener event or owner projection write. A missing
+   or running snapshot never establishes recovery authority. Explicit foreign
+   receipt attachment retains a local observation refreshed by `reconcile` or
+   the observer. Stored `RECOVERY_REQUIRED` items may be hydrated using the
+   restart reconstruction function and terminally repaired from engine truth.
+   Hydration never submits, replaces or regroups a flow. Historical terminal
+   reads do not populate the live map.
 5. A registration without a recoverable plan is an explicit intervention case.
    Matching submission returns `REJECTED` / `TXSTREAM_REGISTRATION_INCOMPLETE`
    without creating a receipt or incrementing accepted counters. If an accepting
@@ -42,6 +47,20 @@ retained registration prevented that replay.
    `TXSTREAM_ABANDONED`, retains it in the recovery scan, and reports it in
    `ReattachReport.recoveryRequired()`. It does not repeatedly rewrite the row.
    There is no automatic pruning, tombstoning, or replay of incomplete work.
+   An absent binding alone never permits same-ID reacceptance: a live owner may
+   still have accepted work queued before its write-ahead binding.
+6. Shipped stores resolve individual plans through item bindings. The observer
+   pages nonterminal IDs with a cursor and charges every inspected row against
+   its budget, including live and abandoned rows. Later rows therefore progress
+   across passes. Restart still inventories all unresolved work.
+7. Operator acknowledgement requires stopping/fencing all producers and recovery
+   workers and investigating the abandoned registration's original execution.
+   `getStoredProjection(streamId, itemId)` supplies the `sourceSequence()` passed
+   as `expectedSequence` to `acknowledgeAbandoned`. The operation atomically checks
+   that exact sequence and `RECOVERY_REQUIRED` / `TXSTREAM_ABANDONED` state, marks
+   bookkeeping `FAILED`, and retains registration, binding and hash. A stale or
+   resolved row returns false. This does not prove transaction failure and does
+   not authorize a replacement payment.
 
 ## Scope and upgrade behavior
 
@@ -53,13 +72,21 @@ their streams; stream-scoped registration keys require a separate schema migrati
 Custom stores remain source compatible through default methods. The default
 `registerOrMatch` delegates to `registerItem`, retaining legacy duplicate rejection
 until the adapter explicitly implements matching. Do not infer the new guarantees
-for an unqualified third-party adapter.
+for an unqualified third-party adapter. Targeted lookup and paging have scan-based
+compatibility fallbacks; custom adapters should override them for efficiency.
+Atomic abandoned acknowledgement is unsupported until explicitly implemented.
 
 Existing terminal cancelled/abandoned rows are not rewritten or replayed on
 upgrade. Identical redelivery attaches to their cancelled result. Operators must
 inspect the source journal, registration, persisted plan/binding, and original
 engine claim before deciding how to recover incomplete work. A new business ID is
 not an automatic recovery strategy.
+
+Outside managed ownership, do not repurpose an observer that explicitly attached
+foreign receipts as a recovery owner: those receipts live in its item map and
+`runReattach` skips live IDs, so an absent execution would not be redispatched.
+Use a fresh stream instance for recovery instead. This promotion path is outside
+the supported ownership model.
 
 ## Qualification
 
@@ -78,32 +105,3 @@ not an automatic recovery strategy.
 Full registration/binding/plan aggregate versioning, automatic pre-plan recovery,
 active/active funding coordination, retention/pruning policy, and sustained
 public-network failover qualification remain outside this preview subset.
-
-### Review corrections
-
-Healthy foreign-item reads are observations. They do not install live items or
-advance the owner's projection sequence, even when the engine snapshot is absent.
-Explicit foreign receipt attachment retains a local observation; poll `reconcile`
-or enable the observer to refresh it. Stored recovery-required items may still be
-hydrated and terminally repaired from engine truth. Observation never infers
-recovery authority from a missing snapshot.
-
-The shipped stores resolve a plan through the item's binding. The observer pages
-nonterminal IDs with a cursor and charges every inspected row against its budget,
-including live or abandoned rows. This keeps a pass bounded and lets later rows
-progress; restart still inventories all unresolved work.
-
-After fencing/stopping all producers and recovery workers and investigating an
-abandoned registration, an operator can call
-`store.acknowledgeAbandoned(streamId, itemId, expectedSequence, reason, acknowledgedAt)`.
-It atomically checks the exact stored sequence and RECOVERY_REQUIRED/TXSTREAM_ABANDONED
-state, marks the bookkeeping FAILED, and retains registration, binding, and hash.
-A stale or already-resolved row returns false. This acknowledgement is not proof
-that a transaction failed and is not permission to submit a replacement payment.
-Custom stores must implement this atomic operation explicitly; it is unsupported
-by default. The paging and targeted-lookup SPI methods have compatibility fallbacks.
-
-Registration matching includes the lane name. Changing lane assignment across
-deployments can therefore conflict even when the transaction payload is unchanged.
-No-binding observations do not authorize automatic same-ID reacceptance: another
-owner may still have accepted work queued before its write-ahead binding.

--- a/txflow/adr/0007-txstream-durable-redelivery-preview.md
+++ b/txflow/adr/0007-txstream-durable-redelivery-preview.md
@@ -1,0 +1,80 @@
+# ADR 0007: Durable redelivery and reconciliation for preview
+
+Status: Implemented preview subset of ADR 0006. This does not mark ADR 0006 complete.
+
+## Problem
+
+Retained registrations outlive the stream's live item map. Identical redelivery
+therefore used to conflict after eviction or restart, and explicit reconciliation
+could report a stored item unknown. Restart handling also called accepted work
+without a persisted plan cancelled and recommended redelivery, although its
+retained registration prevented that replay.
+
+## Decisions
+
+1. `TxStreamStateStore.registerOrMatch` atomically installs a registration or
+   matches its item ID, claim key, lane, and content fingerprint. Acceptance time
+   is excluded from equality. Different content throws the existing typed conflict.
+   Shipped durable memory stores use one map insertion; H2/PostgreSQL use row locks
+   and the database unique constraint. A concurrent insert loser rolls back and
+   compares the winner in a fresh transaction. No pre-read decision permits an
+   overwrite. Legacy `registerItem` keeps its reject-duplicates contract.
+2. Matching never plans or starts a new execution. Terminal matches return a
+   settled receipt without adding another acceptance, terminal counter, or live
+   retention entry. Nonterminal matches use the persisted plan and its original
+   execution identity, then reconcile engine truth. A mismatched stored plan is
+   corruption, not permission to rebuild work.
+3. `getStoredProjection` pairs the exact projection with its CAS watermark.
+   Shipped durable stores read one immutable entry or one database row. The legacy
+   fallback retries when a separately read watermark changes; stores without
+   watermarks retain the previous conservative sequence floor. Custom stores
+   should implement the atomic read before claiming concurrent hydration support.
+4. Explicit status reads, `reconcile`, matching redelivery, and the periodic
+   observer share read-only hydration using the same reconstruction function as
+   restart. Hydration never submits, replaces, or regroups a flow. Snapshot truth
+   repairs the projection at a higher sequence; unresolved work settles as
+   `RECOVERY_REQUIRED`. Historical terminal reads do not populate the live map.
+5. A registration without a recoverable plan is an explicit intervention case.
+   Matching submission returns `REJECTED` / `TXSTREAM_REGISTRATION_INCOMPLETE`
+   without creating a receipt or incrementing accepted counters. If an accepting
+   owner is still progressing, redelivery can be retried after it persists the
+   plan. Restart classifies projected incomplete work as `RECOVERY_REQUIRED` /
+   `TXSTREAM_ABANDONED`, retains it in the recovery scan, and reports it in
+   `ReattachReport.recoveryRequired()`. It does not repeatedly rewrite the row.
+   There is no automatic pruning, tombstoning, or replay of incomplete work.
+
+## Scope and upgrade behavior
+
+No database migration is needed: registration fingerprints, projections, and
+watermarks already exist. Item registrations remain keyed by item ID within the
+store. Applications sharing a database must use globally unique item IDs across
+their streams; stream-scoped registration keys require a separate schema migration.
+
+Custom stores remain source compatible through default methods. The default
+`registerOrMatch` delegates to `registerItem`, retaining legacy duplicate rejection
+until the adapter explicitly implements matching. Do not infer the new guarantees
+for an unqualified third-party adapter.
+
+Existing terminal cancelled/abandoned rows are not rewritten or replayed on
+upgrade. Identical redelivery attaches to their cancelled result. Operators must
+inspect the source journal, registration, persisted plan/binding, and original
+engine claim before deciding how to recover incomplete work. A new business ID is
+not an automatic recovery strategy.
+
+## Qualification
+
+- Shared H2, PostgreSQL, and durable-memory contracts: concurrent matching,
+  projection-only registration races, different-content conflicts, timestamp
+  exclusion, and preservation of projection/watermark.
+- Stream tests: redelivery after eviction and restart, no counter inflation or
+  extra engine start, remote uncertainty hydration and repair, and incomplete
+  registration refusal.
+- H2 runtime tests: actual TxFlowStream with both relational stores, attachment
+  after database reopen, and store-only repair from an engine snapshot with a
+  dominating persisted projection sequence.
+- Existing ownership, shared-flow, template, reconciliation, restart, and abrupt
+  H2 process-termination suites remain applicable.
+
+Full registration/binding/plan aggregate versioning, automatic pre-plan recovery,
+active/active funding coordination, retention/pruning policy, and sustained
+public-network failover qualification remain outside this preview subset.

--- a/txflow/adr/0007-txstream-durable-redelivery-preview.md
+++ b/txflow/adr/0007-txstream-durable-redelivery-preview.md
@@ -78,3 +78,32 @@ not an automatic recovery strategy.
 Full registration/binding/plan aggregate versioning, automatic pre-plan recovery,
 active/active funding coordination, retention/pruning policy, and sustained
 public-network failover qualification remain outside this preview subset.
+
+### Review corrections
+
+Healthy foreign-item reads are observations. They do not install live items or
+advance the owner's projection sequence, even when the engine snapshot is absent.
+Explicit foreign receipt attachment retains a local observation; poll `reconcile`
+or enable the observer to refresh it. Stored recovery-required items may still be
+hydrated and terminally repaired from engine truth. Observation never infers
+recovery authority from a missing snapshot.
+
+The shipped stores resolve a plan through the item's binding. The observer pages
+nonterminal IDs with a cursor and charges every inspected row against its budget,
+including live or abandoned rows. This keeps a pass bounded and lets later rows
+progress; restart still inventories all unresolved work.
+
+After fencing/stopping all producers and recovery workers and investigating an
+abandoned registration, an operator can call
+`store.acknowledgeAbandoned(streamId, itemId, expectedSequence, reason, acknowledgedAt)`.
+It atomically checks the exact stored sequence and RECOVERY_REQUIRED/TXSTREAM_ABANDONED
+state, marks the bookkeeping FAILED, and retains registration, binding, and hash.
+A stale or already-resolved row returns false. This acknowledgement is not proof
+that a transaction failed and is not permission to submit a replacement payment.
+Custom stores must implement this atomic operation explicitly; it is unsupported
+by default. The paging and targeted-lookup SPI methods have compatibility fallbacks.
+
+Registration matching includes the lane name. Changing lane assignment across
+deployments can therefore conflict even when the transaction payload is unchanged.
+No-binding observations do not authorize automatic same-ID reacceptance: another
+owner may still have accepted work queued before its write-ahead binding.

--- a/txflow/docs/TXSTREAM_GETTING_STARTED.md
+++ b/txflow/docs/TXSTREAM_GETTING_STARTED.md
@@ -164,11 +164,10 @@ can produce a second payment.
   idempotency or UTxO assumptions.
 - Graceful `close()` drains accepted work without a default timeout.
   `close(Duration)` bounds that wait; `abort(...)` is the explicit cancellation path.
-- Durable production guidance is deliberately incomplete until
-  [ADR 0006](../adr/0006-txstream-durable-registration-and-hydration.md) ships its
-  registration-matching and store-only hydration requirements. Do not infer restart
-  safety from the in-memory beginner profile. The current durable boundaries are
-  described in [Durable runtime](DURABLE_RUNTIME.md).
+- Durable registration matching and store-only hydration are available in the shipped
+  stores; accepted-but-unplanned work still requires explicit recovery. See
+  [ADR 0007](../adr/0007-txstream-durable-redelivery-preview.md) for the implemented
+  preview contract. Do not infer restart safety from the in-memory beginner profile.
 
 ## Preview operating limits
 

--- a/txflow/docs/TXSTREAM_PREVIEW_READINESS.md
+++ b/txflow/docs/TXSTREAM_PREVIEW_READINESS.md
@@ -87,3 +87,18 @@ value both equalled 73,280,000 lovelace. The exact reconciliation output is save
 
 This was a short smoke run with chaos disabled. It does not establish long-term
 heap stability, public-network throughput, or failover-under-load qualification.
+
+
+## Follow-up review qualification
+
+After the reader/writer projection race was reproduced, the review corrections
+were validated on Java 21: 1,070 TxFlow unit tests, 118 RDBMS unit tests and
+76 H2/PostgreSQL integration tests passed, with no failures or skips. Java 17
+TxFlow/RDBMS unit and integration suites also passed during the correction.
+
+New regressions cover RUNNING and absent snapshots during foreign reads and
+receipt attachment, preserving the owner's later confirmation; targeted plan
+lookup; bounded scanning past abandoned rows; exact-version and concurrent
+operator acknowledgement; and a projection-only insert winning the registration
+race. The dispatch regressions cover progress on another lane under maxInFlight=1,
+FAILED/CANCELLED repair wakeup and stale visibility timers.

--- a/txflow/docs/TXSTREAM_PREVIEW_READINESS.md
+++ b/txflow/docs/TXSTREAM_PREVIEW_READINESS.md
@@ -41,10 +41,12 @@ The RDBMS unit suite also passed on Java 21. The added regressions exercise:
 
 ## Separate durability qualification
 
-This preview does not yet promise transparent queue recovery across every crash
-boundary. ADR 0006 tracks atomic registration matching, shared hydration, and the
-policy for registrations without persisted plans. A retained database row does
-not by itself imply successful attach-on-redelivery.
+The durable follow-up implements atomic registration matching and shared read-only
+hydration for shipped stores. H2/PostgreSQL contract tests exercise concurrent
+identical registration; runtime tests cover eviction, restart, and store-only repair.
+Registrations without a persisted plan remain recovery-required and are never
+silently replanned. See ADR 0007 for the implemented subset and upgrade behavior.
+Transparent queue recovery across every crash boundary remains outside this preview.
 
 Before promoting durable operation beyond experimental support, require H2 and
 PostgreSQL contract tests, restart/redelivery beyond live retention, registration
@@ -69,3 +71,19 @@ caller may retry that work under new IDs; this does not apply to RECOVERY_REQUIR
 Custom backend-based engines used by TxStream enable visibility checks by default;
 custom output services must support historical output lookup or explicitly disable
 `backendVisibilityChecks`. Ordinary engine executions do not invoke this stream gate.
+## Combined-branch qualification, 2026-09-06
+
+Java 21: 1,064 TxFlow unit tests, 114 RDBMS unit tests, 73 RDBMS integration
+tests (including PostgreSQL and abrupt H2 restart), and the soak reconciler unit
+test passed with no skips. Java 17 TxFlow/RDBMS unit suites and the RDBMS
+integration suite also passed during this change.
+
+A two-minute local DevKit smoke run used two lanes, `perItem()`, 0.5 items/second,
+four recipients, and `--utxo-gate=false`. The SDK indexing check remained enabled.
+All 60 submitted items confirmed; there were no failures, cancellations, unresolved
+items, orphan leases, or duplicate/missing payments. Expected and actual payout
+value both equalled 73,280,000 lovelace. The exact reconciliation output is saved in
+[the smoke report](qualification/2026-09-06-txstream-devkit-smoke.txt).
+
+This was a short smoke run with chaos disabled. It does not establish long-term
+heap stability, public-network throughput, or failover-under-load qualification.

--- a/txflow/docs/qualification/2026-09-06-txstream-devkit-smoke.txt
+++ b/txflow/docs/qualification/2026-09-06-txstream-devkit-smoke.txt
@@ -1,0 +1,47 @@
+
+==============================================================================
+  SOAK RECONCILIATION
+==============================================================================
+  planned duration     2m
+  lanes                2
+  chaos                disabled
+
+  submitted (journal)  60
+  confirmed            60
+  failed               0
+  cancelled            0
+  recovery required    0
+  non-terminal         0
+  never registered     0   
+
+  -- value conservation (the double-pay check) --
+  expected total       73280000 lovelace
+  actual total         73280000 lovelace
+  transactions checked 60 on chain
+
+  -- resources --
+  heap trend           run too short to trend (needs 15m+)
+  throughput           30.0/min  (first third 0.0 -> last third 0.0)
+  orphan leases        0
+    txflow_event                            660 rows
+    txflow_execution                         60 rows
+    txflow_execution_lease                    0 rows
+    txflow_idempotency                       60 rows
+    txflow_lease_epoch                        1 rows
+    txflow_resource_lease                     0 rows
+    txflow_schema_history                     1 rows
+    txstream_batch                           60 rows
+    txstream_binding                         60 rows
+    txstream_bootstrap                        0 rows
+    txstream_item                            60 rows
+    txstream_ownership                        0 rows
+    txstream_planned                         60 rows
+    txstream_schema_history                   1 rows
+
+  LOST / NOT ON CHAIN    none
+  DOUBLE PAID            none
+  UNDER PAID             none
+  PAID BUT NOT REPORTED CONFIRMED none
+==============================================================================
+  RESULT: CLEAN — nothing lost, nothing paid twice, nothing left behind
+==============================================================================

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/EngineTxFlowStream.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/EngineTxFlowStream.java
@@ -2354,8 +2354,9 @@ final class EngineTxFlowStream implements TxFlowStream {
             if (budget == 0) {
                 return 0; // cap reached; the rest wait for the next fire
             }
-            if (!state.foreignObservation
-                    && state.projection.current().getStatus() != TxStreamItemStatus.RECOVERY_REQUIRED) {
+            TxStreamItemStatus status = state.projection.current().getStatus();
+            if (ItemProjection.isFinal(status)
+                    || (!state.foreignObservation && status != TxStreamItemStatus.RECOVERY_REQUIRED)) {
                 continue;
             }
             reconcileObserverItem(state);

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/EngineTxFlowStream.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/EngineTxFlowStream.java
@@ -1465,7 +1465,7 @@ final class EngineTxFlowStream implements TxFlowStream {
             // Do not repopulate retention/counters with historical terminal work.
             return Acceptance.attached(settled.receipt);
         }
-        MemberRef ref = buildPlannedIndex().get(item.getItemId());
+        MemberRef ref = findPlannedMember(item.getItemId());
         if (ref == null) {
             throw new TxStreamException("TXSTREAM_REGISTRATION_INCOMPLETE",
                     "Item '" + item.getItemId() + "' is already registered but has no stored terminal "
@@ -1477,7 +1477,7 @@ final class EngineTxFlowStream implements TxFlowStream {
             throw new TxStreamException("TXSTREAM_STORE_CODEC_CORRUPT",
                     "Stored plan does not match the authoritative item registration: " + item.getItemId());
         }
-        ItemState hydrated = hydrateForRead(item.getItemId(), ref);
+        ItemState hydrated = hydrateForRead(item.getItemId(), ref, true);
         if (!prepared.fingerprint.equals(hydrated.fingerprint)) {
             throw new TxStreamException("TXSTREAM_STORE_CODEC_CORRUPT",
                     "Hydrated item differs from its registration: " + item.getItemId());
@@ -2354,7 +2354,8 @@ final class EngineTxFlowStream implements TxFlowStream {
             if (budget == 0) {
                 return 0; // cap reached; the rest wait for the next fire
             }
-            if (state.projection.current().getStatus() != TxStreamItemStatus.RECOVERY_REQUIRED) {
+            if (!state.foreignObservation
+                    && state.projection.current().getStatus() != TxStreamItemStatus.RECOVERY_REQUIRED) {
                 continue;
             }
             reconcileObserverItem(state);
@@ -2369,45 +2370,36 @@ final class EngineTxFlowStream implements TxFlowStream {
      * up to the remaining budget. A no-op on a non-durable stream. Returns the
      * budget left.
      */
+    private String recoveryCursor;
+
     private int reconcileDurableAbsentPhase(int budget) {
         if (budget == 0 || !stateStore.isDurable()) {
             return budget;
         }
-        List<String> nonTerminal;
+        List<String> candidates;
         try {
-            nonTerminal = stateStore.listNonTerminalItemIds(streamId);
-        } catch (RuntimeException listFailure) {
-            log.warn("TxFlowStream[{}] reconciliation could not enumerate durable non-terminal"
-                    + " items", streamId, listFailure);
+            candidates = stateStore.listRecoveryItemIds(streamId, recoveryCursor, budget);
+        } catch (RuntimeException failure) {
+            log.warn("TxFlowStream[{}] recovery page read failed", streamId, failure);
             return budget;
         }
-        Map<String, MemberRef> plannedIndex = null; // built lazily on first durable candidate
-        for (String itemId : nonTerminal) {
-            if (budget == 0) {
-                return 0;
-            }
-            if (items.containsKey(itemId)) {
-                continue; // already handled by the live pass (or being handled live)
-            }
-            Optional<TxStreamItemResult> stored;
+        if (candidates.isEmpty()) {
+            recoveryCursor = null;
+            return budget;
+        }
+        for (String itemId : candidates) {
+            if (budget == 0) break;
+            budget--;
+            recoveryCursor = itemId;
+            if (items.containsKey(itemId)) continue;
             try {
-                stored = stateStore.getItem(streamId, itemId);
-            } catch (RuntimeException readFailure) {
-                log.warn("TxFlowStream[{}] reconciliation store read failed for item '{}'",
-                        streamId, itemId, readFailure);
-                continue;
-            }
-            if (stored.isEmpty()
-                    || stored.get().getStatus() != TxStreamItemStatus.RECOVERY_REQUIRED) {
-                // The observer only push-repairs RECOVERY_REQUIRED items; PLANNED/
-                // SUBMITTED durable rows are covered by live watching / re-attach.
-                continue;
-            }
-            if (plannedIndex == null) {
-                plannedIndex = buildPlannedIndex();
-            }
-            if (reconcileDurableAbsentItem(itemId, plannedIndex)) {
-                budget--;
+                Optional<TxStreamItemResult> stored = stateStore.getItem(streamId, itemId);
+                if (stored.isPresent() && stored.get().getStatus() == TxStreamItemStatus.RECOVERY_REQUIRED) {
+                    MemberRef ref = findPlannedMember(itemId);
+                    if (ref != null) hydrateForRead(itemId, ref);
+                }
+            } catch (RuntimeException failure) {
+                log.warn("TxFlowStream[{}] recovery read failed for '{}'", streamId, itemId, failure);
             }
         }
         return budget;
@@ -2428,71 +2420,37 @@ final class EngineTxFlowStream implements TxFlowStream {
         }
     }
 
-    /**
-     * Reconstructs a durable RECOVERY_REQUIRED item that is not in this live map
-     * from its persisted plan (exactly as re-attach does) and push-repairs it.
-     * Reads-and-repairs only: it publishes the reconstructed item so a later
-     * pass and {@link #getItemStatus(String)} find it, but never enqueues it for
-     * dispatch. Returns whether it was reconstructed and reconciled (so it
-     * counts against the per-fire cap); a missing plan or a race with a live
-     * insert returns {@code false}.
-     */
-    private boolean reconcileDurableAbsentItem(String itemId, Map<String, MemberRef> index) {
-        MemberRef ref = index.get(itemId);
-        if (ref == null) {
-            // No planned record to reconstruct from — not reconcilable by the
-            // observer; re-attach's ghost reaper handles truly abandoned rows.
-            return false;
-        }
-        try {
-            if (items.containsKey(itemId)) return false;
-            hydrateForRead(itemId, ref);
-        } catch (RuntimeException reconstructFailure) {
-            log.warn("TxFlowStream[{}] reconciliation could not reconstruct durable item '{}'",
-                    streamId, itemId, reconstructFailure);
-            return false;
-        }
-        return true;
+    /** Foreign observations never infer uncertainty from a missing or running snapshot. */
+    private ItemState hydrateForRead(String itemId, MemberRef ref) {
+        return hydrateForRead(itemId, ref, false);
     }
 
-    /** Shared read-only hydration path for redelivery, explicit reads, and the observer. */
-    private ItemState hydrateForRead(String itemId, MemberRef ref) {
+    private ItemState hydrateForRead(String itemId, MemberRef ref, boolean attachReceipt) {
         synchronized (acceptanceLock(itemId)) {
             ItemState existing = items.get(itemId);
             if (existing != null) return existing;
             ItemState state = reconstructItemState(ref.record, ref.member, ref.shared);
-            ItemState raced = items.putIfAbsent(itemId, state);
-            if (raced != null) return raced;
-            registerReattachedClaim(state);
-            if (ItemProjection.isFinal(state.projection.current().getStatus())) {
-                noteSettledForRetention(state);
-                return state;
+            state.foreignObservation = state.projection.current().getStatus()
+                    != TxStreamItemStatus.RECOVERY_REQUIRED;
+            // Healthy foreign reads remain detached: no claims, gauges or live-map entries.
+            // Explicit receipt attachment is retained for subsequent observer/poll updates.
+            if (!state.foreignObservation || attachReceipt) {
+                ItemState raced = items.putIfAbsent(itemId, state);
+                if (raced != null) return raced;
+                registerReattachedClaim(state);
             }
             reconcileFromSnapshot(state);
-            if (!ItemProjection.settles(state.projection.current().getStatus())) {
-                project(state, TxStreamItemStatus.RECOVERY_REQUIRED,
-                        builder -> builder.error(new TxStreamException("TXSTREAM_REATTACH_UNCONFIRMED",
-                                "Stored execution has no conclusive outcome; reconcile its original identity")),
-                        true);
-            }
             return state;
         }
     }
 
-    /**
-     * Builds an itemId → (planned record, member, shared) index from the durable
-     * store's planned records, so a durable-absent recovery item can be
-     * reconstructed. Built lazily, at most once per pass.
-     */
-    private Map<String, MemberRef> buildPlannedIndex() {
-        Map<String, MemberRef> index = new HashMap<>();
-        for (TxStreamPlannedRecord record : stateStore.listPlanned(streamId)) {
-            boolean shared = record.members().size() > 1;
-            for (TxStreamPlannedRecord.Member member : record.members()) {
-                index.putIfAbsent(member.itemId(), new MemberRef(record, member, shared));
-            }
-        }
-        return index;
+    private MemberRef findPlannedMember(String itemId) {
+        Optional<TxStreamPlannedRecord> planned = stateStore.findPlanned(streamId, itemId);
+        if (planned.isEmpty()) return null;
+        TxStreamPlannedRecord record = planned.get();
+        return record.members().stream().filter(member -> member.itemId().equals(itemId))
+                .findFirst().map(member -> new MemberRef(record, member, record.members().size() > 1))
+                .orElse(null);
     }
 
     // ------------------------------------------------------------------
@@ -4422,6 +4380,13 @@ final class EngineTxFlowStream implements TxFlowStream {
         ItemProjection.Applied applied = state.projection.advance(
                 target, customize, clock.instant(), authoritative);
         if (applied == null) return null;
+        if (state.foreignObservation) {
+            if (ItemProjection.settles(target)) state.projection.completePromise(applied.result());
+            if (ItemProjection.isFinal(target) && items.get(state.item.getItemId()) == state) {
+                noteSettledForRetention(state);
+            }
+            return applied.result();
+        }
         clearResolvedVisibility(state, target);
         recordTransition(applied.previous(), target);
         safeStoreProject(applied);
@@ -4707,7 +4672,7 @@ final class EngineTxFlowStream implements TxFlowStream {
         }
         projectLiveSubmitted(state);
         TxStreamItemResult current = state.projection.current();
-        if (current.getStatus() == TxStreamItemStatus.RECOVERY_REQUIRED) {
+        if (state.foreignObservation || current.getStatus() == TxStreamItemStatus.RECOVERY_REQUIRED) {
             return Optional.of(reconcileFromSnapshot(state));
         }
         return Optional.of(current);
@@ -4727,7 +4692,7 @@ final class EngineTxFlowStream implements TxFlowStream {
         Optional<TxStreamItemResult> stored = stateStore.getItem(streamId, itemId);
         if (stored.isPresent() && ItemProjection.isFinal(stored.get().getStatus())) return stored;
         if (!stateStore.isDurable()) return stored;
-        MemberRef ref = buildPlannedIndex().get(itemId);
+        MemberRef ref = findPlannedMember(itemId);
         return ref == null ? stored : Optional.of(hydrateForRead(itemId, ref).projection.current());
     }
 
@@ -4790,6 +4755,10 @@ final class EngineTxFlowStream implements TxFlowStream {
      * emitting the repair to the event listener.
      */
     private TxStreamItemResult reconcileFromSnapshot(ItemState state) {
+        if (state.foreignObservation) {
+            stateStore.getItem(streamId, state.item.getItemId()).ifPresent(stored ->
+                    project(state, stored.getStatus(), ignored -> stored.toBuilder(), true));
+        }
         TxStreamItemResult current = state.projection.current();
         if (ItemProjection.isFinal(current.getStatus()) || state.executionId == null) {
             return current;
@@ -5196,6 +5165,7 @@ final class EngineTxFlowStream implements TxFlowStream {
          * result. Never {@code true} together with {@code sharedExecution}.
          */
         volatile boolean wholeFlow;
+        boolean foreignObservation;
         volatile ExecutionState execution;
         volatile EngineGateway.ExecutionHandle handle;
         /**

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/EngineTxFlowStream.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/EngineTxFlowStream.java
@@ -1392,10 +1392,11 @@ final class EngineTxFlowStream implements TxFlowStream {
                 state = ItemState.pending(this, item.withAcceptedStep(prepared.enforcedStep), prepared,
                         inlineIdentity() || prepared.isTemplate());
                 state.wholeFlow = prepared.isTemplate();
+                boolean registered;
                 try {
                     // Authoritative registration precedes receipt publication:
                     // a failed write is a rejection, never accepted work.
-                    stateStore.registerItem(new TxStreamItemRecord(item.getItemId(),
+                    registered = stateStore.registerOrMatch(new TxStreamItemRecord(item.getItemId(),
                             prepared.claimKey, prepared.lane.laneName(), prepared.fingerprint,
                             clock.instant()));
                 } catch (TxStreamDuplicateItemException duplicate) {
@@ -1407,6 +1408,14 @@ final class EngineTxFlowStream implements TxFlowStream {
                             "TXSTREAM_REGISTRATION_FAILED",
                             "Authoritative item registration failed for '"
                                     + item.getItemId() + "'", registrationFailure));
+                }
+                if (!registered) {
+                    itemIdByClaimKey.remove(prepared.claimKey, item.getItemId());
+                    try {
+                        return attachStored(item, prepared);
+                    } catch (TxStreamException unavailable) {
+                        return Acceptance.rejected(unavailable);
+                    }
                 }
                 ItemState raced = items.putIfAbsent(item.getItemId(), state);
                 if (raced != null) {
@@ -1444,6 +1453,36 @@ final class EngineTxFlowStream implements TxFlowStream {
 
     private void notifyRejected(TxWorkItem item, TxStreamException rejection) {
         safeListener(() -> listener.onItemRejected(item.getItemId(), rejection));
+    }
+
+    /** Matching a durable registration never creates a new execution or acceptance. */
+    private Acceptance attachStored(TxWorkItem item, PreparedItem prepared) {
+        Optional<TxStreamStoredProjection> stored = stateStore.getStoredProjection(streamId, item.getItemId());
+        if (stored.isPresent() && ItemProjection.isFinal(stored.get().result().getStatus())) {
+            ItemState settled = ItemState.reattached(this, item.withAcceptedStep(prepared.enforcedStep),
+                    prepared.claimKey, prepared.fingerprint, prepared.lane,
+                    stored.get().result(), stored.get().sourceSequence());
+            // Do not repopulate retention/counters with historical terminal work.
+            return Acceptance.attached(settled.receipt);
+        }
+        MemberRef ref = buildPlannedIndex().get(item.getItemId());
+        if (ref == null) {
+            throw new TxStreamException("TXSTREAM_REGISTRATION_INCOMPLETE",
+                    "Item '" + item.getItemId() + "' is already registered but has no stored terminal "
+                            + "outcome or recoverable plan; wait for the accepting owner or investigate "
+                            + "the incomplete registration. No replacement execution was started");
+        }
+        if (!prepared.fingerprint.equals(ref.member.fingerprint())
+                || !prepared.claimKey.equals(ref.member.idempotencyKey())) {
+            throw new TxStreamException("TXSTREAM_STORE_CODEC_CORRUPT",
+                    "Stored plan does not match the authoritative item registration: " + item.getItemId());
+        }
+        ItemState hydrated = hydrateForRead(item.getItemId(), ref);
+        if (!prepared.fingerprint.equals(hydrated.fingerprint)) {
+            throw new TxStreamException("TXSTREAM_STORE_CODEC_CORRUPT",
+                    "Hydrated item differs from its registration: " + item.getItemId());
+        }
+        return Acceptance.attached(hydrated.receipt);
     }
 
     private Object acceptanceLock(String itemId) {
@@ -2405,20 +2444,39 @@ final class EngineTxFlowStream implements TxFlowStream {
             // observer; re-attach's ghost reaper handles truly abandoned rows.
             return false;
         }
-        ItemState state;
         try {
-            state = reconstructItemState(ref.record, ref.member, ref.shared);
+            if (items.containsKey(itemId)) return false;
+            hydrateForRead(itemId, ref);
         } catch (RuntimeException reconstructFailure) {
             log.warn("TxFlowStream[{}] reconciliation could not reconstruct durable item '{}'",
                     streamId, itemId, reconstructFailure);
             return false;
         }
-        if (items.putIfAbsent(itemId, state) != null) {
-            return false; // raced a live insert; the live pass owns it now
-        }
-        registerReattachedClaim(state);
-        reconcileObserverItem(state);
         return true;
+    }
+
+    /** Shared read-only hydration path for redelivery, explicit reads, and the observer. */
+    private ItemState hydrateForRead(String itemId, MemberRef ref) {
+        synchronized (acceptanceLock(itemId)) {
+            ItemState existing = items.get(itemId);
+            if (existing != null) return existing;
+            ItemState state = reconstructItemState(ref.record, ref.member, ref.shared);
+            ItemState raced = items.putIfAbsent(itemId, state);
+            if (raced != null) return raced;
+            registerReattachedClaim(state);
+            if (ItemProjection.isFinal(state.projection.current().getStatus())) {
+                noteSettledForRetention(state);
+                return state;
+            }
+            reconcileFromSnapshot(state);
+            if (!ItemProjection.settles(state.projection.current().getStatus())) {
+                project(state, TxStreamItemStatus.RECOVERY_REQUIRED,
+                        builder -> builder.error(new TxStreamException("TXSTREAM_REATTACH_UNCONFIRMED",
+                                "Stored execution has no conclusive outcome; reconcile its original identity")),
+                        true);
+            }
+            return state;
+        }
     }
 
     /**
@@ -3568,7 +3626,7 @@ final class EngineTxFlowStream implements TxFlowStream {
                         streamId, record.executionId(), recordFailure);
             }
         }
-        reapAbandonedGhosts(nonTerminal, plannedItemIds);
+        recoveryRequired += reapAbandonedGhosts(nonTerminal, plannedItemIds);
         ReattachReport report = new ReattachReport(reattached, redispatched, recoveryRequired,
                 reattachedItemIds);
         log.info("TxFlowStream[{}] re-attach recovered {} item(s): {} re-attached, {} re-dispatched,"
@@ -3578,28 +3636,29 @@ final class EngineTxFlowStream implements TxFlowStream {
     }
 
     /**
-     * Terminally settles the non-terminal store rows that no planned record and
-     * no resolvable engine execution can ever resolve — an item registered and
-     * projected {@code ACCEPTED} before the crash but never bound (so it has no
-     * planned record to re-dispatch and never reached the engine). Left
-     * untouched they would be returned by {@link TxStreamStateStore#listNonTerminalItemIds}
-     * on every restart, growing the re-attach scan without bound (BUG-4). Each is
-     * settled {@code CANCELLED} typed {@code TXSTREAM_ABANDONED} in the store —
-     * a documented bounded loss; the answer for such work is idempotent source
-     * redelivery. Rows that DO have a planned record (handled by the record loop,
-     * including BUG-1's terminal repair) or a present engine snapshot (still
-     * resolvable) are never touched.
+     * Classifies incomplete accepted registrations without claiming cancellation
+     * or silently replaying source content. A missing persisted plan does not
+     * provide enough information to reconstruct a window's identity. Retain
+     * RECOVERY_REQUIRED / TXSTREAM_ABANDONED for explicit operator recovery;
+     * subsequent restarts report it without advancing its projection sequence.
      */
-    private void reapAbandonedGhosts(Set<String> nonTerminal, Set<String> plannedItemIds) {
+    private int reapAbandonedGhosts(Set<String> nonTerminal, Set<String> plannedItemIds) {
+        int incomplete = 0;
         for (String itemId : nonTerminal) {
             if (plannedItemIds.contains(itemId) || items.containsKey(itemId)) {
                 continue;
             }
-            Optional<TxStreamItemResult> stored = stateStore.getItem(streamId, itemId);
-            if (stored.isEmpty() || ItemProjection.isFinal(stored.get().getStatus())) {
+            Optional<TxStreamStoredProjection> stored = stateStore.getStoredProjection(streamId, itemId);
+            if (stored.isEmpty() || ItemProjection.isFinal(stored.get().result().getStatus())) {
                 continue;
             }
-            TxStreamItemResult prior = stored.get();
+            TxStreamItemResult prior = stored.get().result();
+            if (prior.getStatus() == TxStreamItemStatus.RECOVERY_REQUIRED
+                    && prior.getError() instanceof TxStreamException error
+                    && "TXSTREAM_ABANDONED".equals(error.getCode())) {
+                incomplete++;
+                continue;
+            }
             // A stored execution id whose snapshot is present is still resolvable
             // — leave it for an operator reconcile rather than abandoning it.
             String executionId = prior.getExecutionId();
@@ -3614,24 +3673,26 @@ final class EngineTxFlowStream implements TxFlowStream {
                     continue; // uncertain: do not abandon
                 }
             }
-            long sequence = stateStore.lastProjectionSequence(streamId, itemId)
-                    .orElse(REATTACH_SEQUENCE_FLOOR);
+            long sequence = stored.get().sourceSequence();
             TxStreamException abandoned = new TxStreamException("TXSTREAM_ABANDONED",
                     "Item '" + itemId + "' was accepted before restart but never bound to an"
                             + " execution and has no persisted plan to re-dispatch; it is"
-                            + " abandoned — redeliver it idempotently to run it");
-            TxStreamItemResult cancelled = prior.toBuilder()
-                    .status(TxStreamItemStatus.CANCELLED)
+                            + " incomplete and requires explicit recovery. Redelivery cannot "
+                            + "safely reconstruct the original execution; do not submit a replacement ID");
+            TxStreamItemResult incompleteResult = prior.toBuilder()
+                    .status(TxStreamItemStatus.RECOVERY_REQUIRED)
                     .error(abandoned)
                     .updatedAt(clock.instant())
                     .build();
             try {
-                stateStore.projectItem(cancelled, sequence + 1);
+                stateStore.projectItem(incompleteResult, sequence + 1);
+                incomplete++;
             } catch (RuntimeException reapFailure) {
                 log.warn("TxFlowStream[{}] abandoned-ghost reap failed for '{}'",
                         streamId, itemId, reapFailure);
             }
         }
+        return incomplete;
     }
 
     /**
@@ -3904,7 +3965,8 @@ final class EngineTxFlowStream implements TxFlowStream {
     private ItemState reconstructItemState(TxStreamPlannedRecord record,
                                            TxStreamPlannedRecord.Member member, boolean shared) {
         TxWorkItem item = reconstructWorkItem(record, member);
-        TxStreamItemResult seed = stateStore.getItem(streamId, member.itemId())
+        Optional<TxStreamStoredProjection> stored = stateStore.getStoredProjection(streamId, member.itemId());
+        TxStreamItemResult seed = stored.map(TxStreamStoredProjection::result)
                 .orElseGet(() -> TxStreamItemResult
                         .builder(streamId, member.itemId(), TxStreamItemStatus.PLANNED)
                         .executionId(record.executionId())
@@ -3916,7 +3978,7 @@ final class EngineTxFlowStream implements TxFlowStream {
         // sequence so the first authoritative advance writes at storedSeq+1 and
         // wins the store CAS; without this the terminal repair is dropped as
         // stale and the item is re-attached on every restart forever.
-        long storedSequence = stateStore.lastProjectionSequence(streamId, member.itemId())
+        long storedSequence = stored.map(TxStreamStoredProjection::sourceSequence)
                 .orElse(REATTACH_SEQUENCE_FLOOR);
         ItemState state = ItemState.reattached(this, item, member.idempotencyKey(),
                 member.fingerprint(), reattachLane(record), seed, storedSequence);
@@ -4641,7 +4703,7 @@ final class EngineTxFlowStream implements TxFlowStream {
     public Optional<TxStreamItemResult> getItemStatus(String itemId) {
         ItemState state = items.get(itemId);
         if (state == null) {
-            return stateStore.getItem(streamId, itemId);
+            return reconcileStored(itemId);
         }
         projectLiveSubmitted(state);
         TxStreamItemResult current = state.projection.current();
@@ -4655,10 +4717,18 @@ final class EngineTxFlowStream implements TxFlowStream {
     public Optional<TxStreamItemResult> reconcile(String itemId) {
         ItemState state = items.get(itemId);
         if (state == null) {
-            return Optional.empty();
+            return reconcileStored(itemId);
         }
         projectLiveSubmitted(state);
         return Optional.of(reconcileFromSnapshot(state));
+    }
+
+    private Optional<TxStreamItemResult> reconcileStored(String itemId) {
+        Optional<TxStreamItemResult> stored = stateStore.getItem(streamId, itemId);
+        if (stored.isPresent() && ItemProjection.isFinal(stored.get().getStatus())) return stored;
+        if (!stateStore.isDurable()) return stored;
+        MemberRef ref = buildPlannedIndex().get(itemId);
+        return ref == null ? stored : Optional.of(hydrateForRead(itemId, ref).projection.current());
     }
 
     /**

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/InMemoryDurableTxStreamStore.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/InMemoryDurableTxStreamStore.java
@@ -213,6 +213,35 @@ public final class InMemoryDurableTxStreamStore implements TxStreamStateStore {
     }
 
     @Override
+    public Optional<TxStreamPlannedRecord> findPlanned(String streamId, String itemId) {
+        TxStreamBinding binding = bindings.get(itemId);
+        if (binding == null) return Optional.empty();
+        TxStreamPlannedRecord record = planned.get(binding.executionId());
+        return record != null && record.streamId().equals(streamId)
+                ? Optional.of(record) : Optional.empty();
+    }
+
+    @Override
+    public boolean acknowledgeAbandoned(String streamId, String itemId,
+                                        long expectedSequence, String reason, Instant acknowledgedAt) {
+        if (reason == null || reason.isBlank()) throw new IllegalArgumentException("reason is required");
+        boolean[] applied = new boolean[1];
+        projections.computeIfPresent(itemId, (ignored, entry) -> {
+            TxStreamItemResult result = entry.result();
+            if (entry.sequence() != expectedSequence || !result.getStreamId().equals(streamId)
+                    || result.getStatus() != TxStreamItemStatus.RECOVERY_REQUIRED
+                    || !(result.getError() instanceof TxStreamException error)
+                    || !"TXSTREAM_ABANDONED".equals(error.getCode())) return entry;
+            TxStreamItemResult acknowledged = result.toBuilder().status(TxStreamItemStatus.FAILED)
+                    .error(new TxStreamException("TXSTREAM_ABANDONED", "Operator acknowledgement: " + reason))
+                    .updatedAt(Objects.requireNonNull(acknowledgedAt, "acknowledgedAt")).build();
+            applied[0] = true;
+            return new ProjectionEntry(acknowledged, Math.addExact(expectedSequence, 1));
+        });
+        return applied[0];
+    }
+
+    @Override
     public List<String> listNonTerminalItemIds(String streamId) {
         List<String> result = new ArrayList<>();
         for (ProjectionEntry entry : projections.values()) {

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/InMemoryDurableTxStreamStore.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/InMemoryDurableTxStreamStore.java
@@ -137,6 +137,16 @@ public final class InMemoryDurableTxStreamStore implements TxStreamStateStore {
     }
 
     @Override
+    public boolean registerOrMatch(TxStreamItemRecord record) {
+        Objects.requireNonNull(record, "record");
+        TxStreamItemRecord existing = records.putIfAbsent(record.itemId(), record);
+        if (existing == null) return true;
+        if (existing.matches(record)) return false;
+        throw new TxStreamDuplicateItemException(record.itemId(),
+                "Item registration has different content: " + record.itemId());
+    }
+
+    @Override
     public void registerItem(TxStreamItemRecord record) {
         Objects.requireNonNull(record, "record");
         if (records.putIfAbsent(record.itemId(), record) != null) {
@@ -241,6 +251,13 @@ public final class InMemoryDurableTxStreamStore implements TxStreamStateStore {
             return Optional.empty();
         }
         return Optional.of(entry.result());
+    }
+
+    @Override
+    public Optional<TxStreamStoredProjection> getStoredProjection(String streamId, String itemId) {
+        ProjectionEntry entry = projections.get(itemId);
+        if (entry == null || !entry.result().getStreamId().equals(streamId)) return Optional.empty();
+        return Optional.of(new TxStreamStoredProjection(entry.result(), entry.sequence()));
     }
 
     @Override

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStream.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStream.java
@@ -360,28 +360,30 @@ public interface TxFlowStream extends AutoCloseable {
     boolean cancelExecution(String executionId, String reason);
 
     /**
-     * Returns the latest item projection. For a
-     * {@link TxStreamItemStatus#RECOVERY_REQUIRED} item this is a
-     * read-through: the engine snapshot is consulted and, when it carries an
-     * authoritative terminal answer, the projection is repaired before being
-     * returned.
-     * <p>
-     * A settled item evicted under the retention cap
-     * ({@link Builder#maxRetainedSettledItems(int)}) returns empty — the
-     * engine's execution store remains the durable record of the execution
-     * itself, and the durable stream store of iteration 2 lifts this limit.
+     * Returns the latest live or durable item projection, including retained
+     * terminal items after live eviction. Healthy foreign items are observed
+     * without installing live state, incrementing counters, emitting events or
+     * writing their projection. Missing/running engine snapshots never establish
+     * recovery ownership or manufacture RECOVERY_REQUIRED.
+     *
+     * <p>A stored RECOVERY_REQUIRED item with a persisted plan may be hydrated
+     * into the live map, register its claim and recovery gauge, and repaired from
+     * authoritative engine evidence; terminal repair updates the store and emits
+     * the listener event. This operation never starts an execution.</p>
      *
      * @param itemId caller-provided work item id
-     * @return latest item result if the item is known and retained
+     * @return latest known result, or empty when neither live nor stored
      */
     Optional<TxStreamItemResult> getItemStatus(String itemId);
 
     /**
-     * Forces the read-through reconciliation check for one item, typically
-     * after an operator has run {@code engine.recover(...)}.
+     * Consults engine truth for an item, typically after explicit engine recovery.
+     * The foreign-observation and recovery-repair rules of getItemStatus apply.
+     * An explicitly attached foreign receipt is refreshed locally from the
+     * owner's durable projection or engine truth without writing over its owner.
      *
      * @param itemId caller-provided work item id
-     * @return post-reconciliation item result if the item is known
+     * @return latest known result after reconciliation
      */
     Optional<TxStreamItemResult> reconcile(String itemId);
 

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStream.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStream.java
@@ -134,8 +134,9 @@ public interface TxFlowStream extends AutoCloseable {
      * {@link TxStreamItemStatus#RECOVERY_REQUIRED} and refreshed by
      * read-through ({@link #getItemStatus(String)} / {@link #reconcile
      * (String)}); live push watching of a foreign-process execution is a later
-     * iteration. Items accepted but not yet bound at the crash are lost
-     * (bounded; idempotent redelivery is the answer).
+     * iteration. Items accepted without a recoverable persisted plan remain
+     * recovery-required and need explicit intervention; matching redelivery
+     * reports {@code TXSTREAM_REGISTRATION_INCOMPLETE} and never replans them.
      * <p>
      * {@link #start()} is the supported entry point for a full recover-then-run
      * cycle: it enables the dispatcher, runs this pass, and only then opens for
@@ -277,7 +278,8 @@ public interface TxFlowStream extends AutoCloseable {
      * Attempts non-blocking submission of a common single-transaction plan
      * using the item id as its idempotency key.
      * <p>
-     * The result reports accepted/attached work as {@link EmitResult.Status#OK},
+     * The result reports new work as {@link EmitResult.Status#OK}, identical
+     * redelivery as {@link EmitResult.Status#DUPLICATE_ATTACHED},
      * different-content reuse as {@link EmitResult.Status#CONFLICT}, eager
      * validation or registration failures as {@link EmitResult.Status#REJECTED},
      * ownership standby as {@link EmitResult.Status#PAUSED}, lack of capacity as

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamCodes.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamCodes.java
@@ -9,6 +9,10 @@ package com.bloxbean.cardano.client.txflow.stream;
  * own catalogs; this class intentionally contains only core codes.</p>
  */
 public final class TxStreamCodes {
+    /** Projection changed repeatedly while obtaining a coherent hydration snapshot. */
+    public static final String PROJECTION_BUSY = "TXSTREAM_PROJECTION_BUSY";
+    /** Registration exists but no recoverable planned request can currently be found. */
+    public static final String REGISTRATION_INCOMPLETE = "TXSTREAM_REGISTRATION_INCOMPLETE";
     /** Previous lane transaction is not yet visible to the funding backend. */
     public static final String BACKEND_NOT_READY = "TXSTREAM_BACKEND_NOT_READY";
     /** Accepted work was recovered without an execution binding. */

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamItemRecord.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamItemRecord.java
@@ -40,4 +40,16 @@ public record TxStreamItemRecord(String itemId, String idempotencyKey, String la
             throw new IllegalArgumentException(label + " cannot be blank");
         }
     }
+
+    /**
+     * Compares authoritative identity and content, excluding acceptance time.
+     *
+     * @param other incoming registration
+     * @return whether the registration describes the same accepted intent
+     */
+    public boolean matches(TxStreamItemRecord other) {
+        return other != null && itemId.equals(other.itemId)
+                && idempotencyKey.equals(other.idempotencyKey)
+                && laneName.equals(other.laneName) && fingerprint.equals(other.fingerprint);
+    }
 }

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamStateStore.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamStateStore.java
@@ -254,6 +254,43 @@ public interface TxStreamStateStore {
     }
 
     /**
+     * Looks up only the plan containing one item. Custom stores may use this
+     * compatibility scan; shipped stores use the item's persisted binding.
+     */
+    default Optional<TxStreamPlannedRecord> findPlanned(String streamId, String itemId) {
+        return listPlanned(streamId).stream()
+                .filter(record -> record.members().stream().anyMatch(member -> member.itemId().equals(itemId)))
+                .findFirst();
+    }
+
+    /**
+     * A bounded, item-id-ordered page of recovery candidates after an exclusive
+     * cursor (null starts a pass). Every returned row consumes observer budget,
+     * including incomplete registrations. Custom stores may override this scan.
+     */
+    default List<String> listRecoveryItemIds(String streamId, String afterItemId, int limit) {
+        if (limit <= 0) throw new IllegalArgumentException("limit must be positive");
+        return listNonTerminalItemIds(streamId).stream()
+                .filter(id -> afterItemId == null || id.compareTo(afterItemId) > 0)
+                .sorted().limit(limit).toList();
+    }
+
+    /**
+     * Atomically acknowledges an investigated RECOVERY_REQUIRED/TXSTREAM_ABANDONED
+     * projection at exactly expectedSequence, marking its bookkeeping FAILED and
+     * retaining its registration, hash and binding. Returns false on a stale
+     * sequence or any other state. This is an operator action, never automatic:
+     * stop/fence all producers and recovery workers first and investigate any
+     * engine transaction. Acknowledgement does NOT prove a payment failed and
+     * does NOT authorize replacement submission. Custom stores must implement
+     * the atomic check before supporting this operation.
+     */
+    default boolean acknowledgeAbandoned(String streamId, String itemId,
+                                         long expectedSequence, String reason, Instant acknowledgedAt) {
+        throw new UnsupportedOperationException("Atomic abandoned acknowledgement is not supported");
+    }
+
+    /**
      * Lists the ids of items whose latest stored projection is <em>not</em> a
      * final status (confirmed, failed, or cancelled) — the candidates a
      * restart re-attach must resolve against engine truth. A

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamStateStore.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamStateStore.java
@@ -18,8 +18,9 @@ import java.util.Optional;
  * best-effort and guarded by a per-item sequence so a stale write can never
  * overwrite a newer one.
  * <p>
- * Iteration 1A ships the in-memory implementation only; a durable
- * implementation arrives with iteration 2 and keeps this contract.
+ * Implementations include process-local stores and the optional H2/PostgreSQL
+ * relational adapter. Registration identity is scoped to a store; applications
+ * must not reuse an item id for unrelated streams sharing that store.
  */
 public interface TxStreamStateStore {
     /**
@@ -30,6 +31,22 @@ public interface TxStreamStateStore {
      * @throws TxStreamException when the record cannot be stored
      */
     void registerItem(TxStreamItemRecord record);
+
+    /**
+     * Atomically registers a new identity or matches its authoritative content.
+     * A matched record must never be planned as new work. Implementations must
+     * exclude acceptance time from equality and serialize concurrent writers,
+     * including writers using different database connections.
+     * The compatibility default retains legacy duplicate-rejection behavior.
+     *
+     * @param record proposed registration
+     * @return true for a newly registered item, false for identical existing work
+     * @throws TxStreamDuplicateItemException for different-content reuse
+     */
+    default boolean registerOrMatch(TxStreamItemRecord record) {
+        registerItem(record);
+        return true;
+    }
 
     /**
      * Writes the item's write-ahead execution binding with state
@@ -72,6 +89,30 @@ public interface TxStreamStateStore {
      * @return stored projection when present
      */
     Optional<TxStreamItemResult> getItem(String streamId, String itemId);
+
+    /**
+     * Reads a projection with its matching CAS sequence. Shipped durable stores
+     * override this with one atomic entry/row read. The compatibility fallback
+     * retries when the watermark changes; stores without watermarks retain the
+     * legacy hydration sequence floor and should implement this method before
+     * claiming concurrent hydration support.
+     *
+     * @param streamId stream identity
+     * @param itemId work identity
+     * @return coherent projection, or empty if no projection exists
+     */
+    default Optional<TxStreamStoredProjection> getStoredProjection(String streamId, String itemId) {
+        for (int attempt = 0; attempt < 8; attempt++) {
+            Optional<Long> before = lastProjectionSequence(streamId, itemId);
+            Optional<TxStreamItemResult> result = getItem(streamId, itemId);
+            Optional<Long> after = lastProjectionSequence(streamId, itemId);
+            if (before.equals(after)) {
+                return result.map(value -> new TxStreamStoredProjection(value, after.orElse(1L << 42)));
+            }
+        }
+        throw new TxStreamException("TXSTREAM_PROJECTION_BUSY",
+                "Item projection changed repeatedly during hydration: " + itemId);
+    }
 
     /**
      * Returns the per-item projection sequence of the latest stored projection —

--- a/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamStoredProjection.java
+++ b/txflow/src/main/java/com/bloxbean/cardano/client/txflow/stream/TxStreamStoredProjection.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.client.txflow.stream;
+
+import java.util.Objects;
+
+/**
+ * One coherent stored projection and its CAS watermark. Hydration must not pair
+ * an old result with a newer sequence, which could overwrite subsequent truth.
+ *
+ * @param result stored item result
+ * @param sourceSequence sequence stored with this exact result
+ */
+public record TxStreamStoredProjection(TxStreamItemResult result, long sourceSequence) {
+    /**
+     * Creates a snapshot with a non-null result.
+     *
+     * @param result stored result
+     * @param sourceSequence the matching stored watermark
+     */
+    public TxStreamStoredProjection {
+        Objects.requireNonNull(result, "result");
+    }
+}

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/SharedDurableTxStreamStore.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/SharedDurableTxStreamStore.java
@@ -154,6 +154,16 @@ final class SharedDurableTxStreamStore implements TxStreamStateStore {
     }
 
     @Override
+    public boolean registerOrMatch(TxStreamItemRecord record) {
+        Objects.requireNonNull(record, "record");
+        TxStreamItemRecord existing = records.putIfAbsent(record.itemId(), record);
+        if (existing == null) return true;
+        if (existing.matches(record)) return false;
+        throw new TxStreamDuplicateItemException(record.itemId(),
+                "Item registration has different content: " + record.itemId());
+    }
+
+    @Override
     public void registerItem(TxStreamItemRecord record) {
         Objects.requireNonNull(record, "record");
         if (records.putIfAbsent(record.itemId(), record) != null) {
@@ -280,6 +290,13 @@ final class SharedDurableTxStreamStore implements TxStreamStateStore {
             return Optional.empty();
         }
         return Optional.of(entry.result());
+    }
+
+    @Override
+    public Optional<TxStreamStoredProjection> getStoredProjection(String streamId, String itemId) {
+        ProjectionEntry entry = projections.get(itemId);
+        if (entry == null || !entry.result().getStreamId().equals(streamId)) return Optional.empty();
+        return Optional.of(new TxStreamStoredProjection(entry.result(), entry.sequence()));
     }
 
     @Override

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamDurableReattachTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamDurableReattachTest.java
@@ -514,7 +514,7 @@ class TxFlowStreamDurableReattachTest {
     // ------------------------------------------------------------------
 
     @Test
-    void anAcceptedButUnboundGhostIsReapedOnReattachAndNotReturnedNextRestart() {
+    void anAcceptedButUnboundRegistrationRequiresExplicitRecoveryAcrossRestarts() {
         SharedDurableTxStreamStore store = new SharedDurableTxStreamStore();
         StubEngineGateway engine = durableEngine();
         // Registered + projected ACCEPTED before the crash, never bound (no
@@ -532,16 +532,19 @@ class TxFlowStreamDurableReattachTest {
             assertEquals(0, report.reattachedItems());
             assertEquals(0, report.redispatched());
             TxStreamItemResult reaped = store.getItem("payouts", "ghost").orElseThrow();
-            assertEquals(TxStreamItemStatus.CANCELLED, reaped.getStatus());
+            assertEquals(TxStreamItemStatus.RECOVERY_REQUIRED, reaped.getStatus());
             assertEquals("TXSTREAM_ABANDONED", ((TxStreamException) reaped.getError()).getCode());
-            assertFalse(store.listNonTerminalItemIds("payouts").contains("ghost"),
-                    "a reaped ghost leaves the non-terminal set");
+            assertTrue(store.listNonTerminalItemIds("payouts").contains("ghost"),
+                    "incomplete accepted work remains visible for recovery");
+            assertEquals(1, report.recoveryRequired());
         }
 
         try (TxFlowStream c = durableBuilder(engine, store).build()) {
             ReattachReport report = c.reattach();
-            assertEquals(0, report.reattachedItems() + report.redispatched()
-                    + report.recoveryRequired(), "the reaped ghost is not re-scanned");
+            assertEquals(0, report.reattachedItems() + report.redispatched());
+            assertEquals(1, report.recoveryRequired());
+            assertEquals(2, store.lastProjectionSequence("payouts", "ghost").orElseThrow(),
+                    "restarting must not repeatedly rewrite the incomplete projection");
         }
     }
 

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamDurableRedeliveryTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamDurableRedeliveryTest.java
@@ -1,0 +1,109 @@
+package com.bloxbean.cardano.client.txflow.stream;
+
+import com.bloxbean.cardano.client.api.model.Amount;
+import com.bloxbean.cardano.client.quicktx.Tx;
+import com.bloxbean.cardano.client.quicktx.serialization.TxPlan;
+import com.bloxbean.cardano.client.txflow.exec.FlowExecutionResult;
+import com.bloxbean.cardano.client.txflow.exec.FlowExecutionState;
+import com.bloxbean.cardano.client.txflow.result.FlowStepResult;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TxFlowStreamDurableRedeliveryTest {
+    private static final String STEP = StreamIdentities.GENERATED_STEP_ID;
+
+    @Test
+    void identicalRedeliveryAttachesAfterEvictionAndRestartWithoutChangingCountersOrExecuting() {
+        StubEngineGateway gateway = new StubEngineGateway();
+        gateway.durable = true;
+        TxStreamStateStore store = TxStreamStateStore.inMemoryDurable();
+        try (TxFlowStream stream = builder(gateway, store).maxRetainedSettledItems(1).open()) {
+            for (String id : List.of("one", "two")) {
+                stream.submit(id, plan(2));
+                gateway.lastHandle().completeConfirmed(STEP, "hash-" + id);
+            }
+            assertAttached(stream, "one");
+            assertEquals(2, stream.getStats().acceptedItemCount());
+            assertEquals(2, stream.getStats().confirmedItemCount());
+            assertEquals(EmitResult.Status.CONFLICT, stream.trySubmit("one", plan(3)).getStatus());
+        }
+        try (TxFlowStream restarted = builder(gateway, store).open()) {
+            assertAttached(restarted, "one");
+            assertEquals(0, restarted.getStats().acceptedItemCount());
+            assertEquals(0, restarted.getStats().confirmedItemCount());
+        }
+        assertEquals(2, gateway.started.size());
+    }
+
+    @Test
+    void publicReadAndRedeliveryHydrateRemoteUncertaintyAndRepairFromEngineTruth() {
+        for (boolean useRedelivery : new boolean[] {false, true}) {
+            StubEngineGateway gateway = new StubEngineGateway();
+            gateway.durable = true;
+            TxStreamStateStore store = TxStreamStateStore.inMemoryDurable();
+            try (TxFlowStream reader = builder(gateway, store).open();
+                 TxFlowStream writer = builder(gateway, store).open()) {
+                TxStreamReceipt original = writer.submit("one", plan(2));
+                StubEngineGateway.StubHandle handle = gateway.lastHandle();
+                handle.submittedEvent(STEP, "hash-one");
+                handle.complete(new FlowExecutionResult(handle.executionId(), "fp", FlowExecutionState.FAILED,
+                        List.of(FlowStepResult.submissionPendingAt(STEP, "hash-one", List.of(), List.of(),
+                                new IllegalStateException("uncertain"), StubEngineGateway.NOW)),
+                        null, StubEngineGateway.NOW, StubEngineGateway.NOW));
+                assertEquals(TxStreamItemStatus.RECOVERY_REQUIRED, original.current().getStatus());
+                TxStreamReceipt attached = null;
+                if (useRedelivery) {
+                    EmitResult redelivery = reader.trySubmit("one", plan(2));
+                    assertEquals(EmitResult.Status.DUPLICATE_ATTACHED, redelivery.getStatus());
+                    attached = redelivery.getReceipt();
+                    assertEquals(TxStreamItemStatus.RECOVERY_REQUIRED, attached.awaitSettled().getStatus());
+                }
+                gateway.putSnapshot(original.executionId().orElseThrow(), FlowExecutionState.COMPLETED);
+                assertEquals(TxStreamItemStatus.CONFIRMED, reader.awaitResolution("one",
+                        Duration.ofSeconds(1), Duration.ofMillis(1)).getStatus());
+                if (attached != null) assertEquals(TxStreamItemStatus.CONFIRMED, attached.current().getStatus());
+                assertEquals(TxStreamItemStatus.CONFIRMED, store.getItem("durable", "one").orElseThrow().getStatus());
+                assertEquals(0, reader.getStats().acceptedItemCount());
+                assertEquals(0, reader.getStats().recoveryRequiredItemCount());
+                assertEquals(1, gateway.started.size());
+            }
+        }
+    }
+
+    @Test
+    void redeliveryOfRegisteredButUnplannedWorkNeverStartsAnotherExecution() {
+        StubEngineGateway gateway = new StubEngineGateway();
+        gateway.durable = true;
+        TxStreamStateStore store = TxStreamStateStore.inMemoryDurable();
+        TxFlowStream writer = builder(gateway, store).window(WindowPolicy.count(2)).open();
+        try (TxFlowStream reader = builder(gateway, store).open()) {
+            writer.submit("one", plan(2));
+            EmitResult result = reader.trySubmit("one", plan(2));
+            assertEquals(EmitResult.Status.REJECTED, result.getStatus());
+            assertEquals(TxStreamCodes.REGISTRATION_INCOMPLETE, result.getRejection().getCode());
+            assertTrue(gateway.started.isEmpty());
+        } finally {
+            writer.abort("test cleanup");
+        }
+    }
+
+    private void assertAttached(TxFlowStream stream, String itemId) {
+        EmitResult result = stream.trySubmit(itemId, plan(2));
+        assertEquals(EmitResult.Status.DUPLICATE_ATTACHED, result.getStatus());
+        assertEquals("hash-" + itemId, result.getReceipt().awaitConfirmed().getTransactionHash());
+    }
+
+    private TxFlowStream.Builder builder(StubEngineGateway gateway, TxStreamStateStore store) {
+        return new TxFlowStream.Builder("durable", gateway).executor(Runnable::run).stateStore(store);
+    }
+
+    private TxPlan plan(int ada) {
+        return TxPlan.from(new Tx().payToAddress("addr_test1vpqreceiver", Amount.ada(ada))
+                .from("addr_test1vpqsender"));
+    }
+}

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamDurableRedeliveryTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamDurableRedeliveryTest.java
@@ -13,9 +13,82 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 class TxFlowStreamDurableRedeliveryTest {
     private static final String STEP = StreamIdentities.GENERATED_STEP_ID;
+
+    @Test
+    void foreignReadsAndAttachmentsNeverConsumeTheOwnersNextProjectionSequence() {
+        for (boolean snapshotPresent : List.of(false, true)) {
+            for (boolean attach : List.of(false, true)) {
+                StubEngineGateway gateway = new StubEngineGateway();
+                gateway.durable = true;
+                TxStreamStateStore store = spy(TxStreamStateStore.inMemoryDurable());
+                try (TxFlowStream reader = builder(gateway, store).open();
+                     TxFlowStream writer = builder(gateway, store).open()) {
+                    TxStreamReceipt original = writer.submit("running", plan(2));
+                    StubEngineGateway.StubHandle handle = gateway.lastHandle();
+                    handle.submittedEvent(STEP, "hash-running");
+                    writer.getItemStatus("running");
+                    long sequence = store.lastProjectionSequence("durable", "running").orElseThrow();
+                    if (snapshotPresent) gateway.putSnapshot(original.executionId().orElseThrow(),
+                            FlowExecutionState.RUNNING);
+                    clearInvocations(store);
+                    TxStreamReceipt attached = attach ? reader.submit("running", plan(2)) : null;
+                    assertEquals(TxStreamItemStatus.SUBMITTED, reader.getItemStatus("running").orElseThrow().getStatus());
+                    reader.reconcile("running");
+                    assertEquals(TxStreamItemStatus.SUBMITTED, store.getItem("durable", "running").orElseThrow().getStatus());
+                    assertEquals(sequence, store.lastProjectionSequence("durable", "running").orElseThrow());
+                    assertEquals(0, reader.getStats().recoveryRequiredItemCount());
+                    handle.completeConfirmed(STEP, "hash-running");
+                    assertEquals(TxStreamItemStatus.CONFIRMED, store.getItem("durable", "running").orElseThrow().getStatus());
+                    assertEquals(TxStreamItemStatus.CONFIRMED, reader.reconcile("running").orElseThrow().getStatus());
+                    if (attached != null) assertEquals(TxStreamItemStatus.CONFIRMED,
+                            attached.awaitSettled(Duration.ofSeconds(1)).getStatus());
+                    assertEquals(0, reader.getStats().confirmedItemCount());
+                    assertEquals(1, gateway.started.size());
+                    verify(store, never()).listPlanned("durable");
+                }
+            }
+        }
+    }
+
+    @Test
+    void abandonedRowsConsumeBudgetAndCursorEventuallyReachesRecoverableWork() {
+        StubEngineGateway gateway = new StubEngineGateway();
+        gateway.durable = true;
+        TxStreamStateStore store = spy(TxStreamStateStore.inMemoryDurable());
+        ManualScheduler scheduler = new ManualScheduler();
+        try (TxFlowStream reader = builder(gateway, store).maintenanceExecutor(scheduler)
+                .reconciliationInterval(Duration.ofSeconds(1)).reconciliationBatchSize(2).open();
+             TxFlowStream writer = builder(gateway, store).open()) {
+            for (int i = 0; i < 10; i++) {
+                String id = "abandoned-" + i;
+                store.projectItem(TxStreamItemResult.builder("durable", id, TxStreamItemStatus.RECOVERY_REQUIRED)
+                        .error(new TxStreamException("TXSTREAM_ABANDONED", "incomplete"))
+                        .updatedAt(StubEngineGateway.NOW).build(), 1);
+            }
+            TxStreamReceipt remote = writer.submit("z-remote", plan(2));
+            StubEngineGateway.StubHandle handle = gateway.lastHandle();
+            handle.complete(new FlowExecutionResult(handle.executionId(), "fp", FlowExecutionState.FAILED,
+                    List.of(FlowStepResult.submissionPendingAt(STEP, "hash", List.of(), List.of(),
+                            new IllegalStateException("uncertain"), StubEngineGateway.NOW)),
+                    null, StubEngineGateway.NOW, StubEngineGateway.NOW));
+            gateway.putSnapshot(remote.executionId().orElseThrow(), FlowExecutionState.COMPLETED);
+            clearInvocations(store);
+            scheduler.pending().fire();
+            verify(store, never()).getItem("durable", "abandoned-2");
+            verify(store, never()).listPlanned("durable");
+            for (int pass = 0; pass < 8; pass++) scheduler.pending().fire();
+            assertEquals(TxStreamItemStatus.CONFIRMED,
+                    store.getItem("durable", "z-remote").orElseThrow().getStatus());
+            assertEquals(1, gateway.started.size());
+        }
+    }
 
     @Test
     void identicalRedeliveryAttachesAfterEvictionAndRestartWithoutChangingCountersOrExecuting() {

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamDurableRedeliveryTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamDurableRedeliveryTest.java
@@ -28,7 +28,9 @@ class TxFlowStreamDurableRedeliveryTest {
                 StubEngineGateway gateway = new StubEngineGateway();
                 gateway.durable = true;
                 TxStreamStateStore store = spy(TxStreamStateStore.inMemoryDurable());
-                try (TxFlowStream reader = builder(gateway, store).open();
+                ManualScheduler scheduler = new ManualScheduler();
+                try (TxFlowStream reader = builder(gateway, store).maintenanceExecutor(scheduler)
+                        .reconciliationInterval(Duration.ofSeconds(1)).open();
                      TxFlowStream writer = builder(gateway, store).open()) {
                     TxStreamReceipt original = writer.submit("running", plan(2));
                     StubEngineGateway.StubHandle handle = gateway.lastHandle();
@@ -52,6 +54,9 @@ class TxFlowStreamDurableRedeliveryTest {
                     assertEquals(0, reader.getStats().confirmedItemCount());
                     assertEquals(1, gateway.started.size());
                     verify(store, never()).listPlanned("durable");
+                    clearInvocations(store);
+                    scheduler.pending().fire();
+                    verify(store, never()).getItem("durable", "running");
                 }
             }
         }

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamReconciliationObserverTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamReconciliationObserverTest.java
@@ -139,11 +139,11 @@ class TxFlowStreamReconciliationObserverTest {
                     attemptData(STEP_ID, AttemptState.CONFIRMED, "tx-remote"));
 
             // Precondition: the row is durable-non-terminal but NOT in the
-            // observer's live map (getItemStatus returns the stored projection
-            // verbatim, no read-through repair for a non-live item).
+            // observer's live map. Inspect the store directly because public
+            // getItemStatus now performs the same hydration as the observer.
             assertTrue(store.listNonTerminalItemIds("payouts").contains("pay-remote"));
             assertEquals(TxStreamItemStatus.RECOVERY_REQUIRED,
-                    observer.getItemStatus("pay-remote").orElseThrow().getStatus());
+                    store.getItem("payouts", "pay-remote").orElseThrow().getStatus());
 
             // The observer must recover by READ-THROUGH only: capture the engine's
             // start count so we can prove it never re-executes the foreign item.

--- a/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamReconciliationObserverTest.java
+++ b/txflow/src/test/java/com/bloxbean/cardano/client/txflow/stream/TxFlowStreamReconciliationObserverTest.java
@@ -483,9 +483,9 @@ class TxFlowStreamReconciliationObserverTest {
 
             // Without the phase-alternation, phase-1 residency (2 == batchSize)
             // starves phase 2 on EVERY fire and pay-remote is never discovered.
-            // Alternation guarantees discovery within a bounded number of fires.
-            scheduler.pending().fire();
-            scheduler.pending().fire();
+            // Every inspected durable row now consumes budget, including live rows.
+            // The cursor advances past those rows on the next durable-first pass.
+            for (int fire = 0; fire < 4; fire++) scheduler.pending().fire();
 
             assertEquals(TxStreamItemStatus.CONFIRMED,
                     store.getItem("payouts", "pay-remote").orElseThrow().getStatus(),

--- a/txflow/src/testFixtures/java/com/bloxbean/cardano/client/txflow/stream/contract/TxStreamStateStoreContract.java
+++ b/txflow/src/testFixtures/java/com/bloxbean/cardano/client/txflow/stream/contract/TxStreamStateStoreContract.java
@@ -89,6 +89,55 @@ public abstract class TxStreamStateStoreContract {
     }
 
     @Test
+    void atomicRegistrationMatchesContentIgnoringTimeAndPreservesProjection() {
+        TxStreamItemRecord original = record("matched");
+        assertTrue(store.registerOrMatch(original));
+        store.projectItem(projection("matched", TxStreamItemStatus.CONFIRMED), 7);
+        assertFalse(store.registerOrMatch(new TxStreamItemRecord(original.itemId(),
+                original.idempotencyKey(), original.laneName(), original.fingerprint(), NOW.plusSeconds(9))));
+        assertEquals(TxStreamItemStatus.CONFIRMED, store.getItem(STREAM, "matched").orElseThrow().getStatus());
+        assertEquals(7, store.getStoredProjection(STREAM, "matched").orElseThrow().sourceSequence());
+        assertTrue(store.getStoredProjection("other", "matched").isEmpty());
+    }
+
+    @Test
+    void atomicRegistrationRejectsDifferentFingerprintKeyOrLane() {
+        TxStreamItemRecord original = record("conflict");
+        assertTrue(store.registerOrMatch(original));
+        for (TxStreamItemRecord changed : List.of(
+                new TxStreamItemRecord(original.itemId(), original.idempotencyKey(), original.laneName(), "changed", NOW),
+                new TxStreamItemRecord(original.itemId(), "changed", original.laneName(), original.fingerprint(), NOW),
+                new TxStreamItemRecord(original.itemId(), original.idempotencyKey(), "changed", original.fingerprint(), NOW))) {
+            assertThrows(TxStreamDuplicateItemException.class, () -> store.registerOrMatch(changed));
+        }
+        assertFalse(store.registerOrMatch(original));
+    }
+
+    @Test
+    void concurrentIdenticalRegistrationHasOneWinnerIncludingProjectionOnlyRows() throws Exception {
+        for (boolean projectionOnly : new boolean[] {false, true}) {
+            String id = "race-" + projectionOnly;
+            if (projectionOnly) store.projectItem(projection(id, TxStreamItemStatus.ACCEPTED), 1);
+            ExecutorService pool = Executors.newFixedThreadPool(8);
+            try {
+                CyclicBarrier barrier = new CyclicBarrier(8);
+                List<Future<Boolean>> results = new ArrayList<>();
+                for (int i = 0; i < 8; i++) {
+                    results.add(pool.submit(() -> {
+                        barrier.await(10, TimeUnit.SECONDS);
+                        return store.registerOrMatch(record(id));
+                    }));
+                }
+                int registered = 0;
+                for (Future<Boolean> result : results) if (result.get(30, TimeUnit.SECONDS)) registered++;
+                assertEquals(1, registered);
+            } finally {
+                pool.shutdownNow();
+            }
+        }
+    }
+
+    @Test
     void bindRequiresRegistrationAndConfirmRecordsOutcome() {
         assertCode("TXSTREAM_ITEM_UNKNOWN",
                 () -> store.bind("item-1", binding("exec-1")));

--- a/txflow/src/testFixtures/java/com/bloxbean/cardano/client/txflow/stream/contract/TxStreamStateStoreContract.java
+++ b/txflow/src/testFixtures/java/com/bloxbean/cardano/client/txflow/stream/contract/TxStreamStateStoreContract.java
@@ -75,6 +75,60 @@ public abstract class TxStreamStateStoreContract {
     }
 
     @Test
+    void recoveryPagesAreBoundedAndAcknowledgementRequiresExactAbandonedVersion() {
+        for (String id : List.of("a", "b", "c")) {
+            store.projectItem(TxStreamItemResult.builder(STREAM, id, TxStreamItemStatus.RECOVERY_REQUIRED)
+                    .error(new TxStreamException("TXSTREAM_ABANDONED", "incomplete"))
+                    .transactionHash("retained-hash").updatedAt(NOW).build(), 10);
+        }
+        assertEquals(List.of("a", "b"), store.listRecoveryItemIds(STREAM, null, 2));
+        assertEquals(List.of("c"), store.listRecoveryItemIds(STREAM, "b", 2));
+        assertFalse(store.acknowledgeAbandoned(STREAM, "a", 9, "investigated while fenced", NOW));
+        assertFalse(store.acknowledgeAbandoned("other", "a", 10, "investigated while fenced", NOW));
+        assertTrue(store.acknowledgeAbandoned(STREAM, "a", 10, "investigated while fenced", NOW));
+        assertEquals(TxStreamItemStatus.FAILED, store.getItem(STREAM, "a").orElseThrow().getStatus());
+        assertEquals("retained-hash", store.getItem(STREAM, "a").orElseThrow().getTransactionHash());
+        assertEquals(11, store.lastProjectionSequence(STREAM, "a").orElseThrow());
+        assertFalse(store.acknowledgeAbandoned(STREAM, "a", 11, "again", NOW));
+        assertEquals(List.of("b", "c"), store.listRecoveryItemIds(STREAM, null, 2));
+        store.projectItem(TxStreamItemResult.builder(STREAM, "b", TxStreamItemStatus.RECOVERY_REQUIRED)
+                .updatedAt(NOW).build(), 11);
+        assertFalse(store.acknowledgeAbandoned(STREAM, "b", 11, "not abandoned", NOW));
+    }
+
+    @Test
+    void simultaneousAbandonedAcknowledgementsHaveOneWinner() throws Exception {
+        store.projectItem(TxStreamItemResult.builder(STREAM, "abandoned", TxStreamItemStatus.RECOVERY_REQUIRED)
+                .error(new TxStreamException("TXSTREAM_ABANDONED", "incomplete")).updatedAt(NOW).build(), 10);
+        ExecutorService pool = Executors.newFixedThreadPool(4);
+        try {
+            CyclicBarrier barrier = new CyclicBarrier(4);
+            List<Future<Boolean>> attempts = new ArrayList<>();
+            for (int i = 0; i < 4; i++) attempts.add(pool.submit(() -> {
+                barrier.await(10, TimeUnit.SECONDS);
+                return store.acknowledgeAbandoned(STREAM, "abandoned", 10, "investigated", NOW);
+            }));
+            int winners = 0;
+            for (Future<Boolean> attempt : attempts) if (attempt.get(10, TimeUnit.SECONDS)) winners++;
+            assertEquals(1, winners);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void findPlannedResolvesOnlyTheBoundItemAndStream() {
+        store.registerItem(new TxStreamItemRecord("one", "key", "lane", "fp", NOW));
+        TxStreamPlannedRecord planned = plannedRecord("exec-1", "flow-key",
+                new TxStreamPlannedRecord.Member("one", "key", "step", "fp"));
+        store.bind("one", new TxStreamBinding("exec-1", "flow", "step", "lane"));
+        store.persistPlanned(planned);
+        assertEquals(Optional.of(planned), store.findPlanned(STREAM, "one"));
+        assertTrue(store.findPlanned(STREAM, "missing").isEmpty());
+        assertTrue(store.findPlanned("other", "one").isEmpty());
+    }
+
+    @Test
     void reportsDurable() {
         assertTrue(store.isDurable());
     }


### PR DESCRIPTION
## Summary

Identical durable TxStream redelivery previously conflicted after live eviction, and foreign status reads could manufacture RECOVERY_REQUIRED and consume the sequence needed for an owner's later confirmation. This change attaches retained registrations without executing twice, preserves healthy owners' projections, and repairs stored recovery-required work from engine evidence.

Stacked on #649. Merge #649 first, then retarget this PR to `master` and run the normal merge-target gates. The scope is experimental preview.

## Behavior

- Atomically register or match item ID, idempotency key, lane and fingerprint in shipped durable memory/H2/PostgreSQL stores. Concurrent insert losers roll back and inspect the winner in a fresh locked transaction, including a projection-only winner.
- Attach stored terminal work without repopulating live retention or inflating acceptance/terminal counters. No duplicate engine start.
- Observe healthy foreign work without durable projection writes or lifecycle counters. Ordinary reads remain detached; explicit receipt attachment retains a local observation refreshed by reconciliation or the observer. Running or absent snapshots never establish recovery ownership or manufacture uncertainty.
- Hydrate stored RECOVERY_REQUIRED work from its original plan and coherently read projection/sequence; repair it from authoritative engine evidence. Completed foreign observations no longer consume observer budget.
- Resolve individual plans through persisted item bindings in shipped stores. Page reconciliation candidates with a cursor and charge every inspected row against the budget, including abandoned and already-live rows, so later rows progress.
- Keep incomplete registrations recovery-required and reject unsafe redelivery with TXSTREAM_REGISTRATION_INCOMPLETE. Add atomic operator acknowledgement of investigated TXSTREAM_ABANDONED rows at an exact projection sequence.
- Run soak dispatch through the SDK backend-indexing guard and document the implemented subset in ADR 0007 and the public guides.

## Compatibility and operating limits

No schema migration or automatic row deletion. Custom stores remain source compatible through fallback/default methods; efficient lookup/paging and atomic acknowledgement need appropriate adapter implementations. Registration IDs remain store-scoped. Lane assignment is part of matching, so lane-policy changes can conflict across deployments.

Before acknowledgement, operators must stop/fence producers and recovery workers and investigate any engine transaction. Read `getStoredProjection(...).sourceSequence()` for the exact sequence passed to `acknowledgeAbandoned(...)`. Acknowledgement terminalizes bookkeeping as FAILED while retaining registration, binding and transaction hash. It does not prove a payment failed and does not authorize replacement submission. Automatic same-ID reacceptance is unsafe merely because a binding is absent: another owner may still have the accepted work queued.

Automatic pre-plan recovery, full registration/binding/plan aggregate versioning, stream-scoped registration schema, active/active funding coordination, and sustained public-network failover qualification remain outside the supported preview. Existing terminal cancelled/abandoned rows remain terminal on upgrade.

Outside managed ownership, an observer that explicitly attached foreign receipts must not be repurposed as a recovery owner: reattach skips its live IDs and would not redispatch an absent execution. Use a fresh stream instance for recovery. This limit, the acknowledgement sequence pairing, and observation rules are integrated into the ADR decisions and public contract/restart sections.

## Validation

- Final combined Java 17 project build passed: `./gradlew build -PskipSigning --max-workers=4` (365 tasks).
- Combined Java 21 TxFlow unit suite passed: 1,076 tests, no failures or skips.
- Java 21 RDBMS validation passed: 118 unit tests and 76 H2/PostgreSQL integration tests, no failures or skips. Java 17 unit/integration suites also passed during the change.
- Regressions cover running/absent snapshots and owner confirmation, foreign receipt attachment, no whole-history plan reads, bounded scanning past abandoned rows, exact-version/concurrent acknowledgement, and a deterministically injected projection-only insert race.
- Includes #649's regressions for plain close draining a parked lane, inherited/overridden maintenance schedulers, parked-work buffer accounting, post-probe abort status, unrelated-lane progress, repair wakeup and timer cleanup, including interrupted-close cancellation and single close notification.
- Earlier combined-branch local DevKit smoke: 60/60 confirmed with the application UTxO gate disabled and SDK guard enabled; no duplicate/missing payments or orphan leases. Exact report: `txflow/docs/qualification/2026-09-06-txstream-devkit-smoke.txt`. That short chaos-free run does not establish sustained throughput, heap stability or failover under load.

GitHub checks run separately on the final pushed head; inspect their current results before merging.


